### PR TITLE
fix: YAML editor cursor positioning when clicking mid-line

### DIFF
--- a/src/components/features/resources/ResourceDetail.tsx
+++ b/src/components/features/resources/ResourceDetail.tsx
@@ -229,6 +229,7 @@ export function ResourceDetail({
             onCopyYaml={handleCopyYaml}
             copied={copied}
             readOnly={!onSave}
+            isActive={activeTab === "yaml"}
           />
         </TabsContent>
 


### PR DESCRIPTION
## Summary

- Fix Monaco Editor cursor disappearing when clicking in the middle of a YAML line
- Root cause: Editor initializes inside a hidden container (`forceMount` + `display:none`), causing stale font metric measurements
- Call `remeasureFonts()` and `layout()` when the YAML tab becomes active to recalculate character widths

## Changes

- **YamlTab.tsx**: Add `onMount` handler to capture editor/monaco refs, add `useEffect` to remeasure fonts when `isActive` becomes true
- **ResourceDetail.tsx**: Pass `isActive={activeTab === "yaml"}` to YamlTab

## Test plan

- [ ] Open any resource's detail pane
- [ ] Switch to the YAML tab
- [ ] Click in the middle of any line — cursor should appear at the click position
- [ ] Click at the end of a line — should still work as before
- [ ] Switch away from YAML tab and back — cursor click should still work correctly

Closes #73