### PR TITLE
fix(ci): remove production environment gate from landing page deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-web]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment: production
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
Closes #245

Removes `environment: production` from the CI landing page deploy job so it no longer blocks on manual approval after every push to main.

Deploy still only triggers when `web/` files change on push to main.