### PR TITLE
ci: add Tauri version sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,22 @@ jobs:
           done
           echo "Landing page deployed to production"
 
+  tauri-versions:
+    name: Tauri Version Sync
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.app == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Check tauri crate vs @tauri-apps/api versions
+        run: node scripts/check-tauri-versions.mjs
+
   lint-frontend:
     name: Frontend Lint & Type Check
     needs: [detect-changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,6 @@ jobs:
 
   tauri-versions:
     name: Tauri Version Sync
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/scripts/check-tauri-versions.mjs
+++ b/scripts/check-tauri-versions.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Verify that the Rust `tauri` crate and the npm `@tauri-apps/api` package
+// share the same major.minor version. `tauri-apps/tauri-action` enforces this
+// during the release build; we mirror the check earlier so it fails on PRs
+// instead of after a tag has been pushed.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function majorMinor(version) {
+  const [major, minor] = version.split('.');
+  return `${major}.${minor}`;
+}
+
+function readNpmApiVersion() {
+  const lock = JSON.parse(
+    readFileSync(resolve(repoRoot, 'package-lock.json'), 'utf8'),
+  );
+  const entry = lock.packages?.['node_modules/@tauri-apps/api'];
+  if (!entry?.version) {
+    throw new Error('@tauri-apps/api not found in package-lock.json');
+  }
+  return entry.version;
+}
+
+function readRustTauriVersion() {
+  const lock = readFileSync(resolve(repoRoot, 'src-tauri/Cargo.lock'), 'utf8');
+  // Cargo.lock entries look like:
+  //   [[package]]
+  //   name = "tauri"
+  //   version = "2.11.0"
+  const match = lock.match(/\[\[package\]\]\s*\nname = "tauri"\s*\nversion = "([^"]+)"/);
+  if (!match) {
+    throw new Error('tauri crate not found in src-tauri/Cargo.lock');
+  }
+  return match[1];
+}
+
+const apiVersion = readNpmApiVersion();
+const crateVersion = readRustTauriVersion();
+
+const apiMm = majorMinor(apiVersion);
+const crateMm = majorMinor(crateVersion);
+
+if (apiMm !== crateMm) {
+  console.error('Tauri version mismatch:');
+  console.error(`  Rust crate     tauri            ${crateVersion}  (${crateMm})`);
+  console.error(`  npm package    @tauri-apps/api  ${apiVersion}  (${apiMm})`);
+  console.error('');
+  console.error('tauri-action requires both to share major.minor.');
+  console.error('Bump @tauri-apps/api (and usually @tauri-apps/cli) so they match the Rust crate, e.g.:');
+  console.error(`  npm install @tauri-apps/api@^${crateMm}.0 @tauri-apps/cli@^${crateMm}.0`);
+  process.exit(1);
+}
+
+console.log(`OK: tauri ${crateVersion} matches @tauri-apps/api ${apiVersion} (${apiMm})`);


### PR DESCRIPTION
## Summary

- New `scripts/check-tauri-versions.mjs` reads the Rust `tauri` crate version from `src-tauri/Cargo.lock` and the `@tauri-apps/api` version from `package-lock.json`, and fails if their major.minor differ.
- New `tauri-versions` CI job runs the script on every PR and push to `main`, gated by the existing `app` paths filter.

## Why

`tauri-apps/tauri-action` enforces this rule during the release build. The mismatch in v0.3.73 (Rust `tauri` 2.11.0 vs npm `@tauri-apps/api` 2.10.1) only surfaced *after* the tag was pushed and a draft release had been created. This job catches the same condition on PR.

Closes #302.

## Test plan

- [x] Script passes on current `main` (`tauri 2.11.0` vs `@tauri-apps/api 2.11.0`).
- [x] Script reproduces the v0.3.73 failure when `package-lock.json` is rolled back to commit `b529fdb` (`@tauri-apps/api 2.10.1` vs Rust `tauri 2.11.0`) — exits 1 with a clear message.
- [ ] CI run on this PR shows the `Tauri Version Sync` job green.