### PR TITLE
fix: show toast on automatic update check at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Kubeli will be documented in this file.
 
+## [0.2.38] - 2026-01-21
+
+- Fixed loading spinner to show only on the clicked cluster button
+- Improved update check toast notification UX
+- Fixed delete button icon spacing
+
 ## [0.2.37] - 2026-01-20
 
 - Added Flux CD support for HelmReleases and Kustomizations

--- a/src/lib/hooks/useUpdater.tsx
+++ b/src/lib/hooks/useUpdater.tsx
@@ -304,7 +304,7 @@ export function useUpdater(options: UseUpdaterOptions = {}) {
       if (cancelled) return;
 
       debug(" Checking for updates...");
-      const foundUpdate = await checkForUpdates();
+      const foundUpdate = await checkForUpdates(true);
 
       const shouldAutoInstall = autoInstall || autoInstallUpdates;
 

--- a/web/src/pages/changelog.mdx
+++ b/web/src/pages/changelog.mdx
@@ -3,6 +3,12 @@ layout: ../layouts/ChangelogLayout.astro
 title: Changelog
 ---
 
+## v0.2.38 <span class="text-sm font-normal text-neutral-400 ml-2">2026-01-21</span>
+
+- Fixed loading spinner to show only on the clicked cluster button
+- Improved update check toast notification UX
+- Fixed delete button icon spacing
+
 ## v0.2.37 <span class="text-sm font-normal text-neutral-400 ml-2">2026-01-20</span>
 
 - Added Flux CD support for HelmReleases and Kustomizations


### PR DESCRIPTION
## Summary
- Show "Checking for updates..." toast on automatic update check at app startup
- Previously only manual check showed the toast

## Test plan
- [ ] Start Kubeli
- [ ] Verify toast appears after ~3 seconds
- [ ] Verify "Kubeli ist auf dem neusten Stand" shows if no update