### PR TITLE
Add supply chain hardening and network audit tooling

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -137,6 +137,57 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
+  cargo-deny:
+    name: Cargo Deny (Licenses, Bans, Sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          shared-key: ubuntu-rust-deny
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: Run cargo-deny
+        working-directory: src-tauri
+        run: cargo deny check
+
+  cargo-audit:
+    name: Cargo Audit (RustSec)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Run cargo-audit
+        working-directory: src-tauri
+        run: cargo audit
+
+  lockfile-lint:
+    name: Lockfile Integrity Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Lint lockfile registry sources
+        run: npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
+
   semgrep:
     name: Semgrep SAST Scan
     runs-on: ubuntu-latest

--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -26,3 +26,81 @@ rules:
     message: "Avoid dangerouslySetInnerHTML - XSS risk"
     languages: [typescript, javascript]
     severity: ERROR
+
+  # -- Network call detection (telemetry / phone-home prevention) --
+
+  # Detect direct fetch() calls outside of Tauri command bindings
+  - id: no-direct-fetch
+    patterns:
+      - pattern: fetch(...)
+      - pattern-not-inside: |
+          async function invoke(...) { ... fetch(...) ... }
+    paths:
+      include:
+        - /src/
+      exclude:
+        - /src/**/*.test.*
+        - /src/**/*.spec.*
+        - /src/lib/tauri/
+    message: "Direct fetch() detected. All network requests must go through Tauri commands. If intentional, add a semgrep nosemgrep comment."
+    languages: [typescript, javascript]
+    severity: ERROR
+
+  # Detect XMLHttpRequest usage
+  - id: no-xmlhttprequest
+    pattern: new XMLHttpRequest(...)
+    paths:
+      include:
+        - /src/
+      exclude:
+        - /src/**/*.test.*
+        - /src/**/*.spec.*
+    message: "XMLHttpRequest detected. All network requests must go through Tauri commands."
+    languages: [typescript, javascript]
+    severity: ERROR
+
+  # Detect WebSocket creation (should only be in Tauri backend)
+  - id: no-direct-websocket
+    pattern: new WebSocket(...)
+    paths:
+      include:
+        - /src/
+      exclude:
+        - /src/**/*.test.*
+        - /src/**/*.spec.*
+    message: "Direct WebSocket detected. WebSocket connections should be managed by the Tauri backend."
+    languages: [typescript, javascript]
+    severity: ERROR
+
+  # Detect sendBeacon (commonly used for telemetry)
+  - id: no-sendbeacon
+    pattern: navigator.sendBeacon(...)
+    paths:
+      include:
+        - /src/
+    message: "navigator.sendBeacon() detected - this is commonly used for telemetry. Remove it."
+    languages: [typescript, javascript]
+    severity: ERROR
+
+  # Detect EventSource / Server-Sent Events
+  - id: no-eventsource
+    pattern: new EventSource(...)
+    paths:
+      include:
+        - /src/
+      exclude:
+        - /src/**/*.test.*
+        - /src/**/*.spec.*
+    message: "EventSource detected. All network requests must go through Tauri commands."
+    languages: [typescript, javascript]
+    severity: ERROR
+
+  # Detect known tracking/analytics domains in strings
+  - id: no-tracking-domains
+    pattern-regex: "(google-analytics|googletagmanager|sentry\\.io|segment\\.io|mixpanel|amplitude|hotjar|fullstory|heap\\.io|posthog|plausible\\.io|datadog)"
+    paths:
+      include:
+        - /src/
+    message: "Tracking/analytics domain reference detected. Kubeli must not include any telemetry."
+    languages: [typescript, javascript]
+    severity: ERROR

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release patches for security vulnerabilities for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.x   | :white_check_mark: |
-| < 0.2   | :x:                |
+| 0.3.x   | :white_check_mark: |
+| < 0.3   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -45,6 +45,75 @@ Please include the following information in your report:
 2. We will investigate and validate the vulnerability
 3. We will work on a fix and coordinate disclosure
 4. We will credit you in the release notes (unless you prefer to remain anonymous)
+
+## Supply Chain Security
+
+Kubeli employs multiple layers of automated security scanning to ensure that no bundled dependency introduces telemetry, unauthorized network traffic, or known vulnerabilities into production builds.
+
+### Automated CI Checks
+
+Every push and pull request is scanned by the following tools:
+
+| Tool | What it checks |
+|------|---------------|
+| **Trivy** | Known CVEs in npm and Rust SBOMs, filesystem secrets, misconfigurations |
+| **Semgrep** | SAST with community rulesets (TypeScript, React, Rust, secrets) and custom rules |
+| **cargo-deny** | Rust crate licenses, banned crates, registry sources, RustSec advisories |
+| **cargo-audit** | Rust dependencies against the RustSec Advisory Database |
+| **lockfile-lint** | Validates that all npm packages are sourced from the official HTTPS registry |
+
+Weekly scheduled scans run every Monday to catch newly disclosed advisories.
+
+### Network Isolation (Zero Telemetry)
+
+Kubeli is designed as a **zero-telemetry** application. The following measures enforce this:
+
+- **Content Security Policy (CSP)**: The Tauri CSP restricts `connect-src` to `self`, `ipc:`, and `http://ipc.localhost` only. The frontend WebView cannot make any external network requests.
+- **No HTTP plugin**: The Tauri HTTP plugin is not enabled. The frontend has no capability to make outbound HTTP requests.
+- **Semgrep network-call rules**: Custom Semgrep rules flag any use of `fetch()`, `XMLHttpRequest`, `WebSocket`, `navigator.sendBeacon()`, or `EventSource` in frontend code as errors. References to known tracking domains (Google Analytics, Sentry, Mixpanel, etc.) are also flagged.
+- **Banned Rust crates**: `cargo-deny` blocks telemetry-related crates (`sentry`, `sentry-core`, `opentelemetry`, `datadog`) from ever entering the dependency tree.
+- **Source restriction**: All Rust crates must originate from crates.io. Unknown registries and Git sources are denied.
+
+The only legitimate outbound connections from Kubeli are:
+
+1. **Kubernetes API servers** -- user-configured, initiated by user action via the Rust backend
+2. **Update check** -- `https://api.atilla.app/kubeli/updates/latest.json` via the Tauri updater plugin (signature-verified with a public key)
+
+### SBOM (Software Bill of Materials)
+
+CycloneDX 1.5 SBOMs are generated for both npm and Rust dependencies and attached to every GitHub release. These can be used for independent verification.
+
+### Known Advisories in Transitive Dependencies
+
+The following advisories affect transitive dependencies that are outside of Kubeli's direct control. They are documented here with risk assessments explaining why they do not compromise Kubeli's security posture.
+
+#### Unmaintained crates (no known vulnerability)
+
+| Advisory | Crate | Pulled in by | Assessment |
+|----------|-------|-------------|------------|
+| RUSTSEC-2025-0098 | `unic-ucd-version` | `tauri-utils` > `urlpattern` | Unmaintained, no security flaw. Used internally by Tauri for URL pattern matching. |
+| RUSTSEC-2025-0081 | `unic-char-property` | `tauri-utils` > `urlpattern` | Same as above. |
+| RUSTSEC-2025-0075 | `unic-char-range` | `tauri-utils` > `urlpattern` | Same as above. |
+| RUSTSEC-2025-0080 | `unic-common` | `tauri-utils` > `urlpattern` | Same as above. |
+| RUSTSEC-2025-0100 | `unic-ucd-ident` | `tauri-utils` > `urlpattern` | Same as above. |
+| RUSTSEC-2025-0057 | `fxhash` | Tauri ecosystem | Unmaintained, no security flaw. Hash function used internally by Tauri. |
+
+#### Vulnerabilities with limited impact
+
+| Advisory | Crate | Severity | Pulled in by | Assessment |
+|----------|-------|----------|-------------|------------|
+| RUSTSEC-2026-0007 | `bytes` | Integer overflow in `BytesMut::reserve` | `hyper` / `tokio` (transitive) | Exploitation requires attacker-controlled input to `BytesMut::reserve()`. Kubeli does not call this API directly. The only data flowing through `hyper`/`tokio` originates from user-configured Kubernetes API servers. An attacker would need to compromise the K8s API server itself to exploit this, at which point the cluster is already breached. **Risk: negligible.** |
+| RUSTSEC-2026-0009 | `serde_json` | DoS via stack exhaustion with deeply nested JSON | Transitive dependency | Exploitation requires processing extremely deep JSON nesting (hundreds of levels). Kubernetes API responses have well-defined, shallow schemas. Kubeli does not accept arbitrary JSON from untrusted sources. **Risk: negligible.** |
+
+These exceptions are tracked in `src-tauri/deny.toml` and will be removed once patched versions are available upstream.
+
+### Verification
+
+Users and auditors are encouraged to independently verify Kubeli's network behavior:
+
+1. **Runtime monitoring**: Use [mitmproxy](https://mitmproxy.org/), [Proxyman](https://proxyman.com/), or [Little Snitch](https://www.obdev.at/products/littlesnitch) to monitor all outbound connections from a production build.
+2. **SBOM review**: Download the CycloneDX SBOMs from the GitHub release and scan them with your preferred vulnerability scanner.
+3. **Build from source**: Clone the repository and run `cargo deny check` and `npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm` to verify locally.
 
 ## Security Best Practices for Users
 

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -1,0 +1,87 @@
+# cargo-deny configuration for Kubeli
+# https://embarkstudios.github.io/cargo-deny/
+#
+# Run: cd src-tauri && cargo deny check
+
+[graph]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
+# -- Advisories: check for known vulnerabilities in dependencies --
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+
+# Ignored advisories (transitive deps outside our control)
+ignore = [
+    # unic-* crates: unmaintained, pulled in by tauri-utils -> urlpattern
+    # No alternative available; tracking upstream fix in tauri
+    "RUSTSEC-2025-0098", # unic-ucd-version
+    "RUSTSEC-2025-0081", # unic-char-property
+    "RUSTSEC-2025-0075", # unic-char-range
+    "RUSTSEC-2025-0080", # unic-common
+    "RUSTSEC-2025-0100", # unic-ucd-ident
+
+    # fxhash: unmaintained, pulled in by tauri ecosystem
+    "RUSTSEC-2025-0057",
+
+    # bytes: integer overflow in BytesMut::reserve, transitive via hyper/tokio
+    "RUSTSEC-2026-0007",
+
+    # serde_json: DoS via stack exhaustion, transitive dep
+    "RUSTSEC-2026-0009",
+]
+
+# -- Licenses: ensure all crate licenses are acceptable --
+[licenses]
+version = 2
+confidence-threshold = 0.8
+
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "Unicode-3.0",
+    "CC0-1.0",
+    "MIT-0",
+    "MPL-2.0",
+    "BSL-1.0",
+    "Unlicense",
+    "OpenSSL",
+    "CDLA-Permissive-2.0",
+]
+
+# [[licenses.exceptions]]
+# allow = ["LGPL-2.1-or-later"]
+# crate = "adler2"
+
+# -- Bans: deny or allow specific crates --
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+# Crates that should never be used
+deny = [
+    # Known telemetry / analytics crates
+    { crate = "sentry", wrappers = [] },
+    { crate = "sentry-core", wrappers = [] },
+    { crate = "opentelemetry", wrappers = [] },
+    { crate = "datadog", wrappers = [] },
+]
+
+# -- Sources: ensure crates only come from trusted registries --
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost"
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'; form-action 'none'; frame-ancestors 'none'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

- **cargo-deny**: New `deny.toml` config enforcing license allowlist, banning telemetry crates (sentry, opentelemetry, datadog), restricting all Rust crate sources to crates.io, and checking RustSec advisories
- **Semgrep network rules**: 7 new custom rules detecting `fetch()`, `XMLHttpRequest`, `WebSocket`, `sendBeacon()`, `EventSource`, and known tracking domains in frontend code
- **CSP hardening**: Added `object-src 'none'`, `form-action 'none'`, `frame-ancestors 'none'` directives
- **CI pipeline**: 3 new parallel jobs in `security.yml` -- cargo-deny, cargo-audit, lockfile-lint
- **SECURITY.md**: Documented full supply chain security posture, zero-telemetry architecture, known transitive advisories with risk assessments, and verification instructions for auditors

## Details

### Known transitive advisories (all documented in SECURITY.md)

| Type | Count | Details |
|------|-------|---------|
| Unmaintained (no CVE) | 6 | unic-* crates + fxhash, pulled in by Tauri ecosystem |
| Low-risk vulnerabilities | 2 | bytes (integer overflow, requires compromised K8s API server), serde_json (DoS via deep nesting, K8s schemas are shallow) |

All exceptions are tracked in `src-tauri/deny.toml` with comments and will be removed once upstream patches are available.

### Validation

```
cargo deny check -> advisories ok, bans ok, licenses ok, sources ok
lockfile-lint    -> No issues detected
npm audit        -> found 0 vulnerabilities
```

## Test plan

- [ ] Verify `cargo deny check` passes in CI
- [ ] Verify `cargo audit` runs without blocking errors in CI
- [ ] Verify `lockfile-lint` passes in CI
- [ ] Verify Semgrep picks up the new custom rules (existing pipeline, new `.semgrep.yaml` rules)
- [ ] Verify CSP change does not break app functionality (dev + production build)