### PR TITLE
chore: migrate public URLs to kubeli.dev

### DIFF
--- a/.dev/windows/WINDOWS-SETUP.md
+++ b/.dev/windows/WINDOWS-SETUP.md
@@ -6,14 +6,14 @@
 
 ```powershell
 # Run directly from URL
-irm https://kubeli.atilla.app/setup-minikube.ps1 | iex
+irm https://kubeli.dev/setup-minikube.ps1 | iex
 ```
 
 ### Manual Setup
 
 1. **Download the script:**
    ```powershell
-   Invoke-WebRequest -Uri https://kubeli.atilla.app/setup-minikube.ps1 -OutFile setup-minikube.ps1
+   Invoke-WebRequest -Uri https://kubeli.dev/setup-minikube.ps1 -OutFile setup-minikube.ps1
    ```
 
 2. **Run the script:**

--- a/.dev/windows/setup-minikube.ps1
+++ b/.dev/windows/setup-minikube.ps1
@@ -8,7 +8,7 @@
     and sample resources for testing Kubeli.
 
     Run from URL:
-    irm https://kubeli.atilla.app/setup-minikube.ps1 | iex
+    irm https://kubeli.dev/setup-minikube.ps1 | iex
 
 .NOTES
     Author: Kubeli Team
@@ -107,7 +107,7 @@ EXAMPLES:
     .\setup-minikube.ps1 -CleanOnly
 
 RUN FROM URL:
-    irm https://kubeli.atilla.app/setup-minikube.ps1 | iex
+    irm https://kubeli.dev/setup-minikube.ps1 | iex
 
 "@
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/atilladeniz/Kubeli/discussions
     about: Ask questions and discuss ideas
   - name: Documentation
-    url: https://kubeli.atilla.app
+    url: https://kubeli.dev
     about: Check out the documentation


### PR DESCRIPTION
## Summary
- Migrate all public-facing URLs from `kubeli.atilla.app` to `kubeli.dev`
- Updater endpoints (`api.atilla.app/kubeli/updates/`) intentionally kept unchanged for FTP update compatibility during domain transition

## Changed files
- `.dev/windows/setup-minikube.ps1` - PowerShell script download URLs
- `.dev/windows/WINDOWS-SETUP.md` - Documentation URLs
- `.github/ISSUE_TEMPLATE/config.yml` - Documentation link

## Not changed (intentional)
- `src-tauri/tauri.conf.json` - Updater endpoint stays on `api.atilla.app` (existing installs need this for updates)
- `src-tauri/tauri.conf.debug.json` - Same
- `web/src/layouts/BaseLayout.astro` - Already uses `kubeli.dev`