### PR TITLE
fix(linux): disable WebKitGTK compositing to prevent EGL display crash

### DIFF
--- a/src-tauri/src/app/bootstrap.rs
+++ b/src-tauri/src/app/bootstrap.rs
@@ -12,8 +12,30 @@ pub struct Args {
 
 pub fn initialize() -> Args {
     install_macos_panic_hook();
+    configure_linux_webview();
     extend_path_with_common_cli_dirs();
     Args::parse()
+}
+
+/// Work around the WebKitGTK EGL crash on Linux systems where hardware
+/// compositing is unavailable (e.g. missing/incompatible GPU drivers, VMs,
+/// Wayland edge-cases). Setting `WEBKIT_DISABLE_COMPOSITING_MODE=1` tells
+/// WebKitGTK to fall back to software rendering instead of aborting with
+/// "Could not create default EGL display: EGL_BAD_PARAMETER".
+///
+/// We only set the variable when the user hasn't already provided it, so
+/// users with working GPU acceleration can opt back in via the environment.
+///
+/// See: https://github.com/nicbarker/clay/issues/224
+///      https://github.com/nicbarker/clay/pull/228
+fn configure_linux_webview() {
+    #[cfg(target_os = "linux")]
+    {
+        if env::var_os("WEBKIT_DISABLE_COMPOSITING_MODE").is_none() {
+            env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+            tracing::info!("Set WEBKIT_DISABLE_COMPOSITING_MODE=1 to prevent EGL display errors");
+        }
+    }
 }
 
 pub fn install_rustls_provider() {


### PR DESCRIPTION
## Summary

- Sets `WEBKIT_DISABLE_COMPOSITING_MODE=1` on Linux during bootstrap, before the WebView is created
- Prevents the `Could not create default EGL display: EGL_BAD_PARAMETER` abort on systems where hardware-accelerated EGL is unavailable (incompatible GPU drivers, VMs, certain Wayland setups)
- Only sets the env var when the user hasn't already provided it — users with working GPU compositing can override by exporting `WEBKIT_DISABLE_COMPOSITING_MODE=0`

## Root Cause

WebKitGTK attempts to create a hardware-accelerated EGL display on startup. On systems without compatible GPU drivers (e.g. Manjaro with certain GPU configs, VMs, some Wayland setups), this fails with `EGL_BAD_PARAMETER` and the process aborts — resulting in an empty/invisible window.

This is a known upstream WebKitGTK bug (WebKit Bug [#297921](https://bugs.webkit.org/show_bug.cgi?id=297921), [#302796](https://bugs.webkit.org/show_bug.cgi?id=302796)) affecting versions 2.48.x–2.51.x with no upstream fix available.

## Approach

`WEBKIT_DISABLE_COMPOSITING_MODE=1` is the [recommended workaround by Tauri maintainers](https://github.com/tauri-apps/tauri/issues/14424) and is used by 20+ production Tauri apps (museeks, kanri, elasticvue, etc.). Related Tauri issues: [#5143](https://github.com/tauri-apps/tauri/issues/5143), [#9394](https://github.com/tauri-apps/tauri/issues/9394).

**Trade-off:** Disables GPU compositing on Linux → CSS animations run in software. For a desktop app like Kubeli, the performance impact is negligible.

## Test plan

- [ ] Verify Linux AppImage launches correctly on systems that previously showed the EGL error
- [ ] Verify Linux build still works with GPU acceleration when `WEBKIT_DISABLE_COMPOSITING_MODE=0` is exported
- [ ] Verify no impact on macOS/Windows builds (function is `#[cfg(target_os = "linux")]` gated)

Closes #201