### PR TITLE
fix(security): update quinn-proto to 0.11.14

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4107,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
- Updates `quinn-proto` from 0.11.13 to 0.11.14
- Fixes **RUSTSEC-2026-0037**: high severity (8.7) DoS vulnerability in Quinn endpoints

## Test plan
- [x] Cargo audit passes
- [x] CI green