### PR TITLE
feat: add search bar for cluster list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
   X,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
 import {
   Empty,
   EmptyDescription,
@@ -489,7 +490,10 @@ export default function Home() {
                           variant={isActive ? "secondary" : "default"}
                         >
                           {connectingContext === cluster.context ? (
-                            <Loader2 className="size-4 animate-spin" />
+                            <>
+                              <Spinner />
+                              {t("connecting")}
+                            </>
                           ) : isActive ? (
                             t("connected")
                           ) : (

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -155,7 +155,8 @@
     "latency": "{ms}ms",
     "searchClustersPlaceholder": "Cluster suchen...",
     "noSearchResults": "Keine Cluster gefunden",
-    "noSearchResultsHint": "Keine Cluster für \"{query}\" gefunden. Versuche einen anderen Suchbegriff."
+    "noSearchResultsHint": "Keine Cluster für \"{query}\" gefunden. Versuche einen anderen Suchbegriff.",
+    "connecting": "Verbinde..."
   },
   "workloads": {
     "overview": "Workloads-Übersicht",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -155,7 +155,8 @@
     "latency": "{ms}ms",
     "searchClustersPlaceholder": "Search clusters...",
     "noSearchResults": "No clusters found",
-    "noSearchResultsHint": "No clusters matching \"{query}\". Try a different search term."
+    "noSearchResultsHint": "No clusters matching \"{query}\". Try a different search term.",
+    "connecting": "Connecting..."
   },
   "workloads": {
     "overview": "Workloads Overview",


### PR DESCRIPTION
## Summary
- Adds a search input field next to the refresh button on the cluster selection page
- Filters clusters by name and context as the user types
- Adds `searchPlaceholder` translation keys for EN and DE

Closes #113

## Credit
Based on the contribution by @ezzaze ([commit](https://github.com/ezzaze/Kubeli/commit/2d9c48f9db0f0553203c4e8e5aefaae07f4dbf2d))

## Test plan
- [x] Verify search input appears next to the refresh button
- [x] Type a cluster name and confirm the list filters correctly
- [x] Verify filtering works on both cluster name and context
- [x] Clear the search and confirm all clusters reappear
- [x] Check DE and EN translations for the placeholder text