### PR TITLE
fix(i18n): proper pause label for Follow logs button

### DIFF
--- a/src/components/features/logs/LogViewer.tsx
+++ b/src/components/features/logs/LogViewer.tsx
@@ -175,7 +175,7 @@ export function LogViewer({ namespace, podName, initialContainer }: LogViewerPro
           onStop: stopStream,
           onFetch: () => fetchLogs({ tail_lines: LOG_DEFAULTS.FETCH_TAIL_LINES, previous: showPreviousLogs }),
           followLabel: t("logs.follow"),
-          pausedLabel: t("logs.streamingPaused"),
+          pauseLabel: t("logs.pause"),
           fetchTooltip: showPreviousLogs ? t("logs.previousLogsNoStream") : t("logs.fetchLogs"),
         }}
         download={{

--- a/src/components/features/logs/components/LogToolbar.tsx
+++ b/src/components/features/logs/components/LogToolbar.tsx
@@ -47,7 +47,7 @@ export interface StreamProps {
   onStop: () => void;
   onFetch: () => void;
   followLabel: string;
-  pausedLabel: string;
+  pauseLabel: string;
   fetchTooltip: string;
 }
 
@@ -135,7 +135,7 @@ export function LogToolbar({
           onStart={stream.onStart}
           onStop={stream.onStop}
           followLabel={stream.followLabel}
-          pausedLabel={stream.pausedLabel}
+          pauseLabel={stream.pauseLabel}
         />
 
         <TooltipProvider delayDuration={300}>

--- a/src/components/features/logs/components/toolbar/StreamButton.tsx
+++ b/src/components/features/logs/components/toolbar/StreamButton.tsx
@@ -10,7 +10,7 @@ interface StreamButtonProps {
   onStart: () => void;
   onStop: () => void;
   followLabel: string;
-  pausedLabel: string;
+  pauseLabel: string;
 }
 
 export function StreamButton({
@@ -20,7 +20,7 @@ export function StreamButton({
   onStart,
   onStop,
   followLabel,
-  pausedLabel,
+  pauseLabel,
 }: StreamButtonProps) {
   if (isStreaming) {
     return (
@@ -31,7 +31,7 @@ export function StreamButton({
         className="h-7 text-xs text-yellow-500 hover:text-yellow-600"
       >
         <Pause className="size-3.5" />
-        {pausedLabel}
+        {pauseLabel}
       </Button>
     );
   }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -294,6 +294,7 @@
     "title": "Logs",
     "container": "Container",
     "follow": "Folgen",
+    "pause": "Pause",
     "timestamps": "Zeitstempel",
     "previous": "Vorherige",
     "since": "Seit",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -294,6 +294,7 @@
     "title": "Logs",
     "container": "Container",
     "follow": "Follow",
+    "pause": "Pause",
     "timestamps": "Timestamps",
     "previous": "Previous",
     "since": "Since",


### PR DESCRIPTION
## Description

"Follow" logs button had text "Streaming paused" instead of "Pause"


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate visual changes -->

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested on macOS (version: )
- [x] Tested with Kubernetes cluster (provider: )
