### PR TITLE
feat(tabs): optimize tab bar with adaptive plus button and Cmd+T shortcut

### DIFF
--- a/src/components/features/dashboard/Dashboard.tsx
+++ b/src/components/features/dashboard/Dashboard.tsx
@@ -149,6 +149,7 @@ function DashboardContent() {
     { key: NAVIGATION_SHORTCUTS.FAVORITE_8, meta: true, handler: () => navigateToFavorite(7), description: "Go to Favorite 8" },
     { key: NAVIGATION_SHORTCUTS.FAVORITE_9, meta: true, handler: () => navigateToFavorite(8), description: "Go to Favorite 9" },
     // Tab shortcuts
+    { key: "t", meta: true, handler: () => { if (resourceTabs.length < 10) openTab("cluster-overview", getTabTitle("cluster-overview"), { newTab: true }); }, description: "New tab", global: true },
     { key: "w", meta: true, handler: () => { if (resourceTabs.length > 1) closeTab(activeTabId); }, description: "Close current tab", global: true },
     { key: "Tab", meta: true, handler: () => {
       const idx = resourceTabs.findIndex((t) => t.id === activeTabId);
@@ -160,7 +161,7 @@ function DashboardContent() {
       const prevIdx = (idx - 1 + resourceTabs.length) % resourceTabs.length;
       setActiveTab(resourceTabs[prevIdx].id);
     }, description: "Previous tab", global: true },
-  ], [navigateToFavorite, toggleAIAssistant, isAICliAvailable, resourceTabs, activeTabId, closeTab, setActiveTab, setActiveResource, triggerRefresh, triggerSearchFocus]);
+  ], [navigateToFavorite, toggleAIAssistant, isAICliAvailable, resourceTabs, activeTabId, openTab, getTabTitle, closeTab, setActiveTab, setActiveResource, triggerRefresh, triggerSearchFocus]);
 
   useKeyboardShortcuts(shortcuts, { enabled: isConnected });
 

--- a/src/components/features/shortcuts/ShortcutsHelpDialog.tsx
+++ b/src/components/features/shortcuts/ShortcutsHelpDialog.tsx
@@ -54,6 +54,7 @@ function buildShortcutGroups(mod: string): ShortcutGroup[] {
     {
       titleKey: "tabs",
       shortcuts: [
+        { keys: [mod, "T"], combo: true, label: (t) => t("newTab") },
         { keys: [mod, "W"], combo: true, label: (t) => t("closeTab") },
       ],
     },

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -762,6 +762,7 @@
     "search": "Suche fokussieren",
     "escape": "Schließen / Abbrechen",
     "tabs": "Tabs",
+    "newTab": "Neuer Tab",
     "closeTab": "Tab schließen",
     "nextTab": "Nächster Tab",
     "previousTab": "Vorheriger Tab"

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -762,6 +762,7 @@
     "search": "Focus search",
     "escape": "Close / Cancel",
     "tabs": "Tabs",
+    "newTab": "New tab",
     "closeTab": "Close tab",
     "nextTab": "Next tab",
     "previousTab": "Previous tab"


### PR DESCRIPTION
## Summary
- Plus button now flows next to the last tab when there's space; fixes to the right edge when tabs overflow
- Active tab auto-scrolls into view when switching or creating new tabs
- Added `Cmd+T` / `Ctrl+T` keyboard shortcut to open a new tab
- Plus button tooltip now shows the keyboard shortcut hint

## Test plan
- [x] Open tabs until they overflow — verify plus button sticks to right edge
- [x] With few tabs — verify plus button sits next to last tab
- [x] Click last tab when overflowing — verify it scrolls fully into view
- [x] Press Cmd+T / Ctrl+T — verify new tab opens and scrolls into view
- [x] Hover plus button — verify tooltip shows shortcut
- [x] Open shortcuts help dialog (?) — verify new tab shortcut listed