### PR TITLE
fix: stabilize pod watch lifecycle

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .manage(AppState::new())
-        .manage(WatchManager::new())
+        .manage(Arc::new(WatchManager::new()))
         .manage(Arc::new(LogStreamManager::new()))
         .manage(Arc::new(ShellSessionManager::new()))
         .manage(Arc::new(PortForwardManager::new()))


### PR DESCRIPTION
## Summary\n- remove finished watch sessions to avoid leaking state\n- handle watch errors and backoff in UI\n\n## Task\n- Task 29\n