### PR TITLE
refactor(titlebar): split into hooks and components

### DIFF
--- a/src/components/layout/titlebar/Titlebar.tsx
+++ b/src/components/layout/titlebar/Titlebar.tsx
@@ -1,153 +1,46 @@
 "use client";
 
-import { useEffect } from "react";
-import { Settings, Sparkles, Loader2, CircleHelp } from "lucide-react";
-import { useTranslations } from "next-intl";
-import { Button } from "@/components/ui/button";
-import { Kbd } from "@/components/ui/kbd";
-import { useUpdater } from "@/lib/hooks/useUpdater";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
+import { Settings, CircleHelp } from "lucide-react";
 import { usePlatform } from "@/lib/hooks/usePlatform";
-
-interface TitlebarProps {
-  title?: string;
-  showTitle?: boolean;
-  isAIOpen?: boolean;
-  isAIProcessing?: boolean;
-  isAIDisabled?: boolean;
-  onToggleAI?: () => void;
-  onOpenSettings?: () => void;
-  onOpenShortcutsHelp?: () => void;
-}
+import { useContextMenuBlocker } from "./hooks/useContextMenuBlocker";
+import { UpdateButton } from "./components/UpdateButton";
+import { AIToggleButton } from "./components/AIToggleButton";
+import { TitlebarIconButton } from "./components/TitlebarIconButton";
+import type { TitlebarProps } from "./types";
 
 export function Titlebar({ isAIOpen, isAIProcessing, isAIDisabled, onToggleAI, onOpenSettings, onOpenShortcutsHelp }: TitlebarProps) {
   const { modKeySymbol } = usePlatform();
-  const tu = useTranslations("updates");
-  const { available, update, downloading, progress, readyToRestart, downloadComplete, downloadAndInstall, restartNow } = useUpdater();
-  useEffect(() => {
-    // Disable native context menu globally
-    const handleContextMenu = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      // Allow context menu on our custom context menu triggers
-      if (target.closest('[data-slot="context-menu-trigger"]')) {
-        return;
-      }
-      // Allow context menu on input/textarea for copy/paste
-      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") {
-        return;
-      }
-      // Allow context menu in areas marked with data-allow-context-menu (e.g., AI chat)
-      if (target.closest('[data-allow-context-menu]')) {
-        return;
-      }
-      e.preventDefault();
-    };
-
-    document.addEventListener("contextmenu", handleContextMenu);
-    return () => document.removeEventListener("contextmenu", handleContextMenu);
-  }, []);
+  useContextMenuBlocker();
 
   return (
     <div data-tauri-drag-region className="h-7 shrink-0 flex items-center justify-end px-2 gap-1">
-      {/* Update Button */}
-      {available && update && (
-        <Button
-          variant="default"
-          size="sm"
-          className="h-5 text-[10px] px-2 py-0"
-          onClick={() => (readyToRestart || downloadComplete) ? restartNow() : downloadAndInstall()}
-          disabled={downloading}
-        >
-          {downloading ? `${Math.round(progress)}%` : (readyToRestart || downloadComplete) ? tu("restartNow") : tu("updateNow")}
-        </Button>
-      )}
+      <UpdateButton />
 
-      {/* AI Assistant Button */}
       {onToggleAI && (
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant={isAIOpen ? "secondary" : "ghost"}
-                size="icon"
-                className={cn(
-                  "size-6",
-                  isAIOpen && "bg-primary/10 text-primary hover:bg-primary/20",
-                  !isAIOpen && isAIProcessing && "text-violet-500",
-                  isAIDisabled && "opacity-50 cursor-not-allowed"
-                )}
-                onClick={isAIDisabled ? undefined : onToggleAI}
-                disabled={isAIDisabled}
-              >
-                {!isAIOpen && isAIProcessing ? (
-                  <Loader2 className="size-3.5 animate-spin" />
-                ) : (
-                  <Sparkles className="size-3.5" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="flex items-center gap-2">
-              {isAIDisabled ? (
-                <span className="text-muted-foreground">AI CLI not installed</span>
-              ) : (
-                <>
-                  <span>AI Assistant</span>
-                  <Kbd className="text-[10px]">G I</Kbd>
-                </>
-              )}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <AIToggleButton
+          isOpen={isAIOpen}
+          isProcessing={isAIProcessing}
+          isDisabled={isAIDisabled}
+          onToggle={onToggleAI}
+        />
       )}
 
-      {/* Shortcuts Help Button */}
       {onOpenShortcutsHelp && (
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-6"
-                onClick={onOpenShortcutsHelp}
-              >
-                <CircleHelp className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="flex items-center gap-2">
-              <span>Keyboard Shortcuts</span>
-              <Kbd className="text-[10px]">?</Kbd>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <TitlebarIconButton
+          icon={CircleHelp}
+          label="Keyboard Shortcuts"
+          shortcut="?"
+          onClick={onOpenShortcutsHelp}
+        />
       )}
 
-      {/* Settings Button */}
       {onOpenSettings && (
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-6"
-                onClick={onOpenSettings}
-              >
-                <Settings className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="flex items-center gap-2">
-              <span>Settings</span>
-              <Kbd className="text-[10px]">{modKeySymbol},</Kbd>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <TitlebarIconButton
+          icon={Settings}
+          label="Settings"
+          shortcut={`${modKeySymbol},`}
+          onClick={onOpenSettings}
+        />
       )}
     </div>
   );

--- a/src/components/layout/titlebar/components/AIToggleButton.tsx
+++ b/src/components/layout/titlebar/components/AIToggleButton.tsx
@@ -1,0 +1,56 @@
+import { Sparkles, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface AIToggleButtonProps {
+  isOpen?: boolean;
+  isProcessing?: boolean;
+  isDisabled?: boolean;
+  onToggle: () => void;
+}
+
+export function AIToggleButton({ isOpen, isProcessing, isDisabled, onToggle }: AIToggleButtonProps) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={isOpen ? "secondary" : "ghost"}
+            size="icon"
+            className={cn(
+              "size-6",
+              isOpen && "bg-primary/10 text-primary hover:bg-primary/20",
+              !isOpen && isProcessing && "text-violet-500",
+              isDisabled && "opacity-50 cursor-not-allowed"
+            )}
+            onClick={isDisabled ? undefined : onToggle}
+            disabled={isDisabled}
+          >
+            {!isOpen && isProcessing ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="size-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="flex items-center gap-2">
+          {isDisabled ? (
+            <span className="text-muted-foreground">AI CLI not installed</span>
+          ) : (
+            <>
+              <span>AI Assistant</span>
+              <Kbd className="text-[10px]">G I</Kbd>
+            </>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/layout/titlebar/components/TitlebarIconButton.tsx
+++ b/src/components/layout/titlebar/components/TitlebarIconButton.tsx
@@ -1,0 +1,39 @@
+import type { LucideIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface TitlebarIconButtonProps {
+  icon: LucideIcon;
+  label: string;
+  shortcut: string;
+  onClick: () => void;
+}
+
+export function TitlebarIconButton({ icon: Icon, label, shortcut, onClick }: TitlebarIconButtonProps) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={onClick}
+          >
+            <Icon className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="flex items-center gap-2">
+          <span>{label}</span>
+          <Kbd className="text-[10px]">{shortcut}</Kbd>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/layout/titlebar/components/UpdateButton.tsx
+++ b/src/components/layout/titlebar/components/UpdateButton.tsx
@@ -1,0 +1,22 @@
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { useUpdater } from "@/lib/hooks/useUpdater";
+
+export function UpdateButton() {
+  const tu = useTranslations("updates");
+  const { available, update, downloading, progress, readyToRestart, downloadComplete, downloadAndInstall, restartNow } = useUpdater();
+
+  if (!available || !update) return null;
+
+  return (
+    <Button
+      variant="default"
+      size="sm"
+      className="h-5 text-[10px] px-2 py-0"
+      onClick={() => (readyToRestart || downloadComplete) ? restartNow() : downloadAndInstall()}
+      disabled={downloading}
+    >
+      {downloading ? `${Math.round(progress)}%` : (readyToRestart || downloadComplete) ? tu("restartNow") : tu("updateNow")}
+    </Button>
+  );
+}

--- a/src/components/layout/titlebar/hooks/useContextMenuBlocker.ts
+++ b/src/components/layout/titlebar/hooks/useContextMenuBlocker.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+
+/**
+ * Blocks the native browser context menu globally,
+ * except on custom context-menu triggers, input/textarea elements,
+ * and elements marked with data-allow-context-menu.
+ */
+export function useContextMenuBlocker() {
+  useEffect(() => {
+    const handleContextMenu = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      // Allow context menu on our custom context menu triggers
+      if (target.closest('[data-slot="context-menu-trigger"]')) {
+        return;
+      }
+      // Allow context menu on input/textarea for copy/paste
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") {
+        return;
+      }
+      // Allow context menu in areas marked with data-allow-context-menu (e.g., AI chat)
+      if (target.closest('[data-allow-context-menu]')) {
+        return;
+      }
+      e.preventDefault();
+    };
+
+    document.addEventListener("contextmenu", handleContextMenu);
+    return () => document.removeEventListener("contextmenu", handleContextMenu);
+  }, []);
+}

--- a/src/components/layout/titlebar/index.ts
+++ b/src/components/layout/titlebar/index.ts
@@ -1,0 +1,2 @@
+export { Titlebar } from "./Titlebar";
+export type { TitlebarProps } from "./types";

--- a/src/components/layout/titlebar/types.ts
+++ b/src/components/layout/titlebar/types.ts
@@ -1,0 +1,10 @@
+export interface TitlebarProps {
+  title?: string;
+  showTitle?: boolean;
+  isAIOpen?: boolean;
+  isAIProcessing?: boolean;
+  isAIDisabled?: boolean;
+  onToggleAI?: () => void;
+  onOpenSettings?: () => void;
+  onOpenShortcutsHelp?: () => void;
+}


### PR DESCRIPTION
## Summary
- Extract `useContextMenuBlocker` hook for global context menu blocking
- Extract `UpdateButton` component (self-contained with `useUpdater`)
- Extract `AIToggleButton` component (processing/disabled state variants)
- Extract `TitlebarIconButton` reusable pattern (used by Settings + Shortcuts buttons)
- Add `types.ts` and barrel `index.ts`

## Result
`Titlebar.tsx` reduced from 155 lines to 47 lines — clean composition of sub-components.

## Structure
```
titlebar/
├── Titlebar.tsx                    (47 lines, composition)
├── index.ts
├── types.ts
├── hooks/
│   └── useContextMenuBlocker.ts
└── components/
    ├── AIToggleButton.tsx
    ├── TitlebarIconButton.tsx
    └── UpdateButton.tsx
```