### PR TITLE
feat(diagram): improve trackpad gesture handling for Mac

### DIFF
--- a/src/components/features/visualization/ResourceDiagram.tsx
+++ b/src/components/features/visualization/ResourceDiagram.tsx
@@ -523,6 +523,12 @@ function ResourceDiagramInner() {
           translateExtent={cachedExtent}
           proOptions={{ hideAttribution: true }}
           zIndexMode="auto"
+          panOnScroll
+          zoomOnScroll={false}
+          zoomOnPinch
+          zoomOnDoubleClick={false}
+          panOnDrag
+          selectionOnDrag={false}
         >
           <Background gap={16} size={1} />
           <Controls showInteractive={false} showFitView={false} />


### PR DESCRIPTION
## Summary

- Configure React Flow gestures for better Mac trackpad experience
- Two-finger scroll now pans/moves the diagram instead of zooming
- Two-finger pinch gesture for zoom in/out
- Disabled accidental zoom triggers (double-click, scroll zoom)

## Changes

| Gesture | Before | After |
|---------|--------|-------|
| Two-finger scroll | Zoom (conflicting) | Pan/Move |
| Two-finger pinch | - | Zoom |
| Double-click | Zoom | Disabled |
| Mouse drag | Pan | Pan (unchanged) |

## Test Plan

- [x] Open Resource Diagram view
- [x] Two-finger scroll on trackpad → should pan the view
- [x] Pinch gesture on trackpad → should zoom in/out
- [x] Mouse drag → should still pan
- [x] Double-click → should not zoom