### PR TITLE
fix: remove mr-2 margin from delete button icon

### DIFF
--- a/src/components/features/resources/ResourceDetail.tsx
+++ b/src/components/features/resources/ResourceDetail.tsx
@@ -586,7 +586,7 @@ export function ResourceDetail({
                   size="sm"
                   onClick={() => setShowDeleteDialog(true)}
                 >
-                  <Trash2 className="size-4 mr-2" />
+                  <Trash2 className="size-4" />
                   {resourceType === "helm-release" ? "Uninstall" : t("common.delete")}
                 </Button>
               </div>


### PR DESCRIPTION
## Summary
- Remove unnecessary right margin (mr-2) from Trash2 icon in danger zone delete button
- Improves visual balance of the button layout

## Test plan
- [ ] Navigate to resource detail view with danger zone
- [ ] Verify delete button layout looks correct