### PR TITLE
fix(oidc): add "use kubeconfig auth only" option for exec-based clusters (#335)

### DIFF
--- a/.dev/oidc/README.md
+++ b/.dev/oidc/README.md
@@ -20,6 +20,8 @@ make oidc-dev-stop   # tear it all down
 5. Repoints the profile's own `kubeli-oidc` context at an OIDC sign-in user, so
    Kubeli shows a single cluster that connects via OIDC (not the extra cert
    admin context that `minikube start` creates).
+6. Best-effort installs `kubelogin` (`kubectl oidc-login`) so the kubeconfig
+   exec-provider path is testable too (see "Testing the exec fallback" below).
 
 Then:
 
@@ -33,6 +35,22 @@ returns the token and the connect goes green.
 
 > Need the cert admin back (e.g. if OIDC breaks)? `minikube update-context -p
 > kubeli-oidc` restores the certificate-based `kubeli-oidc` context.
+
+## Testing the exec fallback (#335)
+
+Native OIDC is the default. The same `kubeli-oidc` context also declares a
+`kubectl oidc-login` exec provider, so you can test Kubeli running the
+kubeconfig's own auth instead:
+
+- **Manual:** open the cluster's settings (gear icon) → enable **"Use kubeconfig
+  auth only"** → connect. kube-rs runs `kubectl oidc-login` (needs `kubelogin`,
+  which `make oidc-dev` installs for you).
+- **Automatic:** when native OIDC can't reach the issuer (e.g. `docker stop
+  kubeli-dex`, or a TLS/private-CA error), the connect quietly falls back to the
+  exec provider instead of erroring out.
+
+If `kubelogin` couldn't be auto-installed: `brew install int128/kubelogin/kubelogin`
+(or `kubectl krew install oidc-login`).
 
 ## Why it needs a build (the kubeli:// callback)
 
@@ -56,4 +74,5 @@ the generated dev CA:
 ## Requirements
 
 `docker`, `minikube`, `kubectl`, `openssl`, and `sudo` for the one `/etc/hosts`
-line. Dev only — none of this is for production.
+line. `kubelogin` is auto-installed via Homebrew (best-effort) for the exec
+fallback test. Dev only — none of this is for production.

--- a/scripts/oidc-dev.sh
+++ b/scripts/oidc-dev.sh
@@ -31,9 +31,12 @@ ISSUER="https://${ISSUER_HOST}:${DEX_PORT}/dex"
 DISCOVERY="${ISSUER}/.well-known/openid-configuration"
 
 PROFILE="kubeli-oidc"
+EXEC_CONTEXT="kubeli-oidc-exec"
 LOGIN_USER="kubeli-oidc-login"
 OIDC_EMAIL="dev@kubeli.test"
 CLIENT_ID="kubeli"
+# Kubeli's per-cluster settings store (macOS dev build, identifier com.kubeli).
+KUBELI_SETTINGS="$HOME/Library/Application Support/com.kubeli/cluster-settings.json"
 NODE_CA_PATH="/var/lib/minikube/certs/oidc-dex-ca.crt"
 MINIKUBE_FILES_CA="$HOME/.minikube/files${NODE_CA_PATH}"
 KUBECONFIG_FILE="${KUBECONFIG:-$HOME/.kube/config}"
@@ -45,6 +48,32 @@ log_warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
 require() { command -v "$1" >/dev/null 2>&1 || { log_error "$1 is required but not installed."; exit 1; }; }
+
+KUBELOGIN_FORMULA="int128/kubelogin/kubelogin"
+
+# kubelogin (the `kubectl oidc-login` plugin) is NOT needed for Kubeli's native
+# OIDC flow, but it IS the exec provider the kubeconfig declares. Installing it
+# lets you test the #335 path: "Use kubeconfig auth only" and the automatic
+# fallback when native OIDC can't reach the issuer both run `kubectl oidc-login`.
+# Best-effort: a missing kubelogin only blocks the exec-fallback test, not the
+# native flow, so we warn instead of aborting.
+ensure_kubelogin() {
+  if command -v kubelogin >/dev/null 2>&1 || command -v kubectl-oidc_login >/dev/null 2>&1; then
+    log_info "kubelogin present — exec-provider fallback (#335) is testable."
+    return
+  fi
+  log_warn "kubelogin (kubectl oidc-login) not installed — needed only to test the kubeconfig exec fallback (#335)."
+  if command -v brew >/dev/null 2>&1; then
+    log_info "Installing kubelogin via Homebrew ($KUBELOGIN_FORMULA)..."
+    if brew install "$KUBELOGIN_FORMULA" >/dev/null 2>&1; then
+      log_success "kubelogin installed."
+    else
+      log_warn "Auto-install failed. Install manually: brew install $KUBELOGIN_FORMULA"
+    fi
+  else
+    log_warn "Install manually: brew install $KUBELOGIN_FORMULA   (or: kubectl krew install oidc-login)"
+  fi
+}
 
 gen_certs() {
   if [ -f "$CERT_DIR/dex.crt" ] && [ -f "$CERT_DIR/ca.crt" ]; then
@@ -169,7 +198,36 @@ context_up() {
     --exec-arg="--certificate-authority=${CERT_DIR}/ca.crt" >/dev/null
   kubectl --kubeconfig "$KUBECONFIG_FILE" config set-context "$PROFILE" \
     --cluster="$PROFILE" --user="$LOGIN_USER" >/dev/null
-  log_success "Context '$PROFILE' now signs in via OIDC (single cluster in Kubeli)"
+
+  # Second context onto the SAME cluster + exec user. Native OIDC vs the exec
+  # provider is a Kubeli per-cluster setting, not a kubeconfig difference — so we
+  # expose two cards: '$PROFILE' (native OIDC, default) and '$EXEC_CONTEXT'
+  # (kubeconfig exec login, flag seeded below). Lets you test both #335 paths
+  # side by side without toggling.
+  kubectl --kubeconfig "$KUBECONFIG_FILE" config set-context "$EXEC_CONTEXT" \
+    --cluster="$PROFILE" --user="$LOGIN_USER" >/dev/null
+  log_success "Contexts '$PROFILE' (native OIDC) and '$EXEC_CONTEXT' (kubeconfig exec) ready"
+}
+
+# Pre-enable "use kubeconfig auth only" for EXEC_CONTEXT so its card runs the
+# exec provider out of the box, while PROFILE stays on native OIDC. Best-effort:
+# the store is macOS/dev-build specific and Kubeli reads it at startup.
+seed_kubeli_settings() {
+  [ "$(uname)" = "Darwin" ] || return 0
+  if ! command -v jq >/dev/null 2>&1; then
+    log_warn "jq not found; skipping cluster-settings seed for '$EXEC_CONTEXT'."
+    return 0
+  fi
+  mkdir -p "$(dirname "$KUBELI_SETTINGS")"
+  local current='{}'
+  [ -f "$KUBELI_SETTINGS" ] && current="$(cat "$KUBELI_SETTINGS")"
+  if ! printf '%s' "$current" | jq empty >/dev/null 2>&1; then
+    current='{}'  # tolerate an empty/corrupt file
+  fi
+  printf '%s' "$current" | jq --arg ctx "$EXEC_CONTEXT" \
+    '.[$ctx] = {accessible_namespaces: [], prefer_kubeconfig_auth: true}' \
+    > "$KUBELI_SETTINGS"
+  log_success "Seeded '$EXEC_CONTEXT' with prefer_kubeconfig_auth=true (restart Kubeli to apply)."
 }
 
 print_next_steps() {
@@ -179,13 +237,23 @@ $(echo -e "${GREEN}Local OIDC stack ready.${NC}")
 
   Issuer  : $ISSUER   (client: $CLIENT_ID)
   Login    : $OIDC_EMAIL  /  password
-  Context  : $PROFILE   (signs in via OIDC)
+  Cluster cards in Kubeli (both hit the same minikube + Dex):
+    * $PROFILE        native OIDC browser flow (Kubeli's built-in)
+    * $EXEC_CONTEXT   kubeconfig exec login (kubectl oidc-login), flag pre-set
 
 Next:
   1. Build & open the app so the kubeli:// scheme is registered:
        make build && open src-tauri/target/release/bundle/macos/Kubeli.app
   2. In Kubeli, connect to "$PROFILE".
   3. Browser opens Dex (accept the dev cert warning) -> log in -> connect goes green.
+
+Testing the kubeconfig exec path (#335):
+  * Connect to "$EXEC_CONTEXT": its "Use kubeconfig auth only" flag is already
+    seeded, so kube-rs runs '$LOGIN_USER' -> kubectl oidc-login directly (needs
+    kubelogin). Restart Kubeli once after this script so it picks up the setting.
+  * Automatic fallback: on "$PROFILE", when native OIDC can't reach the issuer
+    (e.g. 'docker stop kubeli-dex'), the connect quietly switches to the exec
+    provider instead of erroring.
 
 Tear down with:  make oidc-dev-stop
 EOF
@@ -198,9 +266,18 @@ down() {
   fi
   if command -v kubectl >/dev/null 2>&1; then
     # minikube delete removes the kubeli-oidc context/cluster; drop the orphan
-    # OIDC user it leaves behind.
+    # OIDC user and the second exec context it leaves behind.
     kubectl --kubeconfig "$KUBECONFIG_FILE" config unset "users.${LOGIN_USER}" >/dev/null 2>&1 \
       && log_success "Removed OIDC user '$LOGIN_USER'." || true
+    kubectl --kubeconfig "$KUBECONFIG_FILE" config delete-context "$EXEC_CONTEXT" >/dev/null 2>&1 \
+      && log_success "Removed context '$EXEC_CONTEXT'." || true
+  fi
+  # Drop the seeded Kubeli setting for the exec context.
+  if [ -f "$KUBELI_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+    if tmp="$(jq --arg ctx "$EXEC_CONTEXT" 'del(.[$ctx])' "$KUBELI_SETTINGS" 2>/dev/null)"; then
+      printf '%s' "$tmp" > "$KUBELI_SETTINGS"
+      log_success "Removed seeded setting for '$EXEC_CONTEXT'."
+    fi
   fi
   rm -f "$MINIKUBE_FILES_CA"
   log_info "Left the /etc/hosts entry and .dev/oidc/certs/ in place (remove manually if desired)."
@@ -214,6 +291,8 @@ case "${1:-up}" in
     dex_up
     cluster_up
     context_up
+    seed_kubeli_settings
+    ensure_kubelogin
     print_next_steps
     ;;
   down) down ;;

--- a/src-tauri/src/app/command_registry/mod.rs
+++ b/src-tauri/src/app/command_registry/mod.rs
@@ -16,6 +16,7 @@ pub fn handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Syn
         crate::commands::clusters::has_kubeconfig,
         crate::commands::cluster_settings::get_cluster_settings,
         crate::commands::cluster_settings::set_cluster_accessible_namespaces,
+        crate::commands::cluster_settings::set_cluster_prefer_kubeconfig_auth,
         crate::commands::cluster_settings::clear_cluster_settings,
         crate::commands::kubeconfig::get_kubeconfig_sources,
         crate::commands::kubeconfig::set_kubeconfig_sources,

--- a/src-tauri/src/commands/cluster_settings.rs
+++ b/src-tauri/src/commands/cluster_settings.rs
@@ -6,6 +6,19 @@ use tauri_plugin_store::StoreExt;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ClusterSettings {
     pub accessible_namespaces: Vec<String>,
+    /// Skip Kubeli's native OIDC flow and let kube-rs run the kubeconfig's
+    /// auth as-is (e.g. an `exec` provider like `kubectl oidc-login`,
+    /// kubelogin, or Pinniped). Lets enterprise exec-based auth work even when
+    /// the native browser flow can't complete (see issue #335).
+    #[serde(default)]
+    pub prefer_kubeconfig_auth: bool,
+}
+
+impl ClusterSettings {
+    /// Whether the settings carry any non-default value worth persisting.
+    fn is_meaningful(&self) -> bool {
+        !self.accessible_namespaces.is_empty() || self.prefer_kubeconfig_auth
+    }
 }
 
 /// Get cluster settings for a specific context
@@ -22,14 +35,46 @@ pub async fn get_cluster_settings(
         Some(value) => {
             let settings: ClusterSettings = serde_json::from_value(value.clone())
                 .map_err(|e| format!("Failed to parse cluster settings: {}", e))?;
-            if settings.accessible_namespaces.is_empty() {
-                Ok(None)
-            } else {
+            if settings.is_meaningful() {
                 Ok(Some(settings))
+            } else {
+                Ok(None)
             }
         }
         None => Ok(None),
     }
+}
+
+/// Read the current settings for a context, falling back to defaults so other
+/// fields are preserved across partial updates.
+fn current_settings(
+    store: &tauri_plugin_store::Store<tauri::Wry>,
+    context: &str,
+) -> ClusterSettings {
+    store
+        .get(context)
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default()
+}
+
+fn persist_settings(
+    store: &tauri_plugin_store::Store<tauri::Wry>,
+    context: &str,
+    settings: &ClusterSettings,
+) -> Result<(), String> {
+    if settings.is_meaningful() {
+        store.set(
+            context,
+            serde_json::to_value(settings)
+                .map_err(|e| format!("Failed to serialize cluster settings: {}", e))?,
+        );
+    } else {
+        // Nothing worth keeping — drop the entry so it reverts to auto-discovery.
+        store.delete(context);
+    }
+    store
+        .save()
+        .map_err(|e| format!("Failed to save cluster settings: {}", e))
 }
 
 /// Set accessible namespaces for a specific context
@@ -43,24 +88,38 @@ pub async fn set_cluster_accessible_namespaces(
         .store("cluster-settings.json")
         .map_err(|e| format!("Failed to open cluster settings store: {}", e))?;
 
-    let settings = ClusterSettings {
-        accessible_namespaces: namespaces,
-    };
-
-    store.set(
-        &context,
-        serde_json::to_value(&settings)
-            .map_err(|e| format!("Failed to serialize cluster settings: {}", e))?,
-    );
-
-    store
-        .save()
-        .map_err(|e| format!("Failed to save cluster settings: {}", e))?;
+    let mut settings = current_settings(&store, &context);
+    settings.accessible_namespaces = namespaces;
+    persist_settings(&store, &context, &settings)?;
 
     tracing::info!(
         "Saved accessible namespaces for context '{}': {:?}",
         context,
         settings.accessible_namespaces
+    );
+
+    Ok(())
+}
+
+/// Toggle "use kubeconfig authentication only" for a specific context.
+#[command]
+pub async fn set_cluster_prefer_kubeconfig_auth(
+    app: AppHandle,
+    context: String,
+    prefer: bool,
+) -> Result<(), String> {
+    let store = app
+        .store("cluster-settings.json")
+        .map_err(|e| format!("Failed to open cluster settings store: {}", e))?;
+
+    let mut settings = current_settings(&store, &context);
+    settings.prefer_kubeconfig_auth = prefer;
+    persist_settings(&store, &context, &settings)?;
+
+    tracing::info!(
+        "Set prefer_kubeconfig_auth={} for context '{}'",
+        prefer,
+        context
     );
 
     Ok(())
@@ -82,4 +141,43 @@ pub async fn clear_cluster_settings(app: AppHandle, context: String) -> Result<(
     tracing::info!("Cleared cluster settings for context '{}'", context);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_settings_default_prefer_flag_to_false() {
+        // Settings written before the flag existed must still deserialize.
+        let settings: ClusterSettings =
+            serde_json::from_str(r#"{"accessible_namespaces":["team-a"]}"#).unwrap();
+        assert!(!settings.prefer_kubeconfig_auth);
+        assert_eq!(settings.accessible_namespaces, vec!["team-a"]);
+    }
+
+    #[test]
+    fn prefer_flag_alone_is_meaningful() {
+        // A context with only the auth flag set must be persisted/returned,
+        // even though it has no configured namespaces (issue #335).
+        let settings = ClusterSettings {
+            accessible_namespaces: vec![],
+            prefer_kubeconfig_auth: true,
+        };
+        assert!(settings.is_meaningful());
+
+        assert!(!ClusterSettings::default().is_meaningful());
+    }
+
+    #[test]
+    fn prefer_flag_round_trips_through_json() {
+        let settings = ClusterSettings {
+            accessible_namespaces: vec!["ns".into()],
+            prefer_kubeconfig_auth: true,
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: ClusterSettings = serde_json::from_str(&json).unwrap();
+        assert!(parsed.prefer_kubeconfig_auth);
+        assert_eq!(parsed.accessible_namespaces, vec!["ns"]);
+    }
 }

--- a/src-tauri/src/commands/clusters/commands.rs
+++ b/src-tauri/src/commands/clusters/commands.rs
@@ -3,7 +3,7 @@
 use crate::error::KubeliError;
 use crate::k8s::{AppState, AuthType, KubeConfig};
 use crate::oidc::commands::OidcState;
-use crate::oidc::config::detect_oidc_exec;
+use crate::oidc::config::{detect_oidc_exec, exec_provider_runnable};
 use crate::oidc::flow::RefreshError;
 use kube::config::Kubeconfig;
 use kube::Client;
@@ -13,7 +13,7 @@ use tokio::sync::RwLock;
 
 use super::kubeconfig::{
     build_kubeconfig_for_connect, is_self_contained, load_configured_namespaces,
-    load_kubeconfig_from_sources,
+    load_kubeconfig_from_sources, load_prefer_kubeconfig_auth,
 };
 use super::types::{
     ClusterInfo, ConnectionStatus, HealthCheckResult, NamespaceResult, OidcAuthInfo,
@@ -189,8 +189,41 @@ pub async fn connect_cluster(
 
     let mut active_oidc: Option<crate::oidc::config::OidcExecConfig> = None;
 
+    // Decide between two OIDC paths for an exec-based kubeconfig:
+    //
+    //   1. Let kube-rs run the kubeconfig's exec provider (kubectl oidc-login /
+    //      kubelogin / Pinniped). This is the standard, best-practice behaviour
+    //      (the same one Headlamp and Lens use) and is what makes issue #335
+    //      work: the user's kubeconfig already authenticates with kubectl.
+    //   2. Kubeli's native browser flow (Authorization Code + PKCE), which needs
+    //      no plugin binary but cannot complete in some environments (#335).
+    //
+    // Prefer (1) whenever the plugin binary is actually installed, and fall back
+    // to (2) only when it is missing — that keeps the no-binary comfort added in
+    // e079d70 while no longer overriding a working exec setup. A per-cluster
+    // "use kubeconfig auth only" flag forces (1) regardless of detection.
+    let prefer_kubeconfig_auth = load_prefer_kubeconfig_auth(&app, &context);
+    if prefer_kubeconfig_auth {
+        tracing::info!(
+            "Context '{}' set to use kubeconfig auth only; skipping native OIDC",
+            context
+        );
+    }
+
     if let Some(ref user) = user_name {
-        if let Some(oidc_config) = detect_oidc_exec(&kubeconfig, user) {
+        if let Some(oidc_config) = detect_oidc_exec(&kubeconfig, user).filter(|cfg| {
+            // Use native OIDC only when the user hasn't forced exec auth AND the
+            // exec provider isn't runnable; otherwise let kube-rs run exec.
+            let run_exec = prefer_kubeconfig_auth || exec_provider_runnable(cfg);
+            if run_exec {
+                tracing::info!(
+                    "Context '{}' uses exec plugin '{}'; letting kube-rs run it (skipping native OIDC)",
+                    context,
+                    cfg.command
+                );
+            }
+            !run_exec
+        }) {
             let oidc_state: State<'_, Arc<OidcState>> = app.state();
 
             // Remember the CA/TLS settings so the interactive browser flow

--- a/src-tauri/src/commands/clusters/kubeconfig.rs
+++ b/src-tauri/src/commands/clusters/kubeconfig.rs
@@ -140,6 +140,22 @@ pub(super) fn load_configured_namespaces(app: &AppHandle, context: &str) -> Vec<
     }
 }
 
+/// Whether the user asked to skip Kubeli's native OIDC flow for this context
+/// and rely solely on the kubeconfig's own auth (e.g. an exec provider). See #335.
+pub(super) fn load_prefer_kubeconfig_auth(app: &AppHandle, context: &str) -> bool {
+    let store = match app.store("cluster-settings.json") {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    match store.get(context) {
+        Some(value) => serde_json::from_value::<ClusterSettings>(value.clone())
+            .map(|s| s.prefer_kubeconfig_auth)
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
 #[cfg(test)]
 #[path = "kubeconfig_tests.rs"]
 mod tests;

--- a/src-tauri/src/oidc/config.rs
+++ b/src-tauri/src/oidc/config.rs
@@ -2,6 +2,16 @@ use kube::config::Kubeconfig;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OidcExecConfig {
+    /// The exec plugin binary (kubeconfig `exec.command`, e.g. `kubectl` or
+    /// `kubelogin`). Used to decide whether the plugin is installed so we can
+    /// let kube-rs run it instead of Kubeli's native flow (issue #335).
+    pub command: String,
+    /// The actual krew plugin binary backing `kubectl oidc-login`
+    /// (`kubectl-oidc_login`), when the command is `kubectl` invoking the
+    /// `oidc-login` subcommand. `kubectl` existing does not mean its plugin is
+    /// installed, so this must be checked separately. `None` when `command` is
+    /// already the standalone binary.
+    pub plugin_binary: Option<String>,
     pub issuer_url: String,
     pub client_id: String,
     pub extra_scopes: Vec<String>,
@@ -37,13 +47,119 @@ pub fn detect_oidc_exec(kubeconfig: &Kubeconfig, user_name: &str) -> Option<Oidc
     let certificate_authority_data = extract_first_flag_value(args, "--certificate-authority-data");
     let insecure_skip_tls_verify = is_flag_set(args, "--insecure-skip-tls-verify");
 
+    let command = exec.command.clone().unwrap_or_default();
+
+    // `kubectl oidc-login ...` runs the krew plugin `kubectl-oidc_login`. The
+    // `kubectl` binary being present says nothing about whether that plugin is
+    // installed, so track the plugin binary to check it directly.
+    let plugin_binary =
+        if command_basename_is_kubectl(&command) && args.iter().any(|a| a == "oidc-login") {
+            Some("kubectl-oidc_login".to_string())
+        } else {
+            None
+        };
+
     Some(OidcExecConfig {
+        command,
+        plugin_binary,
         issuer_url,
         client_id,
         extra_scopes,
         certificate_authority,
         certificate_authority_data,
         insecure_skip_tls_verify,
+    })
+}
+
+/// Whether the kubeconfig's exec OIDC provider can actually run on this machine.
+///
+/// Best practice (as in Headlamp/Lens) is to let the exec plugin drive OIDC
+/// login when it is installed, and only fall back to Kubeli's native browser
+/// flow when it isn't. The PATH we scan is the same one kube-rs would use to
+/// spawn the plugin, so this answers exactly "could the exec provider run?" —
+/// including the GUI-app case where the launcher gives a stripped PATH (then
+/// exec couldn't run either, and native is correct).
+///
+/// For `kubectl oidc-login`, both `kubectl` and its krew plugin
+/// (`kubectl-oidc_login`) must be present — `kubectl` alone is not enough.
+pub fn exec_provider_runnable(config: &OidcExecConfig) -> bool {
+    exec_binary_available(&config.command)
+        && config
+            .plugin_binary
+            .as_deref()
+            .is_none_or(exec_binary_available)
+}
+
+/// Whether `command`'s basename is `kubectl` (handles absolute/relative paths
+/// and the Windows `.exe` suffix; matched case-insensitively for Windows).
+fn command_basename_is_kubectl(command: &str) -> bool {
+    std::path::Path::new(command)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|name| {
+            name.eq_ignore_ascii_case("kubectl") || name.eq_ignore_ascii_case("kubectl.exe")
+        })
+        .unwrap_or(false)
+}
+
+/// Whether `path` is a regular file Kubeli could actually execute. On Unix the
+/// executable bit must be set — a readable-but-not-executable file on PATH would
+/// otherwise be mistaken for a runnable plugin, skip the native fallback, and
+/// make kube-rs fail later with "permission denied".
+fn is_executable_file(path: &std::path::Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        match path.metadata() {
+            Ok(meta) => meta.is_file() && meta.permissions().mode() & 0o111 != 0,
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
+/// Whether a single command resolves to an executable on PATH.
+pub fn exec_binary_available(command: &str) -> bool {
+    if command.is_empty() {
+        return false;
+    }
+
+    // An explicit path is checked directly, not searched on PATH. Treat both
+    // separators as a path component so a relative `bin/kubectl` isn't PATH-
+    // searched on Windows (where MAIN_SEPARATOR is only `\\`).
+    let as_path = std::path::Path::new(command);
+    if as_path.is_absolute() || command.contains('/') || command.contains('\\') {
+        return is_executable_file(as_path);
+    }
+
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return false;
+    };
+
+    std::env::split_paths(&path_var).any(|dir| {
+        // Always try the command exactly as written first (e.g. `kubectl.exe`).
+        if is_executable_file(&dir.join(command)) {
+            return true;
+        }
+
+        // On Windows a bare name like `kubectl` is resolved via PATHEXT. Only
+        // append extensions when the command doesn't already carry one, so we
+        // never search for `kubectl.exe.EXE`.
+        #[cfg(windows)]
+        if as_path.extension().is_none() {
+            let pathext =
+                std::env::var("PATHEXT").unwrap_or_else(|_| ".EXE;.CMD;.BAT;.COM".to_string());
+            for ext in pathext.split(';').filter(|e| !e.is_empty()) {
+                if is_executable_file(&dir.join(format!("{command}{ext}"))) {
+                    return true;
+                }
+            }
+        }
+
+        false
     })
 }
 
@@ -129,6 +245,189 @@ users:
         assert_eq!(detected.issuer_url, "https://issuer.example.com");
         assert_eq!(detected.client_id, "desktop-client");
         assert_eq!(detected.extra_scopes, vec!["email", "profile"]);
+    }
+
+    #[test]
+    fn prefer_kubeconfig_auth_bypasses_native_oidc() {
+        // connect_cluster gates native OIDC with
+        // `detect_oidc_exec(..).filter(|_| !prefer_kubeconfig_auth)`. When the
+        // user opts into kubeconfig-only auth, detection must yield None so
+        // kube-rs runs the exec provider as-is (issue #335).
+        let kubeconfig = kubeconfig_from_yaml(
+            r#"
+apiVersion: v1
+kind: Config
+users:
+  - name: oidc-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1
+        command: kubectl
+        args:
+          - oidc-login
+          - get-token
+          - --oidc-issuer-url=https://issuer.example.com
+          - --oidc-client-id=desktop-client
+"#,
+        );
+
+        // Without the opt-out, OIDC is detected (native flow would run).
+        assert!(detect_oidc_exec(&kubeconfig, "oidc-user").is_some());
+
+        // With the opt-out, the same detection is suppressed.
+        let prefer_kubeconfig_auth = true;
+        let active = detect_oidc_exec(&kubeconfig, "oidc-user").filter(|_| !prefer_kubeconfig_auth);
+        assert!(active.is_none());
+    }
+
+    #[test]
+    fn captures_exec_command_for_binary_detection() {
+        let kubeconfig = kubeconfig_from_yaml(
+            r#"
+apiVersion: v1
+kind: Config
+users:
+  - name: oidc-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: kubelogin
+        args:
+          - oidc-login
+          - get-token
+          - --oidc-issuer-url=https://issuer.example.com
+          - --oidc-client-id=desktop-client
+"#,
+        );
+
+        let detected = detect_oidc_exec(&kubeconfig, "oidc-user").expect("oidc should be detected");
+        assert_eq!(detected.command, "kubelogin");
+        // A standalone binary has no separate krew plugin to check.
+        assert_eq!(detected.plugin_binary, None);
+    }
+
+    #[test]
+    fn kubectl_oidc_login_tracks_krew_plugin_binary() {
+        // `kubectl oidc-login` runs the krew plugin `kubectl-oidc_login`. The
+        // `kubectl` binary existing is not enough — the plugin must be present
+        // too, otherwise kube-rs runs into an exec error (review finding).
+        let kubeconfig = kubeconfig_from_yaml(
+            r#"
+apiVersion: v1
+kind: Config
+users:
+  - name: oidc-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: /usr/local/bin/kubectl
+        args:
+          - oidc-login
+          - get-token
+          - --oidc-issuer-url=https://issuer.example.com
+          - --oidc-client-id=desktop-client
+"#,
+        );
+
+        let detected = detect_oidc_exec(&kubeconfig, "oidc-user").expect("oidc should be detected");
+        assert_eq!(detected.command, "/usr/local/bin/kubectl");
+        assert_eq!(
+            detected.plugin_binary.as_deref(),
+            Some("kubectl-oidc_login")
+        );
+
+        // kubectl present but plugin missing -> provider not runnable -> native.
+        let current = std::env::current_exe().expect("current exe path");
+        let kubectl_present_plugin_missing = OidcExecConfig {
+            command: current.to_string_lossy().into_owned(),
+            plugin_binary: Some("definitely-not-a-real-plugin-xyz123".to_string()),
+            ..Default::default()
+        };
+        assert!(!exec_provider_runnable(&kubectl_present_plugin_missing));
+
+        // Both present -> runnable.
+        let both_present = OidcExecConfig {
+            command: current.to_string_lossy().into_owned(),
+            plugin_binary: Some(current.to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        assert!(exec_provider_runnable(&both_present));
+    }
+
+    #[test]
+    fn exec_binary_available_resolves_path_and_absolute() {
+        // Empty and clearly-bogus names never resolve.
+        assert!(!exec_binary_available(""));
+        assert!(!exec_binary_available(
+            "definitely-not-a-real-binary-xyz123"
+        ));
+
+        // An absolute path to an existing executable resolves directly. The
+        // test binary itself is a stable, cross-platform example.
+        let current = std::env::current_exe().expect("current exe path");
+        assert!(exec_binary_available(current.to_str().expect("utf-8 path")));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn exec_binary_available_requires_executable_bit_on_unix() {
+        // A readable but non-executable file must not count as runnable,
+        // otherwise the native OIDC fallback is wrongly skipped (review finding).
+        use std::os::unix::fs::PermissionsExt;
+
+        // A private, uniquely-named temp dir (not a fixed name in shared /tmp)
+        // avoids the insecure-temp-file class flagged by Semgrep.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("kubeli-exec-test");
+        std::fs::write(&path, b"#!/bin/sh\nexit 0\n").expect("write temp file");
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("chmod 644");
+        assert!(!exec_binary_available(path.to_str().expect("utf-8 path")));
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod 755");
+        assert!(exec_binary_available(path.to_str().expect("utf-8 path")));
+    }
+
+    #[test]
+    fn detects_krew_plugin_with_windows_style_command() {
+        // command_basename_is_kubectl must match case-insensitively and tolerate
+        // the `.exe` suffix so Windows kubeconfigs aren't misclassified (review
+        // finding). String logic only, so this runs on every platform.
+        let kubeconfig = kubeconfig_from_yaml(
+            r#"
+apiVersion: v1
+kind: Config
+users:
+  - name: oidc-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: KUBECTL.EXE
+        args:
+          - oidc-login
+          - get-token
+          - --oidc-issuer-url=https://issuer.example.com
+          - --oidc-client-id=desktop-client
+"#,
+        );
+
+        let detected = detect_oidc_exec(&kubeconfig, "oidc-user").expect("oidc should be detected");
+        assert_eq!(
+            detected.plugin_binary.as_deref(),
+            Some("kubectl-oidc_login")
+        );
+    }
+
+    #[test]
+    fn native_oidc_used_only_when_exec_binary_missing() {
+        // connect_cluster keeps the native flow (detection stays Some) only when
+        // exec auth isn't forced AND the plugin binary can't be run.
+        let decide = |prefer: bool, available: bool| !(prefer || available);
+
+        assert!(decide(false, false)); // no binary, not forced -> native fallback
+        assert!(!decide(false, true)); // binary present -> let kube-rs run exec
+        assert!(!decide(true, false)); // forced exec -> skip native even if absent
+        assert!(!decide(true, true));
     }
 
     #[test]

--- a/src/components/features/home/components/ClusterGrid.tsx
+++ b/src/components/features/home/components/ClusterGrid.tsx
@@ -49,6 +49,7 @@ export function ClusterGrid() {
     fetchClusters,
     connect,
     oidcPendingContext,
+    cancelConnect,
     saveAccessibleNamespaces,
     clearAccessibleNamespaces,
   } = useClusterStore();
@@ -59,10 +60,11 @@ export function ClusterGrid() {
     open: boolean;
     context: string;
     existing: string[] | undefined;
+    preferAuth: boolean;
     configuredContexts: Set<string>;
   };
   type NsDialogAction =
-    | { type: "open"; context: string; existing: string[] | undefined }
+    | { type: "open"; context: string; existing: string[] | undefined; preferAuth: boolean }
     | { type: "close" }
     | { type: "setOpen"; open: boolean }
     | { type: "addConfigured"; context: string }
@@ -73,7 +75,13 @@ export function ClusterGrid() {
     (state: NsDialogState, action: NsDialogAction): NsDialogState => {
       switch (action.type) {
         case "open":
-          return { ...state, open: true, context: action.context, existing: action.existing };
+          return {
+            ...state,
+            open: true,
+            context: action.context,
+            existing: action.existing,
+            preferAuth: action.preferAuth,
+          };
         case "close":
           return { ...state, open: false };
         case "setOpen":
@@ -89,7 +97,7 @@ export function ClusterGrid() {
           return { ...state, configuredContexts: action.contexts };
       }
     },
-    { open: false, context: "", existing: undefined, configuredContexts: new Set<string>() },
+    { open: false, context: "", existing: undefined, preferAuth: false, configuredContexts: new Set<string>() },
   );
 
   // Load configured contexts on mount and when clusters change
@@ -115,13 +123,15 @@ export function ClusterGrid() {
 
   const handleConfigureNamespaces = useCallback(async (context: string) => {
     let existing: string[] | undefined;
+    let preferAuth = false;
     try {
       const settings = await getClusterSettings(context);
       existing = settings?.accessible_namespaces;
+      preferAuth = Boolean(settings?.prefer_kubeconfig_auth);
     } catch {
       existing = undefined;
     }
-    nsDialogDispatch({ type: "open", context, existing });
+    nsDialogDispatch({ type: "open", context, existing, preferAuth });
   }, []);
 
   const handleSaveNamespaces = useCallback(async (context: string, namespaces: string[]) => {
@@ -148,13 +158,23 @@ export function ClusterGrid() {
       cluster.context.toLowerCase().includes(searchLower),
   );
 
+  // Monotonic id so a cancelled connect that resolves late can't clobber the UI.
+  const connectSeq = useRef(0);
+
   const handleConnect = async (context: string) => {
+    const seq = ++connectSeq.current;
     setConnectingContext(context);
     try {
       await connect(context);
     } finally {
-      setConnectingContext(null);
+      if (connectSeq.current === seq) setConnectingContext(null);
     }
+  };
+
+  const handleCancelConnect = () => {
+    connectSeq.current++; // invalidate the in-flight connect
+    setConnectingContext(null);
+    cancelConnect();
   };
 
   return (
@@ -278,6 +298,7 @@ export function ClusterGrid() {
                 disabled:
                   connectingContext !== null || oidcPendingContext !== null || isActive,
                 onConnect: handleConnect,
+                onCancelConnect: handleCancelConnect,
                 onConfigureNamespaces: handleConfigureNamespaces,
                 forwardsCount: showForwards ? forwards.length : 0,
                 hasConfiguredNamespaces: nsDialog.configuredContexts.has(cluster.context),
@@ -298,6 +319,7 @@ export function ClusterGrid() {
         context={nsDialog.context}
         defaultNamespace={clusters.find((c) => c.context === nsDialog.context)?.namespace}
         existingNamespaces={nsDialog.existing}
+        preferKubeconfigAuth={nsDialog.preferAuth}
         onSave={handleSaveNamespaces}
         onClear={handleClearNamespaces}
       />

--- a/src/components/features/home/components/ClusterGridCard.tsx
+++ b/src/components/features/home/components/ClusterGridCard.tsx
@@ -19,11 +19,13 @@ export function ClusterGridCard({
   isConnecting,
   disabled,
   onConnect,
+  onCancelConnect,
   onConfigureNamespaces,
   forwardsCount,
   hasConfiguredNamespaces,
 }: ClusterCardProps) {
   const t = useTranslations("cluster");
+  const tCommon = useTranslations("common");
 
   return (
     <Card
@@ -88,23 +90,26 @@ export function ClusterGridCard({
         >
           <Settings2 className="size-4" />
         </Button>
-        <Button
-          onClick={() => onConnect(cluster.context)}
-          disabled={disabled}
-          className="flex-1"
-          variant={isActive ? "secondary" : "default"}
-        >
-          {isConnecting ? (
-            <>
-              <Spinner />
-              {t("connecting")}
-            </>
-          ) : isActive ? (
-            t("connected")
-          ) : (
-            t("connect")
-          )}
-        </Button>
+        {isConnecting ? (
+          <Button
+            onClick={onCancelConnect}
+            className="flex-1"
+            variant="destructive"
+            title={t("cancelConnect")}
+          >
+            <Spinner />
+            {tCommon("cancel")}
+          </Button>
+        ) : (
+          <Button
+            onClick={() => onConnect(cluster.context)}
+            disabled={disabled}
+            className="flex-1"
+            variant={isActive ? "secondary" : "default"}
+          >
+            {isActive ? t("connected") : t("connect")}
+          </Button>
+        )}
         </div>
       </CardContent>
     </Card>

--- a/src/components/features/home/components/ClusterListCard.tsx
+++ b/src/components/features/home/components/ClusterListCard.tsx
@@ -12,11 +12,13 @@ export function ClusterListCard({
   isConnecting,
   disabled,
   onConnect,
+  onCancelConnect,
   onConfigureNamespaces,
   forwardsCount,
   hasConfiguredNamespaces,
 }: ClusterCardProps) {
   const t = useTranslations("cluster");
+  const tCommon = useTranslations("common");
 
   return (
     <div
@@ -77,24 +79,28 @@ export function ClusterListCard({
         >
           <Settings2 className="size-3.5" />
         </Button>
-        <Button
-          onClick={() => onConnect(cluster.context)}
-          disabled={disabled}
-          size="sm"
-          variant={isActive ? "secondary" : "default"}
-          className="h-7 px-3 text-xs"
-        >
-          {isConnecting ? (
-            <>
-              <Spinner />
-              {t("connecting")}
-            </>
-          ) : isActive ? (
-            t("connected")
-          ) : (
-            t("connect")
-          )}
-        </Button>
+        {isConnecting ? (
+          <Button
+            onClick={onCancelConnect}
+            size="sm"
+            variant="destructive"
+            className="h-7 px-3 text-xs"
+            title={t("cancelConnect")}
+          >
+            <Spinner />
+            {tCommon("cancel")}
+          </Button>
+        ) : (
+          <Button
+            onClick={() => onConnect(cluster.context)}
+            disabled={disabled}
+            size="sm"
+            variant={isActive ? "secondary" : "default"}
+            className="h-7 px-3 text-xs"
+          >
+            {isActive ? t("connected") : t("connect")}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/features/home/components/ConfigureNamespacesDialog.tsx
+++ b/src/components/features/home/components/ConfigureNamespacesDialog.tsx
@@ -2,8 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { AlertTriangle, ChevronDown, HelpCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { setClusterPreferKubeconfigAuth } from "@/lib/tauri/commands";
 import {
   Collapsible,
   CollapsibleContent,
@@ -42,6 +46,7 @@ interface ConfigureNamespacesDialogProps {
   context: string;
   defaultNamespace?: string | null;
   existingNamespaces?: string[];
+  preferKubeconfigAuth?: boolean;
   onSave: (context: string, namespaces: string[]) => Promise<void>;
   onClear: (context: string) => Promise<void>;
 }
@@ -52,6 +57,7 @@ export function ConfigureNamespacesDialog({
   context,
   defaultNamespace,
   existingNamespaces,
+  preferKubeconfigAuth: preferKubeconfigAuthProp = false,
   onSave,
   onClear,
 }: ConfigureNamespacesDialogProps) {
@@ -60,17 +66,32 @@ export function ConfigureNamespacesDialog({
   const [input, setInput] = useState("");
   const [saving, setSaving] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+  const [preferKubeconfigAuth, setPreferKubeconfigAuth] = useState(false);
 
-  // Pre-fill textarea when dialog opens
+  // Seed local state from props when the dialog opens. The parent already
+  // fetched the cluster settings to open the dialog, so the auth flag arrives
+  // as a prop — no second fetch needed here.
   useEffect(() => {
-    if (open) {
-      if (existingNamespaces && existingNamespaces.length > 0) {
-        setInput(existingNamespaces.join("\n"));
-      } else {
-        setInput("");
+    if (!open) return;
+    setInput(existingNamespaces && existingNamespaces.length > 0 ? existingNamespaces.join("\n") : "");
+    setPreferKubeconfigAuth(preferKubeconfigAuthProp);
+  }, [open, existingNamespaces, defaultNamespace, preferKubeconfigAuthProp]);
+
+  const handleToggleAuth = useCallback(
+    async (next: boolean) => {
+      setPreferKubeconfigAuth(next);
+      try {
+        await setClusterPreferKubeconfigAuth(context, next);
+        toast.success(
+          next ? t("preferKubeconfigAuthEnabled") : t("preferKubeconfigAuthDisabled")
+        );
+      } catch {
+        setPreferKubeconfigAuth(!next); // revert on failure
+        toast.error(t("preferKubeconfigAuthError"));
       }
-    }
-  }, [open, existingNamespaces, defaultNamespace]);
+    },
+    [context, t]
+  );
 
   const parsed = parseNamespaces(input);
   const invalidNames = parsed.filter((ns) => !validateNamespace(ns));
@@ -125,6 +146,40 @@ export function ConfigureNamespacesDialog({
             </div>
           </CollapsibleContent>
         </Collapsible>
+
+        <div
+          role="button"
+          tabIndex={saving ? -1 : 0}
+          onClick={() => !saving && handleToggleAuth(!preferKubeconfigAuth)}
+          onKeyDown={(e) => {
+            if (saving) return;
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleToggleAuth(!preferKubeconfigAuth);
+            }
+          }}
+          className={cn(
+            "flex items-start justify-between gap-3 rounded-md border border-input p-3 transition-colors",
+            saving ? "opacity-60" : "cursor-pointer hover:bg-muted/50"
+          )}
+        >
+          <div className="space-y-1">
+            <Label htmlFor="prefer-kubeconfig-auth" className="text-sm font-medium pointer-events-none">
+              {t("preferKubeconfigAuth")}
+            </Label>
+            <p className="text-xs text-muted-foreground">{t("preferKubeconfigAuthDesc")}</p>
+          </div>
+          {/* Stop propagation so the switch toggles once via its own handler,
+              not twice (switch + container click). */}
+          <div onClick={(e) => e.stopPropagation()}>
+            <Switch
+              id="prefer-kubeconfig-auth"
+              checked={preferKubeconfigAuth}
+              onCheckedChange={handleToggleAuth}
+              disabled={saving}
+            />
+          </div>
+        </div>
 
         <div className="space-y-3">
           <textarea

--- a/src/components/features/home/components/ConnectionErrorAlert.tsx
+++ b/src/components/features/home/components/ConnectionErrorAlert.tsx
@@ -12,10 +12,17 @@ import { getErrorMessage } from "@/lib/types/errors";
 
 export function ConnectionErrorAlert() {
   const td = useTranslations("debug");
+  const tc = useTranslations("cluster");
   const [isDownloading, setIsDownloading] = useState(false);
 
-  const { error, lastConnectionErrorContext, lastConnectionErrorMessage, setError } =
-    useClusterStore();
+  const {
+    error,
+    lastConnectionErrorContext,
+    lastConnectionErrorMessage,
+    oidcTimedOutContext,
+    setError,
+    fallbackToKubeconfigAuth,
+  } = useClusterStore();
 
   const canDownloadDebugLog = Boolean(
     error &&
@@ -79,6 +86,17 @@ export function ConnectionErrorAlert() {
       >
         <X className="size-3.5" />
       </Button>
+      {oidcTimedOutContext && (
+        <div className="flex flex-wrap gap-2 pl-6">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => fallbackToKubeconfigAuth(oidcTimedOutContext)}
+          >
+            {tc("useKubeconfigAuthAndReconnect")}
+          </Button>
+        </div>
+      )}
       {canDownloadDebugLog && (
         <div className="flex flex-wrap gap-2 pl-6">
           <Button

--- a/src/components/features/home/components/cluster-card-types.ts
+++ b/src/components/features/home/components/cluster-card-types.ts
@@ -6,6 +6,8 @@ export interface ClusterCardProps {
   isConnecting: boolean;
   disabled: boolean;
   onConnect: (context: string) => void;
+  /** Abort the in-flight connect (OIDC browser wait, or a hung exec/cert connect). */
+  onCancelConnect: () => void;
   onConfigureNamespaces: (context: string) => void;
   forwardsCount: number;
   hasConfiguredNamespaces?: boolean;

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -175,7 +175,14 @@
     "configureNamespacesWhy1": "Kubeli erkennt normalerweise alle Namespaces automatisch. Das funktioniert, wenn Ihr Konto clusterweite Berechtigungen hat.",
     "configureNamespacesWhy2": "Auf manchen Clustern gewährt der Admin nur Zugriff auf bestimmte Namespaces (z.B. \"team-frontend\", \"staging\"), ohne die Berechtigung, alle aufzulisten. In dem Fall kann Kubeli keine Namespaces erkennen und zeigt eine leere Liste.",
     "configureNamespacesWhy3": "Wenn Sie Ihre Namespaces hier eintragen, überspringt Kubeli die Erkennung und nutzt direkt die angegebenen. Bei vollem Zugriff brauchen Sie das nicht.",
-    "invalidNamespaceWarning": "Möglicherweise kein gültiger Kubernetes-Namespace-Name"
+    "invalidNamespaceWarning": "Möglicherweise kein gültiger Kubernetes-Namespace-Name",
+    "preferKubeconfigAuth": "Nur kubeconfig-Authentifizierung verwenden",
+    "preferKubeconfigAuthDesc": "Kubeli nutzt den exec-Provider deiner kubeconfig (kubectl oidc-login, kubelogin oder Pinniped) automatisch, sobald dessen Plugin installiert ist, und greift nur auf die integrierte Browser-Anmeldung zurück, wenn es fehlt. Aktiviere dies, um immer die kubeconfig-Authentifizierung zu verwenden und nie die integrierte Anmeldung.",
+    "preferKubeconfigAuthEnabled": "Es wird nur die kubeconfig-Authentifizierung verwendet. Zum Anwenden neu verbinden.",
+    "preferKubeconfigAuthDisabled": "Automatische Authentifizierung wiederhergestellt. Zum Anwenden neu verbinden.",
+    "preferKubeconfigAuthError": "Authentifizierungs-Einstellung konnte nicht geändert werden.",
+    "useKubeconfigAuthAndReconnect": "Kubeconfig-Authentifizierung verwenden & neu verbinden",
+    "cancelConnect": "Verbinden abbrechen"
   },
   "workloads": {
     "overview": "Workloads-Übersicht",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -175,7 +175,14 @@
     "configureNamespacesWhy1": "Kubeli normally discovers all namespaces automatically. This works when your account has cluster-wide permissions.",
     "configureNamespacesWhy2": "On some clusters, your admin only grants access to specific namespaces (e.g. \"team-frontend\", \"staging\") without permission to list all of them. In that case, Kubeli can't discover namespaces and shows an empty list.",
     "configureNamespacesWhy3": "By entering your namespaces here, Kubeli skips the discovery step and directly uses the ones you specified. If you have full access, you don't need this.",
-    "invalidNamespaceWarning": "May not be a valid Kubernetes namespace name"
+    "invalidNamespaceWarning": "May not be a valid Kubernetes namespace name",
+    "preferKubeconfigAuth": "Use kubeconfig authentication only",
+    "preferKubeconfigAuthDesc": "Kubeli already uses your kubeconfig's exec provider (kubectl oidc-login, kubelogin, or Pinniped) when its plugin is installed, and only falls back to the built-in browser login when it isn't. Turn this on to always use kubeconfig authentication and never the built-in login.",
+    "preferKubeconfigAuthEnabled": "Using kubeconfig authentication only. Reconnect to apply.",
+    "preferKubeconfigAuthDisabled": "Automatic authentication restored. Reconnect to apply.",
+    "preferKubeconfigAuthError": "Could not change the authentication setting.",
+    "useKubeconfigAuthAndReconnect": "Use kubeconfig authentication & reconnect",
+    "cancelConnect": "Cancel connecting"
   },
   "workloads": {
     "overview": "Workloads Overview",

--- a/src/lib/stores/__tests__/cluster-store.test.ts
+++ b/src/lib/stores/__tests__/cluster-store.test.ts
@@ -14,6 +14,8 @@ const mockWatchNamespaces = jest.fn();
 const mockStopWatch = jest.fn();
 const mockOidcStartAuth = jest.fn();
 const mockOidcHandleCallback = jest.fn();
+const mockSetClusterPreferKubeconfigAuth = jest.fn();
+const mockSetClusterAccessibleNamespaces = jest.fn();
 
 jest.mock("../../tauri/commands", () => ({
   listClusters: () => mockListClusters(),
@@ -24,6 +26,10 @@ jest.mock("../../tauri/commands", () => ({
   checkConnectionHealth: () => mockCheckConnectionHealth(),
   watchNamespaces: (watchId: string) => mockWatchNamespaces(watchId),
   stopWatch: (watchId: string) => mockStopWatch(watchId),
+  setClusterPreferKubeconfigAuth: (context: string, prefer: boolean) =>
+    mockSetClusterPreferKubeconfigAuth(context, prefer),
+  setClusterAccessibleNamespaces: (context: string, namespaces: string[]) =>
+    mockSetClusterAccessibleNamespaces(context, namespaces),
 }));
 
 jest.mock("../../tauri/commands/oidc", () => ({
@@ -297,6 +303,442 @@ describe("ClusterStore", () => {
       expect(state.isConnected).toBe(true);
       expect(state.oidcPendingContext).toBeNull();
       expect(state.oidcAuthTimeout).toBeNull();
+    });
+
+    it("falls back to kubeconfig auth when native OIDC discovery fails (#335)", async () => {
+      // 1st connect → needs OIDC; native start fails (e.g. discovery/TLS); the
+      // retry after enabling the flag connects via the exec provider.
+      mockConnectCluster
+        .mockResolvedValueOnce({
+          connected: false,
+          context: "oidc-context",
+          oidc_auth_required: {
+            issuer_url: "https://host.minikube.internal:5556/dex",
+            client_id: "kubeli",
+            extra_scopes: [],
+          },
+        })
+        .mockResolvedValueOnce({ connected: true, context: "oidc-context", latency_ms: 7 });
+      const unlisten = jest.fn();
+      (listen as jest.Mock).mockResolvedValue(unlisten);
+      mockOidcStartAuth.mockRejectedValue(new Error("Failed OIDC discovery: Request failed"));
+      mockSetClusterPreferKubeconfigAuth.mockResolvedValue(undefined);
+      mockGetNamespaces.mockResolvedValue({ namespaces: ["default"], source: "auto" });
+      mockCheckConnectionHealth.mockResolvedValue({ healthy: true, latency_ms: 7 });
+      mockWatchNamespaces.mockResolvedValue(undefined);
+
+      await act(async () => {
+        await useClusterStore.getState().connect("oidc-context");
+      });
+
+      // The flag was persisted and a reconnect happened, ending connected with no error.
+      expect(mockSetClusterPreferKubeconfigAuth).toHaveBeenCalledWith("oidc-context", true);
+      expect(mockConnectCluster).toHaveBeenCalledTimes(2);
+      const state = useClusterStore.getState();
+      expect(state.isConnected).toBe(true);
+      expect(state.error).toBeNull();
+      expect(state.oidcPendingContext).toBeNull();
+    });
+
+    it("does not persist kubeconfig-auth fallback if cancelled during OIDC start", async () => {
+      // If the user cancels while native OIDC is starting and it then fails, the
+      // auto-fallback must NOT run — it would write prefer_kubeconfig_auth=true to
+      // disk and reconnect behind the user's back (review finding).
+      mockConnectCluster.mockResolvedValue({
+        connected: false,
+        context: "oidc-context",
+        oidc_auth_required: {
+          issuer_url: "https://issuer.example.com",
+          client_id: "kubeli",
+          extra_scopes: [],
+        },
+      });
+      const unlisten = jest.fn();
+      (listen as jest.Mock).mockResolvedValue(unlisten);
+      let rejectStart!: (e: unknown) => void;
+      mockOidcStartAuth.mockImplementation(
+        () => new Promise((_, reject) => { rejectStart = reject; }),
+      );
+      mockSetClusterPreferKubeconfigAuth.mockResolvedValue(undefined);
+
+      let connectPromise!: Promise<unknown>;
+      await act(async () => {
+        connectPromise = useClusterStore.getState().connect("oidc-context");
+        // Let connect() reach the pending oidcStartAuth await.
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // User cancels while oidcStartAuth is still pending.
+      useClusterStore.getState().cancelConnect();
+
+      await act(async () => {
+        rejectStart(new Error("Failed OIDC discovery"));
+        await connectPromise;
+      });
+
+      // Fallback was suppressed: nothing persisted, listener torn down, no reconnect.
+      expect(mockSetClusterPreferKubeconfigAuth).not.toHaveBeenCalled();
+      expect(unlisten).toHaveBeenCalled();
+      expect(mockConnectCluster).toHaveBeenCalledTimes(1);
+      expect(useClusterStore.getState().isConnected).toBe(false);
+    });
+
+    it("ignores an oidc-callback that arrives after cancel during OIDC start", async () => {
+      // A warm SSO session can emit oidc-callback while oidcStartAuth is still
+      // pending. If the user already cancelled, the callback must not resurrect
+      // the connect (recursive connect / disk persist) — review finding.
+      mockConnectCluster.mockResolvedValue({
+        connected: false,
+        context: "oidc-context",
+        oidc_auth_required: {
+          issuer_url: "https://issuer.example.com",
+          client_id: "kubeli",
+          extra_scopes: [],
+        },
+      });
+      const unlisten = jest.fn();
+      let capturedCallback!: (event: {
+        payload: { code: string; state: string };
+      }) => Promise<void> | void;
+      (listen as jest.Mock).mockImplementation((_channel, cb) => {
+        capturedCallback = cb;
+        return Promise.resolve(unlisten);
+      });
+      // oidcStartAuth stays pending so we can cancel mid-flight.
+      mockOidcStartAuth.mockImplementation(() => new Promise(() => {}));
+      mockOidcHandleCallback.mockResolvedValue({ status: "authenticated" });
+      mockSetClusterPreferKubeconfigAuth.mockResolvedValue(undefined);
+
+      await act(async () => {
+        void useClusterStore.getState().connect("oidc-context");
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // User cancels while oidcStartAuth is pending; the listener is torn down.
+      useClusterStore.getState().cancelConnect();
+      expect(unlisten).toHaveBeenCalled();
+
+      // A late callback fires anyway — the superseded() guard must drop it.
+      await act(async () => {
+        await capturedCallback({ payload: { code: "c", state: "s" } });
+      });
+
+      expect(mockOidcHandleCallback).not.toHaveBeenCalled();
+      expect(mockSetClusterPreferKubeconfigAuth).not.toHaveBeenCalled();
+      expect(mockConnectCluster).toHaveBeenCalledTimes(1);
+      expect(useClusterStore.getState().isConnected).toBe(false);
+    });
+
+    it("ignores a callback whose token exchange completes after cancel", async () => {
+      // The callback passes the entry guard, then the token exchange (which can
+      // take >1s on Entra) is still in flight when the user cancels. The result
+      // must not resurrect the connect or overwrite the cancelled state.
+      mockConnectCluster.mockResolvedValue({
+        connected: false,
+        context: "oidc-context",
+        oidc_auth_required: {
+          issuer_url: "https://issuer.example.com",
+          client_id: "kubeli",
+          extra_scopes: [],
+        },
+      });
+      const unlisten = jest.fn();
+      let capturedCallback!: (event: {
+        payload: { code: string; state: string };
+      }) => Promise<void> | void;
+      (listen as jest.Mock).mockImplementation((_channel, cb) => {
+        capturedCallback = cb;
+        return Promise.resolve(unlisten);
+      });
+      mockOidcStartAuth.mockResolvedValue({
+        status: "auth_pending",
+        auth_url: "https://issuer.example.com/auth",
+        token: null,
+      });
+      // The token exchange stays pending so we can cancel during it.
+      let resolveHandle!: (value: unknown) => void;
+      mockOidcHandleCallback.mockImplementation(
+        () => new Promise((resolve) => { resolveHandle = resolve; }),
+      );
+
+      await act(async () => {
+        void useClusterStore.getState().connect("oidc-context");
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Callback arrives (passes the entry guard) and starts the token exchange.
+      await act(async () => {
+        void capturedCallback({ payload: { code: "c", state: "s" } });
+        await Promise.resolve();
+      });
+      expect(mockOidcHandleCallback).toHaveBeenCalledTimes(1);
+
+      // User cancels while the exchange is in flight.
+      useClusterStore.getState().cancelConnect();
+
+      // The exchange then resolves "authenticated" — must be dropped.
+      await act(async () => {
+        resolveHandle({ status: "authenticated" });
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(mockConnectCluster).toHaveBeenCalledTimes(1); // no recursive connect
+      expect(useClusterStore.getState().isConnected).toBe(false);
+      expect(useClusterStore.getState().error).toBeNull(); // no stale error write
+    });
+
+    it("a cancelled attempt's late failure does not tear down a newer attempt's listener", async () => {
+      // Cancel+retry: attempt A is cancelled, attempt B registers its own
+      // listener, then A's oidcStartAuth finally rejects. A's catch must tear
+      // down only A's listener, not B's (which would strand B). Review finding.
+      mockConnectCluster.mockResolvedValue({
+        connected: false,
+        context: "oidc-context",
+        oidc_auth_required: {
+          issuer_url: "https://issuer.example.com",
+          client_id: "kubeli",
+          extra_scopes: [],
+        },
+      });
+      const unlistenA = jest.fn();
+      const unlistenB = jest.fn();
+      const unlistens = [unlistenA, unlistenB];
+      let listenIdx = 0;
+      (listen as jest.Mock).mockImplementation(() =>
+        Promise.resolve(unlistens[listenIdx++] ?? jest.fn()),
+      );
+      let rejectA!: (e: unknown) => void;
+      mockOidcStartAuth
+        .mockImplementationOnce(() => new Promise((_, reject) => { rejectA = reject; }))
+        .mockResolvedValueOnce({
+          status: "auth_pending",
+          auth_url: "https://issuer.example.com/auth",
+          token: null,
+        });
+      mockSetClusterPreferKubeconfigAuth.mockResolvedValue(undefined);
+
+      // Attempt A, then cancel it.
+      await act(async () => {
+        void useClusterStore.getState().connect("oidc-context");
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      useClusterStore.getState().cancelConnect();
+      expect(unlistenA).toHaveBeenCalled();
+
+      // Attempt B registers its own listener and arms (auth_pending).
+      await act(async () => {
+        void useClusterStore.getState().connect("oidc-context");
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      expect(useClusterStore.getState().oidcCallbackUnlisten).toBe(unlistenB);
+      const bCallsBefore = unlistenB.mock.calls.length;
+
+      // A's oidcStartAuth finally rejects — must not touch B's listener/state.
+      await act(async () => {
+        rejectA(new Error("discovery failed"));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(unlistenB.mock.calls.length).toBe(bCallsBefore); // B intact
+      expect(useClusterStore.getState().oidcCallbackUnlisten).toBe(unlistenB);
+      expect(mockSetClusterPreferKubeconfigAuth).not.toHaveBeenCalled(); // no stale fallback
+
+      useClusterStore.getState().cancelConnect(); // clear B's armed timeout
+    });
+
+    it("a superseded attempt in the setup window does not clobber a newer attempt's listener", async () => {
+      // Attempt A parks at `await listen()`; while it's parked it gets cancelled
+      // and attempt B fully arms. When A's listen() finally resolves, A must tear
+      // down only its own listener and bail BEFORE writing to shared state — it
+      // must not overwrite B's oidcCallbackUnlisten (review finding).
+      mockConnectCluster.mockResolvedValue({
+        connected: false,
+        context: "oidc-context",
+        oidc_auth_required: {
+          issuer_url: "https://issuer.example.com",
+          client_id: "kubeli",
+          extra_scopes: [],
+        },
+      });
+      const unlistenA = jest.fn();
+      const unlistenB = jest.fn();
+      let resolveListenA!: (fn: unknown) => void;
+      const listenReturns: Array<Promise<unknown>> = [
+        new Promise((resolve) => { resolveListenA = resolve; }), // A parks here
+        Promise.resolve(unlistenB), // B resolves immediately
+      ];
+      let listenIdx = 0;
+      (listen as jest.Mock).mockImplementation(
+        () => listenReturns[listenIdx++] ?? Promise.resolve(jest.fn()),
+      );
+      mockOidcStartAuth.mockResolvedValue({
+        status: "auth_pending",
+        auth_url: "https://issuer.example.com/auth",
+        token: null,
+      });
+      mockSetClusterPreferKubeconfigAuth.mockResolvedValue(undefined);
+
+      // Attempt A starts and parks at await listen().
+      await act(async () => {
+        void useClusterStore.getState().connect("oidc-context");
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      // Cancel A (it hasn't registered its listener yet).
+      useClusterStore.getState().cancelConnect();
+
+      // Attempt B starts, completes, and arms (its listener is in state).
+      await act(async () => {
+        void useClusterStore.getState().connect("oidc-context");
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      expect(useClusterStore.getState().oidcCallbackUnlisten).toBe(unlistenB);
+
+      // A's listen() finally resolves — A must not clobber B.
+      await act(async () => {
+        resolveListenA(unlistenA);
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(useClusterStore.getState().oidcCallbackUnlisten).toBe(unlistenB); // B intact
+      expect(unlistenB).not.toHaveBeenCalled(); // B not torn down by A
+      expect(unlistenA).toHaveBeenCalled(); // A's own listener torn down
+
+      useClusterStore.getState().cancelConnect(); // clear B's armed timeout
+    });
+
+    it("auto-fallback aborts the reconnect if cancelled during the preference write", async () => {
+      // oidcStartAuth fails -> auto-fallback persists the flag then reconnects.
+      // A cancel while that disk write is in flight must abort the reconnect.
+      mockConnectCluster.mockResolvedValue({
+        connected: false,
+        context: "oidc-context",
+        oidc_auth_required: {
+          issuer_url: "https://issuer.example.com",
+          client_id: "kubeli",
+          extra_scopes: [],
+        },
+      });
+      (listen as jest.Mock).mockResolvedValue(jest.fn());
+      mockOidcStartAuth.mockRejectedValue(new Error("Failed OIDC discovery"));
+      let resolvePref!: () => void;
+      mockSetClusterPreferKubeconfigAuth.mockImplementation(
+        () => new Promise<void>((resolve) => { resolvePref = resolve; }),
+      );
+
+      let connectPromise!: Promise<unknown>;
+      await act(async () => {
+        connectPromise = useClusterStore.getState().connect("oidc-context");
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      // Now parked in fallbackToKubeconfigAuth awaiting the preference write.
+      useClusterStore.getState().cancelConnect();
+
+      await act(async () => {
+        resolvePref();
+        await connectPromise;
+      });
+
+      // No reconnect happened (connectCluster only the initial call).
+      expect(mockConnectCluster).toHaveBeenCalledTimes(1);
+      expect(useClusterStore.getState().isConnected).toBe(false);
+    });
+
+    it("the manual kubeconfig-auth fallback aborts if a newer connect starts during the write", async () => {
+      // The error-banner button passes no generation. If the user starts another
+      // connect while the preference write is in flight, the fallback must not
+      // then reconnect to its own (older) context behind that newer action.
+      let resolvePref!: () => void;
+      mockSetClusterPreferKubeconfigAuth.mockImplementation(
+        () => new Promise<void>((resolve) => { resolvePref = resolve; }),
+      );
+      mockConnectCluster.mockResolvedValue({
+        connected: true,
+        context: "prod-context",
+        latency_ms: 5,
+      });
+      mockGetNamespaces.mockResolvedValue({ namespaces: ["default"], source: "auto" });
+      mockCheckConnectionHealth.mockResolvedValue({ healthy: true, latency_ms: 5 });
+      mockWatchNamespaces.mockResolvedValue(undefined);
+
+      // Manual fallback for the old context (no generation passed).
+      let fallbackPromise!: Promise<unknown>;
+      await act(async () => {
+        fallbackPromise = useClusterStore.getState().fallbackToKubeconfigAuth("oidc-context");
+        await Promise.resolve();
+      });
+
+      // A newer connect bumps the generation while the pref write is pending.
+      await act(async () => {
+        await useClusterStore.getState().connect("prod-context");
+      });
+
+      // The pref write resolves — the fallback must abort, not connect to its context.
+      await act(async () => {
+        resolvePref();
+        await fallbackPromise;
+      });
+
+      expect(mockConnectCluster).toHaveBeenCalledTimes(1);
+      expect(mockConnectCluster).toHaveBeenCalledWith("prod-context");
+      useClusterStore.getState().stopHealthMonitoring();
+    });
+
+    it("the OIDC timeout does not write a stale error over a newer connection", async () => {
+      jest.useFakeTimers();
+      try {
+        mockConnectCluster
+          .mockResolvedValueOnce({
+            connected: false,
+            context: "oidc-context",
+            oidc_auth_required: {
+              issuer_url: "https://issuer.example.com",
+              client_id: "kubeli",
+              extra_scopes: [],
+            },
+          })
+          .mockResolvedValueOnce({ connected: true, context: "prod-context", latency_ms: 5 });
+        (listen as jest.Mock).mockResolvedValue(jest.fn());
+        mockOidcStartAuth.mockResolvedValue({
+          status: "auth_pending",
+          auth_url: "https://issuer.example.com/auth",
+          token: null,
+        });
+        mockGetNamespaces.mockResolvedValue({ namespaces: ["default"], source: "auto" });
+        mockCheckConnectionHealth.mockResolvedValue({ healthy: true, latency_ms: 5 });
+        mockWatchNamespaces.mockResolvedValue(undefined);
+
+        // A: OIDC reaches auth_pending and arms the 120s timeout.
+        await act(async () => {
+          await useClusterStore.getState().connect("oidc-context");
+        });
+        expect(useClusterStore.getState().oidcAuthTimeout).not.toBeNull();
+
+        // B: a non-OIDC connect to another cluster (bumps generation, connected).
+        await act(async () => {
+          await useClusterStore.getState().connect("prod-context");
+        });
+        expect(useClusterStore.getState().isConnected).toBe(true);
+        useClusterStore.getState().stopHealthMonitoring(); // isolate the OIDC timeout
+
+        // ~120s later A's timeout fires — it must not error over B.
+        await act(async () => {
+          jest.advanceTimersByTime(120_000);
+        });
+
+        expect(useClusterStore.getState().error).toBeNull();
+        expect(useClusterStore.getState().isConnected).toBe(true);
+        expect(useClusterStore.getState().oidcTimedOutContext).toBeNull();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 
@@ -802,6 +1244,56 @@ describe("ClusterStore", () => {
         oidcAuthTimeout: null,
       });
       expect(() => useClusterStore.getState().cancelOidcAuth()).not.toThrow();
+    });
+
+    it("cancelConnect aborts a pending sign-in and clears the loading state", () => {
+      // User closed the OIDC browser; the card must reset without waiting 120s.
+      const unlisten = jest.fn();
+      useClusterStore.setState({
+        oidcPendingContext: "oidc-context",
+        oidcCallbackUnlisten: unlisten,
+        oidcAuthTimeout: setTimeout(() => {}, 100_000),
+        isLoading: true,
+      });
+
+      useClusterStore.getState().cancelConnect();
+
+      expect(unlisten).toHaveBeenCalledTimes(1);
+      const state = useClusterStore.getState();
+      expect(state.oidcPendingContext).toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
+
+    it("drops a hung non-OIDC connect result after cancelConnect", async () => {
+      // A slow exec/cert connect can resolve connected=true long after the user
+      // hit Cancel. The stale-result guard must keep that from undoing the cancel.
+      let resolveConnect!: (value: unknown) => void;
+      mockConnectCluster.mockImplementation(
+        () => new Promise((resolve) => { resolveConnect = resolve; }),
+      );
+
+      let connectPromise!: Promise<unknown>;
+      await act(async () => {
+        connectPromise = useClusterStore.getState().connect("hung-context");
+        await Promise.resolve(); // let connect() reach the await
+      });
+
+      // User cancels while connectCluster is still pending.
+      useClusterStore.getState().cancelConnect();
+
+      await act(async () => {
+        resolveConnect({
+          connected: true,
+          context: "hung-context",
+          latency_ms: 5,
+          oidc_auth_required: null,
+        });
+        await connectPromise;
+      });
+
+      const state = useClusterStore.getState();
+      expect(state.isConnected).toBe(false);
+      expect(state.isLoading).toBe(false);
     });
 
     it("is invoked by disconnect to tear down a pending browser flow", async () => {

--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -12,7 +12,7 @@ import {
   watchNamespaces,
   stopWatch,
   setClusterAccessibleNamespaces,
-  clearClusterSettings,
+  setClusterPreferKubeconfigAuth,
 } from "../tauri/commands";
 import { useResourceCacheStore } from "./resource-cache-store";
 import type { WatchEvent } from "../types";
@@ -33,6 +33,10 @@ interface ClusterState {
   namespaceSource: NamespaceSource;
   isConnected: boolean;
   isLoading: boolean;
+  // Bumped on every connect() start and on cancel/disconnect. A connect attempt
+  // captures it and drops its result if the value changed while it was awaiting,
+  // so a cancelled-but-still-running connect can't flip state back to connected.
+  connectGeneration: number;
   error: KubeliError | null;
   lastConnectionErrorContext: string | null;
   lastConnectionErrorMessage: string | null;
@@ -51,6 +55,9 @@ interface ClusterState {
   oidcPendingContext: string | null;
   oidcCallbackUnlisten: UnlistenFn | null;
   oidcAuthTimeout: ReturnType<typeof setTimeout> | null;
+  /** Context whose native OIDC flow just timed out — drives the
+   *  "use kubeconfig auth instead" suggestion in the error banner (#335). */
+  oidcTimedOutContext: string | null;
 
   // Auto-reconnect
   reconnectAttempts: number;
@@ -65,6 +72,14 @@ interface ClusterState {
   disconnect: () => Promise<void>;
   /** Cancel any in-flight OIDC browser auth, clearing its listener and timeout. */
   cancelOidcAuth: () => void;
+  /** User-initiated abort of a pending connect (e.g. closed the OIDC browser):
+   *  cancels the OIDC wait and drops the loading state so the card resets. */
+  cancelConnect: () => void;
+  /** Enable "use kubeconfig auth only" for a context and immediately reconnect (#335). */
+  fallbackToKubeconfigAuth: (
+    context: string,
+    expectedGeneration?: number,
+  ) => Promise<ConnectionStatus>;
   refreshConnectionStatus: () => Promise<void>;
   fetchNamespaces: () => Promise<void>;
   setSelectedNamespaces: (namespaces: string[]) => void;
@@ -112,6 +127,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
   namespaceSource: "none",
   isConnected: false,
   isLoading: false,
+  connectGeneration: 0,
   error: null,
   lastConnectionErrorContext: null,
   lastConnectionErrorMessage: null,
@@ -130,6 +146,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
   oidcPendingContext: null,
   oidcCallbackUnlisten: null,
   oidcAuthTimeout: null,
+  oidcTimedOutContext: null,
 
   // Auto-reconnect initial state
   reconnectAttempts: 0,
@@ -162,15 +179,33 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
   },
 
   connect: async (context: string) => {
-    set({ isLoading: true, isReconnecting: false });
+    const generation = get().connectGeneration + 1;
+    set({
+      connectGeneration: generation,
+      isLoading: true,
+      isReconnecting: false,
+      oidcTimedOutContext: null,
+    });
+    // True once a newer connect started or the user cancelled/disconnected while
+    // this attempt was awaiting — then we must not apply its (stale) result.
+    const superseded = () => get().connectGeneration !== generation;
     useResourceCacheStore.getState().clearCache();
     try {
       const status = await connectCluster(context);
+      // A hung non-OIDC connect (exec/cert) can resolve long after the user hit
+      // Cancel; dropping it here keeps the cancel from being undone.
+      if (superseded()) return status;
       if (status.oidc_auth_required) {
         const { issuer_url, client_id, extra_scopes } = status.oidc_auth_required;
         set({ isLoading: true });
 
         const { oidcStartAuth, oidcHandleCallback } = await import("../tauri/commands/oidc");
+
+        // The module import is awaited; if the user cancelled / a newer attempt
+        // started meanwhile, bail BEFORE cancelOidcAuth — otherwise we'd clear a
+        // newer attempt's listener/timeout from the shared OIDC state. No local
+        // listener exists yet, so there's nothing of ours to tear down.
+        if (superseded()) return status;
 
         // Clear any previous in-flight OIDC auth so repeated connects during the
         // browser wait cannot accumulate duplicate listeners/timeouts.
@@ -186,6 +221,12 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
         const unlisten = await listen<{ code: string; state: string }>(
           "oidc-callback",
           async (event) => {
+            // If the user cancelled/disconnected while the browser was open, a
+            // late warm-SSO callback must not resurrect the connect. The
+            // superseding actor already removed this listener; just drop the
+            // event (don't call cancelOidcAuth, which could tear down a newer
+            // attempt's listener).
+            if (superseded()) return;
             callbackHandled = true;
             get().cancelOidcAuth();
             try {
@@ -193,30 +234,73 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
                 event.payload.code,
                 event.payload.state
               );
+              // The token exchange can take >1s (e.g. Entra); if the user
+              // cancelled/disconnected during it, neither resurrect the connect
+              // nor overwrite the terminal state with an auth error.
+              if (superseded()) return;
               if (callbackResult.status === "authenticated") {
                 await get().connect(context);
               } else {
                 set({ error: toKubeliError("OIDC authentication failed"), isLoading: false });
               }
             } catch {
+              if (superseded()) return;
               set({ error: toKubeliError("OIDC authentication failed"), isLoading: false });
             }
           }
         );
 
+        // listen() is awaited; if the user cancelled / a newer attempt started
+        // meanwhile, tear down only OUR just-registered listener and bail BEFORE
+        // writing it into shared state — otherwise we'd overwrite a newer
+        // attempt's oidcCallbackUnlisten and strand it.
+        if (superseded()) {
+          unlisten();
+          return status;
+        }
+
+        // Track the listener in state immediately (not only after auth_pending),
+        // so a cancel/disconnect during the oidcStartAuth wait can tear it down.
+        set({ oidcCallbackUnlisten: unlisten });
+
         let authResult: Awaited<ReturnType<typeof oidcStartAuth>>;
         try {
           authResult = await oidcStartAuth(issuer_url, client_id, extra_scopes);
         } catch (e) {
+          // Check superseded BEFORE touching OIDC state: a late rejection from a
+          // cancelled attempt must not call cancelOidcAuth and tear down a newer
+          // attempt's listener/timeout (which would strand it). It also must not
+          // auto-fall-back, which would persist prefer_kubeconfig_auth=true and
+          // reconnect behind the user's back.
+          if (superseded()) {
+            unlisten();
+            return status;
+          }
+          get().cancelOidcAuth();
+          // Native OIDC couldn't even start — typically OIDC discovery failing
+          // (unreachable issuer, private-CA/TLS error, or an Azure/Entra issuer
+          // the generic OIDC discovery can't handle). We only got here because
+          // the kubeconfig has an oidc-login exec provider, which already works
+          // with kubectl, so fall back to it automatically instead of dead-ending
+          // on the error (#335).
+          debug("Native OIDC start failed, falling back to kubeconfig auth:", e);
+          return get().fallbackToKubeconfigAuth(context, generation);
+        }
+
+        // The browser auth started; if the user cancelled/disconnected meanwhile,
+        // tear down only our listener and bail before arming a timeout, driving
+        // the callback flow, or writing state for an abandoned attempt.
+        if (superseded()) {
           unlisten();
-          throw e;
+          return status;
         }
 
         // A cached/refreshed token authenticated without opening the browser, so
         // the callback listener is unused — tear it down and retry the connect.
         if (authResult.status === "authenticated") {
-          unlisten();
+          get().cancelOidcAuth();
           const retryStatus = await connectCluster(context);
+          if (superseded()) return retryStatus;
           if (retryStatus.connected) {
             const clusters = get().clusters;
             const currentCluster = clusters.find((c) => c.context === context) || null;
@@ -235,6 +319,9 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
               lastConnectionErrorMessage: null,
             });
             await get().fetchNamespaces();
+            // A disconnect during fetchNamespaces() would leave a leaked watch
+            // and health interval running for a connection that's already gone.
+            if (superseded()) return retryStatus;
             if (get().namespaceSource === "auto") {
               get().startNamespaceWatch();
             }
@@ -258,15 +345,23 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
           // already arrived during the start-auth round trip, the handler has
           // driven the flow — don't arm a stale timeout over a finished auth.
           if (callbackHandled) {
-            unlisten();
+            get().cancelOidcAuth();
             return status;
           }
           const OIDC_TIMEOUT_MS = 120_000;
           const timeout = setTimeout(() => {
             get().cancelOidcAuth();
+            // A non-OIDC connect to another cluster doesn't clear this timeout
+            // (only cancelOidcAuth/a new auth does). If such a connect happened
+            // while the browser sat open, don't write a stale timeout error over
+            // the newer connection's state ~120s later.
+            if (superseded()) return;
             set({
               error: toKubeliError("OIDC authentication timed out — no response from browser"),
               isLoading: false,
+              // Remember which context timed out so the error banner can offer
+              // the kubeconfig-auth fallback for it (#335).
+              oidcTimedOutContext: context,
             });
           }, OIDC_TIMEOUT_MS);
           set({
@@ -278,7 +373,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
         }
 
         // Unexpected status — don't leak the listener.
-        unlisten();
+        get().cancelOidcAuth();
       }
       if (status.connected) {
         const clusters = get().clusters;
@@ -299,6 +394,9 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
         });
         // Fetch namespaces after connecting, then start watch for live updates
         await get().fetchNamespaces();
+        // A disconnect during fetchNamespaces() would leave a leaked watch and
+        // health interval running for a connection that's already gone.
+        if (superseded()) return status;
         // Only start namespace watch for auto-discovered namespaces (not configured)
         if (get().namespaceSource === "auto") {
           get().startNamespaceWatch();
@@ -319,6 +417,11 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
       return status;
     } catch (e) {
       const errorMsg = getErrorMessage(e);
+      // A failure from a cancelled/superseded attempt must not overwrite the
+      // state the newer attempt (or the cancel) already set.
+      if (superseded()) {
+        return { connected: false, context, error: errorMsg, latency_ms: null, oidc_auth_required: null };
+      }
       set({
         error: toKubeliError(e),
         isLoading: false,
@@ -338,14 +441,47 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
     set({ oidcAuthTimeout: null, oidcCallbackUnlisten: null, oidcPendingContext: null });
   },
 
+  cancelConnect: () => {
+    get().cancelOidcAuth();
+    // Bump the generation so an in-flight connect (including a hung non-OIDC
+    // exec/cert connect) drops its result instead of flipping us to connected.
+    set({
+      connectGeneration: get().connectGeneration + 1,
+      isLoading: false,
+      oidcTimedOutContext: null,
+    });
+  },
+
+  fallbackToKubeconfigAuth: async (context, expectedGeneration) => {
+    get().cancelOidcAuth();
+    // Auto-fallback (connect() catch) passes the originating attempt's
+    // generation; the manual banner button passes none, so baseline against the
+    // current generation. Either way, if a connect/cancel/disconnect happens
+    // while the preference write is in flight, abort rather than reconnect
+    // behind the user's newer action.
+    const baseline = expectedGeneration ?? get().connectGeneration;
+    await setClusterPreferKubeconfigAuth(context, true);
+    if (get().connectGeneration !== baseline) {
+      return { connected: false, context, error: null, latency_ms: null, oidc_auth_required: null };
+    }
+    set({ error: null, oidcTimedOutContext: null });
+    return get().connect(context);
+  },
+
   disconnect: async () => {
-    // Stop any in-flight OIDC auth, health monitoring and namespace watch first
+    // Stop any in-flight OIDC auth, health monitoring and namespace watch first.
+    // Bumping the generation also drops any connect that's still awaiting.
     get().cancelOidcAuth();
     get().stopHealthMonitoring();
     get().stopNamespaceWatch();
+    const generation = get().connectGeneration + 1;
+    set({ connectGeneration: generation });
     useResourceCacheStore.getState().clearCache();
     try {
       await disconnectCluster();
+      // A connect started after this disconnect (newer generation) wins — don't
+      // clobber its freshly-established state with our teardown.
+      if (get().connectGeneration !== generation) return;
       // Keep currentCluster so port forward badge still shows on the correct cluster card
       set({
         isConnected: false,
@@ -361,6 +497,9 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
         lastConnectionErrorMessage: null,
       });
     } catch (e) {
+      // A connect that started during disconnectCluster()'s await (newer
+      // generation) wins — don't overwrite its state with a stale disconnect error.
+      if (get().connectGeneration !== generation) return;
       set({
         error: toKubeliError(e),
       });
@@ -423,7 +562,10 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
   },
 
   clearAccessibleNamespaces: async (context) => {
-    await clearClusterSettings(context);
+    // Clear only the namespace list, not the whole context entry, so the
+    // prefer_kubeconfig_auth flag (#335) survives. The Rust setter drops the
+    // entry automatically if nothing meaningful remains.
+    await setClusterAccessibleNamespaces(context, []);
     set({ namespaceSource: "none", namespaces: [], selectedNamespaces: [], currentNamespace: "" });
     // Re-fetch namespaces via auto-discovery
     await get().fetchNamespaces();
@@ -585,15 +727,29 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
 
     set({ isReconnecting: true, reconnectAttempts: reconnectAttempts + 1 });
 
+    // Capture the connect generation so a manual connect or an explicit
+    // disconnect during the backoff/connect drops this auto-reconnect instead
+    // of resurrecting a connection the user already moved on from.
+    const generation = get().connectGeneration;
+    const superseded = () => get().connectGeneration !== generation;
+
     // Calculate backoff delay
     const delay = getBackoffDelay(reconnectAttempts);
     debug(`Attempting reconnect in ${delay}ms (attempt ${reconnectAttempts + 1}/${maxReconnectAttempts})`);
 
     // Wait for backoff delay
     await new Promise((resolve) => setTimeout(resolve, delay));
+    if (superseded()) {
+      set({ isReconnecting: false });
+      return false;
+    }
 
     try {
       const status = await connectCluster(lastConnectedContext);
+      if (superseded()) {
+        set({ isReconnecting: false });
+        return false;
+      }
       if (status.connected) {
         const clusters = get().clusters;
         const currentCluster = clusters.find((c) => c.context === lastConnectedContext) || null;
@@ -618,6 +774,12 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
       }
     } catch (e) {
       console.error("Reconnect attempt failed:", e);
+      // A manual connect / explicit disconnect during the failed attempt wins —
+      // stop retrying instead of fighting the user's newer action.
+      if (superseded()) {
+        set({ isReconnecting: false });
+        return false;
+      }
       // Retry
       return get().attemptReconnect();
     }

--- a/src/lib/tauri/commands/__tests__/wrappers.test.ts
+++ b/src/lib/tauri/commands/__tests__/wrappers.test.ts
@@ -45,6 +45,7 @@ const cases: TestCase[] = [
   { name: "getNamespaces", run: () => cluster.getNamespaces(), expectedCommand: "get_namespaces" },
   { name: "getClusterSettings", run: () => cluster.getClusterSettings("ctx"), expectedCommand: "get_cluster_settings", expectedPayload: { context: "ctx" } },
   { name: "setClusterAccessibleNamespaces", run: () => cluster.setClusterAccessibleNamespaces("ctx", ["a", "b"]), expectedCommand: "set_cluster_accessible_namespaces", expectedPayload: { context: "ctx", namespaces: ["a", "b"] } },
+  { name: "setClusterPreferKubeconfigAuth", run: () => cluster.setClusterPreferKubeconfigAuth("ctx", true), expectedCommand: "set_cluster_prefer_kubeconfig_auth", expectedPayload: { context: "ctx", prefer: true } },
   { name: "clearClusterSettings", run: () => cluster.clearClusterSettings("ctx"), expectedCommand: "clear_cluster_settings", expectedPayload: { context: "ctx" } },
   { name: "addCluster", run: () => cluster.addCluster("apiVersion: v1"), expectedCommand: "add_cluster", expectedPayload: { kubeconfigContent: "apiVersion: v1" } },
   { name: "removeCluster", run: () => cluster.removeCluster("ctx"), expectedCommand: "remove_cluster", expectedPayload: { context: "ctx" } },

--- a/src/lib/tauri/commands/cluster.ts
+++ b/src/lib/tauri/commands/cluster.ts
@@ -43,6 +43,13 @@ export async function setClusterAccessibleNamespaces(
   return invoke("set_cluster_accessible_namespaces", { context, namespaces });
 }
 
+export async function setClusterPreferKubeconfigAuth(
+  context: string,
+  prefer: boolean
+): Promise<void> {
+  return invoke("set_cluster_prefer_kubeconfig_auth", { context, prefer });
+}
+
 export async function clearClusterSettings(context: string): Promise<void> {
   return invoke("clear_cluster_settings", { context });
 }

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -24,6 +24,8 @@ export interface NamespaceResult {
 
 export interface ClusterSettings {
   accessible_namespaces: string[];
+  /** Skip Kubeli's native OIDC flow; use the kubeconfig's own auth (e.g. exec provider). */
+  prefer_kubeconfig_auth?: boolean;
 }
 
 export interface ConnectionStatus {


### PR DESCRIPTION
Fixes #335

## Problem

Native OIDC (added in e079d70) replaces the kubeconfig `exec` provider with an injected token. On Linux with Microsoft Entra ID and an exec-based kubeconfig (`kubectl oidc-login`), that flow never completes ("No response from browser") — even though the same kubeconfig already authenticates fine with `kubectl`.

## Solution

Respect the kubeconfig `exec` provider, like Headlamp and Lens do.

When a context uses an exec OIDC provider (`kubectl oidc-login` / `kubelogin` / Pinniped) that can actually run, Kubeli lets kube-rs run it instead of overriding it with the native flow. It falls back to native OIDC only when the provider can't run — keeping the no-binary comfort from e079d70.

"Can run" is checked against the same `PATH` kube-rs uses to spawn the plugin. For `kubectl oidc-login` that means both `kubectl` and its krew plugin `kubectl-oidc_login` must resolve and be executable (Unix exec bit; Windows case-insensitive basename + `PATHEXT`).

Result: a kubeconfig that already works with `kubectl` now connects in Kubeli with no manual step.

```rust
// connect_cluster
detect_oidc_exec(&kubeconfig, user).filter(|cfg| {
    let run_exec = prefer_kubeconfig_auth || exec_provider_runnable(cfg);
    !run_exec // keep native OIDC only when exec can't run and isn't forced
})
```

Native OIDC, ArgoCD and deep links from e079d70 are untouched — both paths work.

## Also included

- A per-cluster **"Use kubeconfig authentication only"** toggle (Configure namespaces dialog, persisted in `cluster-settings.json`) to force the exec path.
- Automatic fallback to the exec provider when native OIDC can't start, plus a one-click fallback in the connection error banner on timeout.
- A **Cancel** button on every connecting cluster card.

## Testing

- Rust: exec-provider detection and runnability (kubectl + krew plugin, Unix exec bit, Windows resolution), settings round-trip.
- Frontend: the command wrapper and the connect/cancel flow (auto-fallback, cancel handling, no stale state after cancel/disconnect).
- Local: `make oidc-dev` installs `kubelogin` and seeds a `kubeli-oidc-exec` context so the exec path is testable end to end.
