### PR TITLE
docs(readme): update tech stack from Recharts to uPlot

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A modern, beautiful Kubernetes management desktop application with real-time mon
 | UI Components | Radix UI, Lucide Icons |
 | Editor | Monaco Editor |
 | Terminal | XTerm.js |
-| Charts | Recharts |
+| Charts | uPlot |
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Update Charts entry in Tech Stack table from Recharts to uPlot
- Reflects the switch made in 0d8e755 (pod metrics feature)