### PR TITLE
fix(settings): speed up Settings open right after launch

### DIFF
--- a/src/components/features/settings/SettingsPanel.tsx
+++ b/src/components/features/settings/SettingsPanel.tsx
@@ -29,8 +29,11 @@ export function SettingsPanel() {
   const [activeTab, setActiveTab] = useState("appearance");
   const [appVersion, setAppVersion] = useState<string>("0.1.0");
 
-  const aiCli = useAiCli(isSettingsOpen);
-  const mcp = useMcpIdes(isSettingsOpen);
+  // Only probe a tab's backend (AI CLI subprocess spawns, IDE detection) once
+  // that tab is actually visited. Probing eagerly on every open congests Tauri
+  // IPC and makes Settings slow to open right after launch.
+  const aiCli = useAiCli(isSettingsOpen && activeTab === "ai");
+  const mcp = useMcpIdes(isSettingsOpen && activeTab === "mcp");
 
   // Sync active tab when settings panel opens with a specific tab
   useEffect(() => {

--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -158,11 +158,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
   fetchClusters: async () => {
     set({ isLoading: true, error: null });
     try {
-      // Minimum delay for visible loading feedback
-      const [clusters] = await Promise.all([
-        listClusters(),
-        new Promise((resolve) => setTimeout(resolve, 400)),
-      ]);
+      const clusters = await listClusters();
       const currentCluster = clusters.find((c) => c.current) || null;
       set({
         clusters,


### PR DESCRIPTION
Closes #340

## Problem

Clicking **Settings** right after launching Kubeli sometimes takes a long time to open, or needs a second click. Cold-start main-thread / Tauri IPC contention.

## Changes

1. **Remove 400ms artificial delay** in `fetchClusters` (`cluster-store.ts`). It ran alongside `listClusters()` as a "minimum delay for visible loading feedback" and gated `isReady` in `App.tsx`, keeping the home screen contended and faded for an extra 400ms+ on every launch.

2. **Lazy tab probes** in `SettingsPanel.tsx`. Opening Settings (default `appearance` tab) eagerly fired `useAiCli` — 4 AI-CLI checks that **spawn subprocesses** (`claude`/`codex`/`opencode`/`droid --version`) — plus `useMcpIdes` IDE detection. These congested the Tauri command worker pool during startup and delayed the dialog. Now gated to `isOpen && activeTab === "ai" | "mcp"`, so a normal open does no subprocess work; each tab probes when first visited.

## Test notes

`npm run typecheck` passes. Not reproducible deterministically (timing-dependent). No regression test added — failure mode is startup IPC timing, not unit-testable without an integration harness.

Secondary suspect left for follow-up (noted in #340): Settings opens via a zustand flag + manual `setSettingsOpen(true)` rather than Radix `<DialogTrigger>`, which can race open/close-on-same-gesture under load.