### PR TITLE
fix: fetch each namespace individually for multi-namespace selection

### DIFF
--- a/src/lib/hooks/k8s/__tests__/useK8sResource.test.ts
+++ b/src/lib/hooks/k8s/__tests__/useK8sResource.test.ts
@@ -83,8 +83,13 @@ describe("useK8sResource", () => {
         await flushPromises();
       });
 
+      // Watch restart is debounced by 300ms
+      await act(async () => {
+        jest.advanceTimersByTime(350);
+        await flushPromises();
+      });
+
       // The restart effect should have stopped the old watch
-      // (cleanup effect also calls stopWatch — harmless idempotent call)
       expect(mockStopWatch).toHaveBeenCalled();
 
       // Auto-watch should restart with the new namespace after delay
@@ -151,6 +156,12 @@ describe("useK8sResource", () => {
       // Switch to "All Namespaces" (empty string in store)
       await act(async () => {
         useClusterStore.setState({ selectedNamespaces: [], currentNamespace: "" });
+        await flushPromises();
+      });
+
+      // Watch restart is debounced by 300ms
+      await act(async () => {
+        jest.advanceTimersByTime(350);
         await flushPromises();
       });
 

--- a/src/lib/hooks/k8s/factory.ts
+++ b/src/lib/hooks/k8s/factory.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import type { ListOptions } from "../../types";
-import { useK8sResource, useClusterScopedResource, useOptionalNamespaceResource } from "./useK8sResource";
+import { useK8sResource } from "./useK8sResource";
+import { useClusterScopedResource } from "./useClusterScoped";
+import { useOptionalNamespaceResource } from "./useOptionalNamespace";
 import type { UseK8sResourcesOptions, UseK8sResourcesReturn, ResourceHookConfig } from "./types";
 
 /**

--- a/src/lib/hooks/k8s/index.ts
+++ b/src/lib/hooks/k8s/index.ts
@@ -23,8 +23,10 @@ export type { UseK8sResourcesOptions, UseK8sResourcesReturn, ResourceHookConfig 
 // Factory functions (for creating custom hooks)
 export { createNamespacedHook, createClusterScopedHook, createOptionalNamespaceHook, createListOptionsHook } from "./factory";
 
-// Core hook (for advanced use cases)
-export { useK8sResource, useClusterScopedResource, useOptionalNamespaceResource } from "./useK8sResource";
+// Core hooks (for advanced use cases)
+export { useK8sResource } from "./useK8sResource";
+export { useClusterScopedResource } from "./useClusterScoped";
+export { useOptionalNamespaceResource } from "./useOptionalNamespace";
 
 // All resource hooks
 export * from "./resources";

--- a/src/lib/hooks/k8s/useClusterScoped.ts
+++ b/src/lib/hooks/k8s/useClusterScoped.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useClusterStore } from "../../stores/cluster-store";
+import { useResourceCacheStore } from "../../stores/resource-cache-store";
+import type { UseK8sResourcesOptions, UseK8sResourcesReturn } from "./types";
+
+/**
+ * Simplified hook for cluster-scoped resources (no namespace).
+ * Used for Nodes, Namespaces, ClusterRoles, PVs, etc.
+ */
+export function useClusterScopedResource<T>(
+  displayName: string,
+  listFn: () => Promise<T[]>,
+  options: UseK8sResourcesOptions = {}
+): UseK8sResourcesReturn<T> {
+  const { isConnected } = useClusterStore();
+  const { getCache, setCache } = useResourceCacheStore();
+  const cacheKey = `${displayName}:`;
+
+  const [data, setData] = useState<T[]>(() => getCache<T>(cacheKey));
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!isConnected) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await listFn();
+      setData(result);
+      setCache(cacheKey, result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : `Failed to fetch ${displayName}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isConnected, listFn, displayName, cacheKey, setCache]);
+
+  useEffect(() => {
+    if (isConnected) {
+      refresh();
+    }
+  }, [isConnected, refresh]);
+
+  useEffect(() => {
+    if (!options.autoRefresh || !isConnected) return;
+    const interval = setInterval(refresh, options.refreshInterval || 30000);
+    return () => clearInterval(interval);
+  }, [options.autoRefresh, options.refreshInterval, isConnected, refresh]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refresh,
+    startWatch: async () => {},
+    stopWatchFn: async () => {},
+    isWatching: false,
+  };
+}

--- a/src/lib/hooks/k8s/useOptionalNamespace.ts
+++ b/src/lib/hooks/k8s/useOptionalNamespace.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useClusterStore } from "../../stores/cluster-store";
+import { useResourceCacheStore } from "../../stores/resource-cache-store";
+import { pSettledWithLimit, MAX_CONCURRENT_NS_REQUESTS } from "./utils";
+import type { UseK8sResourcesOptions, UseK8sResourcesReturn } from "./types";
+
+/**
+ * Hook for resources with optional namespace parameter (different signature).
+ * Some Tauri commands accept namespace as a direct parameter instead of ListOptions.
+ */
+export function useOptionalNamespaceResource<T>(
+  displayName: string,
+  listFn: (namespace?: string) => Promise<T[]>,
+  options: UseK8sResourcesOptions = {}
+): UseK8sResourcesReturn<T> {
+  const { isConnected, selectedNamespaces, namespaceSource, namespaces: configuredNamespaces } = useClusterStore();
+  const isMultiNs = !options.namespace && selectedNamespaces.length > 1;
+  const isConfiguredAllNs = namespaceSource === "configured" && !options.namespace && selectedNamespaces.length === 0;
+  const namespace = options.namespace ?? (selectedNamespaces.length === 1 ? selectedNamespaces[0] : "");
+  const { getCache, setCache } = useResourceCacheStore();
+  const cacheKey = `${displayName}:${options.namespace ?? (isConfiguredAllNs ? `configured:${configuredNamespaces.slice().sort().join(",")}` : isMultiNs ? selectedNamespaces.slice().sort().join(",") : namespace)}`;
+
+  const [data, setData] = useState<T[]>(() => getCache<T>(cacheKey));
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!isConnected) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      let result: T[];
+      if (isConfiguredAllNs && configuredNamespaces.length > 0) {
+        // Configured mode "All Namespaces": fetch each namespace individually
+        const outcomes = await pSettledWithLimit(
+          configuredNamespaces.map((ns) => () => listFn(ns)),
+          MAX_CONCURRENT_NS_REQUESTS
+        );
+        result = [];
+        const errors: string[] = [];
+        outcomes.forEach((outcome, i) => {
+          if (outcome.status === "fulfilled") {
+            result.push(...outcome.value);
+          } else {
+            errors.push(`${configuredNamespaces[i]}: ${outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason)}`);
+          }
+        });
+        if (errors.length > 0 && result.length === 0) {
+          throw new Error(`Failed to fetch ${displayName}: ${errors.join("; ")}`);
+        }
+      } else if (isMultiNs) {
+        // Multi-namespace: fetch each namespace individually to avoid
+        // 403 from Api::all() on RBAC-restricted clusters
+        const outcomes = await pSettledWithLimit(
+          selectedNamespaces.map((ns) => () => listFn(ns)),
+          MAX_CONCURRENT_NS_REQUESTS
+        );
+        result = [];
+        const errors: string[] = [];
+        outcomes.forEach((outcome, i) => {
+          if (outcome.status === "fulfilled") {
+            result.push(...outcome.value);
+          } else {
+            errors.push(`${selectedNamespaces[i]}: ${outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason)}`);
+          }
+        });
+        if (errors.length > 0 && result.length === 0) {
+          throw new Error(`Failed to fetch ${displayName}: ${errors.join("; ")}`);
+        }
+      } else {
+        result = await listFn(namespace || undefined);
+      }
+      setData(result);
+      setCache(cacheKey, result);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : `Failed to fetch ${displayName}`);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isConnected, namespace, isMultiNs, isConfiguredAllNs, configuredNamespaces, selectedNamespaces, listFn, displayName, cacheKey, setCache]);
+
+  // Reset data from cache when cache key changes (e.g. namespace switch)
+  useEffect(() => {
+    setData(getCache<T>(cacheKey));
+  }, [cacheKey, getCache]);
+
+  useEffect(() => {
+    if (isConnected) {
+      refresh();
+    }
+  }, [isConnected, refresh]);
+
+  useEffect(() => {
+    if (!options.autoRefresh || !isConnected) return;
+    const interval = setInterval(refresh, options.refreshInterval || 30000);
+    return () => clearInterval(interval);
+  }, [options.autoRefresh, options.refreshInterval, isConnected, refresh]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refresh,
+    startWatch: async () => {},
+    stopWatchFn: async () => {},
+    isWatching: false,
+  };
+}

--- a/src/lib/hooks/k8s/utils.ts
+++ b/src/lib/hooks/k8s/utils.ts
@@ -1,0 +1,34 @@
+/** Max concurrent per-namespace API requests */
+export const MAX_CONCURRENT_NS_REQUESTS = 5;
+
+/** Debounce delay for watch restart on namespace change (ms) */
+export const NAMESPACE_CHANGE_DEBOUNCE_MS = 300;
+
+/**
+ * Run async tasks with a concurrency limit, returning settled results.
+ * Preserves order: results[i] corresponds to tasks[i].
+ */
+export async function pSettledWithLimit<T>(
+  tasks: (() => Promise<T>)[],
+  limit: number
+): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex++;
+      try {
+        const value = await tasks[index]();
+        results[index] = { status: "fulfilled", value };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, tasks.length) }, () => worker())
+  );
+  return results;
+}


### PR DESCRIPTION
## Summary

Fixes "Failed to fetch pods" when selecting multiple configured namespaces on RBAC-restricted clusters.

- **Per-namespace fetching**: Instead of calling `Api::all()` (which returns 403 without cluster-wide permissions), each selected namespace is fetched individually via `Promise.allSettled`
- **Per-namespace watch**: Starts one watcher per namespace and merges events by uid for real-time updates across multiple namespaces
- **Concurrency limit**: Max 5 concurrent per-namespace API requests to protect the API server
- **300ms debounce**: Watch restart on namespace change is debounced to avoid rapid churn when clicking through namespaces
- **Race condition fixes**: Async listener teardown protection, concurrent startWatch guard, stale closure prevention via refs, unmount-only cleanup

Fixes #140 (follow-up from #151)

Reported by @pgebert in https://github.com/atilladeniz/Kubeli/issues/140#issuecomment-2843432960

## Test plan

- [x] Configure multiple accessible namespaces on an RBAC-restricted cluster
- [x] Select a single namespace -> pods load, watch active
- [x] Select multiple namespaces -> pods from all selected namespaces load, watch active per namespace
- [x] Select "All Namespaces" -> existing behavior unchanged
- [x] Switch namespaces rapidly -> no orphaned listeners or duplicate watches
- [x] Disconnect/reconnect -> watches cleaned up and restarted properly