### PR TITLE
fix(deps): resolve 8 dompurify security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7536,9 +7536,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "overrides": {
     "minimatch": ">=3.1.3",
-    "dompurify": ">=3.4.0",
+    "dompurify": ">=3.4.11",
     "fast-uri": ">=3.1.2",
     "postcss": ">=8.5.10",
     "ws": ">=8.21.0",


### PR DESCRIPTION
## Problem

8 open Dependabot alerts flag the transitive `dompurify` dependency
(pulled in by `monaco-editor`). The lockfile resolved `dompurify@3.4.1`,
which predates the patches for these advisories — a mix of `IN_PLACE`
XSS bypasses, hook/config pollution of the default allow-lists, and a
Trusted Types poisoning issue.

## Fix

The repo already pins `dompurify` through an `overrides` floor. This bumps
that floor from `>=3.4.0` to `>=3.4.11`, the first release that patches the
newest advisory (GHSA-cmwh-pvxp-8882, affecting `<=3.4.10`). `npm install`
re-resolves the transitive copy to `3.4.11`.

No application code changes — `monaco-editor` consumes the patched copy
transparently.

## Advisories resolved

| Severity | Advisory |
|----------|----------|
| Moderate | GHSA-cmwh-pvxp-8882 — `ALLOWED_ATTR` pollution via `setConfig()` |
| Moderate | GHSA-76mc-f452-cxcm — hook mutation pollutes `DEFAULT_ALLOWED_TAGS`/`ATTR` |
| Moderate | GHSA-hpcv-96wg-7vj8 — cross-realm `IN_PLACE` leaves markup intact |
| Moderate | GHSA-r47g-fvhr-h676 — `IN_PLACE` preserves clobbered root attributes |
| Moderate | GHSA-rp9w-3fw7-7cwq — `IN_PLACE` bypass via attached shadow root |
| Low      | GHSA-vxr8-fq34-vvx9 — Trusted Types policy survives `clearConfig()` |
| Low      | GHSA-gvmj-g25r-r7wr — `SAFE_FOR_TEMPLATES` bypass in `<template>` |
| Low      | GHSA-x4vx-rjvf-j5p4 — `IN_PLACE` trusts attacker-controlled `nodeName` |

## Verification

- `npm audit` → 0 vulnerabilities
- `npm run typecheck` → clean
- `npm ls dompurify` → `dompurify@3.4.11`
