### PR TITLE
chore: disable macOS build job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
   build:
+    if: false # Temporarily disabled; re-enable when macOS build is ready.
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: [lint-frontend, lint-backend]


### PR DESCRIPTION
## Summary\n- disable the macOS build job in CI temporarily\n\n## Notes\n- can be re-enabled by removing the  guard\n