### PR TITLE
fix(web): update comparison pages to reflect Windows support

### DIFF
--- a/web/src/pages/compare/dashboard-alternative.astro
+++ b/web/src/pages/compare/dashboard-alternative.astro
@@ -36,7 +36,7 @@ const comparisonPoints = [
   },
   {
     category: "Resource Usage",
-    kubeli: "Local Mac only",
+    kubeli: "Local desktop only",
     dashboard: "Uses cluster resources",
     winner: "kubeli",
     detail: "Dashboard consumes CPU/memory in your cluster."
@@ -74,7 +74,7 @@ const comparisonPoints = [
 
 <BaseLayout
   title="Kubeli vs Kubernetes Dashboard - Desktop Alternative"
-  description="Looking for a Kubernetes Dashboard alternative? Kubeli is a native macOS app that doesn't require cluster deployment. AI-powered, multi-cluster, and secure."
+  description="Looking for a Kubernetes Dashboard alternative? Kubeli is a native desktop app for macOS and Windows that doesn't require cluster deployment. AI-powered, multi-cluster, and secure."
   activeNav=""
   canonicalPath="/compare/dashboard-alternative"
 >
@@ -88,7 +88,7 @@ const comparisonPoints = [
         Looking for a <span class="text-orange-600">Dashboard Alternative</span>?
       </h1>
       <p class="text-neutral-500 max-w-2xl mx-auto text-lg mt-6">
-        Kubeli is a native macOS app that doesn't require deploying anything to your cluster.
+        Kubeli is a native desktop app for macOS and Windows that doesn't require deploying anything to your cluster.
         Multi-cluster support, AI-powered analysis, and zero security exposure.
       </p>
 

--- a/web/src/pages/compare/k9s-alternative.astro
+++ b/web/src/pages/compare/k9s-alternative.astro
@@ -71,17 +71,17 @@ const comparisonPoints = [
   },
   {
     category: "Platforms",
-    kubeli: "macOS",
+    kubeli: "macOS, Windows",
     k9s: "macOS, Linux, Windows",
-    winner: "k9s",
-    detail: "k9s supports more platforms."
+    winner: "tie",
+    detail: "Both support major desktop platforms. k9s also supports Linux."
   }
 ];
 ---
 
 <BaseLayout
   title="Kubeli vs k9s - GUI Alternative to Terminal"
-  description="Looking for a k9s alternative with a visual interface? Kubeli is a native macOS Kubernetes GUI with AI-powered log analysis and interactive diagrams."
+  description="Looking for a k9s alternative with a visual interface? Kubeli is a native Kubernetes GUI for macOS and Windows with AI-powered log analysis and interactive diagrams."
   activeNav=""
   canonicalPath="/compare/k9s-alternative"
 >
@@ -162,11 +162,7 @@ const comparisonPoints = [
             </li>
             <li class="flex items-start gap-2">
               <span class="text-green-500 mt-0.5">+</span>
-              <span>Native macOS experience</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <span class="text-neutral-400 mt-0.5">-</span>
-              <span>macOS only (for now)</span>
+              <span>Native desktop experience (macOS & Windows)</span>
             </li>
           </ul>
         </div>
@@ -215,7 +211,7 @@ const comparisonPoints = [
           <ul class="space-y-2 text-neutral-400">
             <li>Love terminal-based workflows</li>
             <li>Already know vim keybindings</li>
-            <li>Need Linux/Windows support</li>
+            <li>Need Linux support</li>
             <li>Work primarily over SSH</li>
           </ul>
         </div>
@@ -225,7 +221,7 @@ const comparisonPoints = [
             <li>Prefer visual interfaces</li>
             <li>Want AI-assisted troubleshooting</li>
             <li>Need to visualize cluster topology</li>
-            <li>Use macOS as your primary OS</li>
+            <li>Use macOS or Windows as your primary OS</li>
           </ul>
         </div>
       </div>

--- a/web/src/pages/compare/kubectl-alternative.astro
+++ b/web/src/pages/compare/kubectl-alternative.astro
@@ -74,7 +74,7 @@ const comparisonPoints = [
 
 <BaseLayout
   title="Kubeli vs kubectl - Visual Alternative to CLI"
-  description="Looking for a kubectl alternative with a visual interface? Kubeli is a native macOS Kubernetes GUI with AI-powered analysis. No commands to memorize."
+  description="Looking for a kubectl alternative with a visual interface? Kubeli is a native Kubernetes GUI for macOS and Windows with AI-powered analysis. No commands to memorize."
   activeNav=""
   canonicalPath="/compare/kubectl-alternative"
 >

--- a/web/src/pages/compare/lens-alternative.astro
+++ b/web/src/pages/compare/lens-alternative.astro
@@ -18,7 +18,7 @@ const comparisonPoints = [
     kubeli: "26.8MB",
     lens: "~1.93 GB",
     winner: "kubeli",
-    detail: "Lens bundles a full Chromium browser. Kubeli uses the native macOS WebView."
+    detail: "Lens bundles a full Chromium browser. Kubeli uses the native OS WebView."
   },
   {
     category: "Memory Usage",
@@ -81,7 +81,7 @@ const comparisonPoints = [
 
 <BaseLayout
   title="Kubeli vs Lens - The Lightweight Alternative"
-  description="Looking for a Lens alternative? Kubeli is a native macOS Kubernetes client that's 70x smaller, uses 3x less memory, and is 100% free. Compare features."
+  description="Looking for a Lens alternative? Kubeli is a native Kubernetes client for macOS and Windows that's 70x smaller, uses 3x less memory, and is 100% free. Compare features."
   activeNav=""
   canonicalPath="/compare/lens-alternative"
 >
@@ -95,7 +95,7 @@ const comparisonPoints = [
         Looking for a <span class="text-blue-600">Lens Alternative</span>?
       </h1>
       <p class="text-neutral-500 max-w-2xl mx-auto text-lg mt-6">
-        Kubeli is a native macOS Kubernetes client that's 70x smaller, uses 3x less memory,
+        Kubeli is a native Kubernetes client for macOS and Windows that's 70x smaller, uses 3x less memory,
         starts instantly, and is 100% free and open source.
       </p>
 
@@ -185,7 +185,7 @@ const comparisonPoints = [
           <div>
             <h3 class="font-semibold text-lg">No more Electron bloat</h3>
             <p class="text-neutral-400 mt-1">
-              Lens bundles an entire Chromium browser. Kubeli uses native macOS WebView for a lightweight experience.
+              Lens bundles an entire Chromium browser. Kubeli uses native OS WebView for a lightweight experience.
             </p>
           </div>
         </div>
@@ -225,7 +225,7 @@ const comparisonPoints = [
             </svg>
           </div>
           <div>
-            <h3 class="font-semibold text-lg">Native macOS experience</h3>
+            <h3 class="font-semibold text-lg">Native desktop experience</h3>
             <p class="text-neutral-400 mt-1">
               Vibrancy effects, system-level integration, and a fraction of the memory footprint.
             </p>


### PR DESCRIPTION
## Summary

- Updated all comparison pages in `/web` to reflect that Kubeli now supports both macOS and Windows
- Removed outdated "macOS only" references from k9s, lens, dashboard, and kubectl comparison pages
- Platform comparison with k9s changed from "k9s wins" to "tie" since both now support major desktop platforms

## Changes

| Page | Before | After |
|------|--------|-------|
| k9s-alternative | "macOS" / "macOS only (for now)" | "macOS, Windows" / removed limitation |
| dashboard-alternative | "Local Mac only" / "native macOS app" | "Local desktop only" / "native desktop app for macOS and Windows" |
| lens-alternative | "native macOS Kubernetes client" | "native Kubernetes client for macOS and Windows" |
| kubectl-alternative | "native macOS Kubernetes GUI" | "native Kubernetes GUI for macOS and Windows" |

## Test plan

- [ ] Verify comparison pages render correctly
- [ ] Check SEO meta descriptions are accurate