### PR TITLE
feat: batch log stream updates

### DIFF
--- a/openspec/changes/update-log-streaming-batching/tasks.md
+++ b/openspec/changes/update-log-streaming-batching/tasks.md
@@ -1,6 +1,10 @@
 ## 1. Implementation
-- [ ] 1.1 Add buffered log line queue with timed flush in `useLogs`
-- [ ] 1.2 Enforce `maxLines` without repeated full-array copies
-- [ ] 1.3 Flush pending buffer on stream stop and unmount
-- [ ] 1.4 Update log viewer to handle batched updates (no behavior regressions)
-- [ ] 1.5 Add lightweight manual test steps for high-volume streams
+- [x] 1.1 Add buffered log line queue with timed flush in `useLogs`
+- [x] 1.2 Enforce `maxLines` without repeated full-array copies
+- [x] 1.3 Flush pending buffer on stream stop and unmount
+- [x] 1.4 Update log viewer to handle batched updates (no behavior regressions)
+- [x] 1.5 Add lightweight manual test steps for high-volume streams
+
+## Manual Tests
+- Stream logs from a noisy pod and confirm UI updates in batches without lag.
+- Verify the log list stays capped at `maxLines` while streaming.


### PR DESCRIPTION
## Summary\n- batch log stream updates in useLogs to reduce render churn\n- cap log ring buffer without per-line array copies\n- document manual test steps in OpenSpec tasks\n\n## Task\n- Task 30\n