### PR TITLE
fix: show cached resource data on tab switch

### DIFF
--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -11,6 +11,7 @@ import {
   watchNamespaces,
   stopWatch,
 } from "../tauri/commands";
+import { useResourceCacheStore } from "./resource-cache-store";
 import type { WatchEvent } from "../types";
 
 // Debug logger - only logs in development
@@ -130,6 +131,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
 
   connect: async (context: string) => {
     set({ isLoading: true, isReconnecting: false });
+    useResourceCacheStore.getState().clearCache();
     try {
       const status = await connectCluster(context);
       if (status.connected) {
@@ -184,6 +186,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
     // Stop health monitoring and namespace watch before disconnecting
     get().stopHealthMonitoring();
     get().stopNamespaceWatch();
+    useResourceCacheStore.getState().clearCache();
     try {
       await disconnectCluster();
       // Keep currentCluster so port forward badge still shows on the correct cluster card

--- a/src/lib/stores/resource-cache-store.ts
+++ b/src/lib/stores/resource-cache-store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+interface ResourceCacheState {
+  cache: Record<string, unknown[]>;
+  getCache: <T>(key: string) => T[];
+  setCache: <T>(key: string, data: T[]) => void;
+  clearCache: () => void;
+}
+
+export const useResourceCacheStore = create<ResourceCacheState>((set, get) => ({
+  cache: {},
+
+  getCache: <T>(key: string): T[] => {
+    return (get().cache[key] as T[] | undefined) ?? [];
+  },
+
+  setCache: <T>(key: string, data: T[]) => {
+    set((state) => ({
+      cache: { ...state.cache, [key]: data },
+    }));
+  },
+
+  clearCache: () => {
+    set({ cache: {} });
+  },
+}));


### PR DESCRIPTION
## Summary
- Add `resource-cache-store` (Zustand) to cache fetched resource data keyed by `resourceType:namespace`
- `useK8sResource`, `useClusterScopedResource`, and `useOptionalNamespaceResource` initialize from cache instead of `[]`
- Returning to a previously viewed tab shows data instantly — no loading spinner — while a background refresh runs silently
- Cache is cleared on cluster connect and disconnect to prevent stale cross-cluster data

## How it works
- **First visit**: spinner (no cache) → fetch → data shown + cached
- **Tab switch back**: cached data shown instantly → background refresh updates in-place  
- **Namespace change**: new cache key → spinner if uncached, instant if cached
- **Cluster switch/disconnect**: cache cleared, fresh load

Watch events (new/modified/deleted pods, etc.) continue to work exactly as before — the cache only affects the initial mount state.

## Test plan
- [ ] Navigate to Pods — first load shows spinner, then data
- [ ] Switch to another tab (e.g. Services), switch back to Pods — data appears instantly, no spinner
- [ ] Change namespace — if not cached, brief spinner; if cached, instant
- [ ] Disconnect cluster and reconnect — cache cleared, fresh load
- [ ] Verify watch events still work (create/delete a pod while viewing)