### PR TITLE
fix: add Cmd+S / Ctrl+S save shortcut to YAML editor

### DIFF
--- a/src/components/features/resources/components/YamlTab.tsx
+++ b/src/components/features/resources/components/YamlTab.tsx
@@ -189,6 +189,27 @@ export const YamlTab = forwardRef<YamlTabHandle, YamlTabProps>(function YamlTab(
     }
   };
 
+  // Cmd/Ctrl+S saves when in edit mode
+  const handleSaveRef = useRef(handleSave);
+  const hasChangesRef = useRef(hasChanges);
+  useEffect(() => {
+    handleSaveRef.current = handleSave;
+    hasChangesRef.current = hasChanges;
+  });
+
+  useEffect(() => {
+    if (!isEditing || !editorRef.current || !monacoRef.current) return;
+    const disposable = editorRef.current.addAction({
+      id: "kubeli-save",
+      label: "Save",
+      keybindings: [monacoRef.current.KeyMod.CtrlCmd | monacoRef.current.KeyCode.KeyS],
+      run: () => {
+        if (hasChangesRef.current) handleSaveRef.current();
+      },
+    });
+    return () => disposable.dispose();
+  }, [isEditing]);  
+
   // ESC exits edit mode when the Monaco find widget is not open
   useEffect(() => {
     if (!isEditing || !editorRef.current) return;


### PR DESCRIPTION
Closes #254

Registers a Monaco `addAction` for Cmd+S (macOS) / Ctrl+S (Windows/Linux) in the YAML editor that triggers save when in edit mode with unsaved changes. Uses the same pattern as `CreateResourcePanel`.

## Test plan
- [x] TypeScript check passes
- [x] ESLint passes
- [x] Build passes
- [x] Manual: Open resource → Edit YAML → Cmd+S saves changes
- [x] Manual: Cmd+S does nothing when no changes are made