### PR TITLE
chore(ci): ignore eslint in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
       - "npm"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # eslint updates handled manually (v10 flat-config migration)
+      - dependency-name: "eslint"
 
   # Rust/Cargo dependencies
   - package-ecosystem: "cargo"


### PR DESCRIPTION
Disables eslint updates in dependabot. eslint v10 is a major bump (flat-config breaking changes) and the related plugins (eslint-plugin-react-hooks@7, typescript-eslint@8) need manual validation. Closes #320 by superseding it.

Migrations to eslint v10 will be handled manually.