### PR TITLE
fix: show tab limit toast on Cmd+T/Ctrl+T shortcut

### DIFF
--- a/src/components/features/dashboard/Dashboard.tsx
+++ b/src/components/features/dashboard/Dashboard.tsx
@@ -341,7 +341,7 @@ function DashboardContent() {
     { key: NAVIGATION_SHORTCUTS.FAVORITE_8, meta: true, handler: () => navigateToFavorite(7), description: "Go to Favorite 8" },
     { key: NAVIGATION_SHORTCUTS.FAVORITE_9, meta: true, handler: () => navigateToFavorite(8), description: "Go to Favorite 9" },
     // Tab shortcuts
-    { key: "t", meta: true, handler: () => { if (resourceTabs.length < 10) openTab("cluster-overview", getTabTitle("cluster-overview"), { newTab: true }); }, description: "New tab", global: true },
+    { key: "t", meta: true, handler: () => { if (resourceTabs.length < 10) { openTab("cluster-overview", getTabTitle("cluster-overview"), { newTab: true }); } else { toast.warning(t("tabs.limitToast")); } }, description: "New tab", global: true },
     { key: "w", meta: true, handler: () => { if (resourceTabs.length > 1) closeTab(activeTabId); }, description: "Close current tab", global: true },
     { key: "Tab", meta: true, handler: () => {
       const idx = resourceTabs.findIndex((t) => t.id === activeTabId);
@@ -353,7 +353,7 @@ function DashboardContent() {
       const prevIdx = (idx - 1 + resourceTabs.length) % resourceTabs.length;
       setActiveTab(resourceTabs[prevIdx].id);
     }, description: "Previous tab", global: true },
-  ], [navigateToFavorite, toggleAIAssistant, isAICliAvailable, resourceTabs, activeTabId, openTab, getTabTitle, closeTab, setActiveTab, setActiveResource, triggerRefresh, triggerSearchFocus]);
+  ], [navigateToFavorite, toggleAIAssistant, isAICliAvailable, resourceTabs, activeTabId, openTab, getTabTitle, closeTab, setActiveTab, setActiveResource, triggerRefresh, triggerSearchFocus, t]);
 
   useKeyboardShortcuts(shortcuts, { enabled: isConnected });
 


### PR DESCRIPTION
## Summary
- When pressing Cmd+T (Mac) or Ctrl+T (Windows) with 10 tabs already open, the shortcut silently did nothing
- Now shows the same warning toast ("You already have 10 tabs open. Please close a tab to open a new one.") that is already used when opening tabs from the sidebar or favorites

## Changes
- Added `else` branch in keyboard shortcut handler to show `toast.warning(t("tabs.limitToast"))` when tab limit is reached
- Added `t` to `useMemo` dependency array to satisfy React hooks rules

## Test plan
- [x] Open 10 tabs in Kubeli
- [x] Press Cmd+T (Mac) or Ctrl+T (Windows)
- [x] Verify the warning toast appears with the message "You already have 10 tabs open. Please close a tab to open a new one."