### PR TITLE
fix(web): mobile layout polish for changelog, footer, menu

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -17,6 +17,9 @@ export default defineConfig({
       name: 'Inter',
       cssVariable: '--font-inter',
       weights: [400, 500, 600, 700],
+      // optional: with the preload above the woff2 is ready before first paint,
+      // so Inter shows immediately and never flashes/swaps (no FOUT).
+      display: 'optional',
       fallbacks: ['ui-sans-serif', 'system-ui', 'Segoe UI', 'Helvetica Neue', 'Arial', 'sans-serif'],
     },
     {
@@ -24,6 +27,7 @@ export default defineConfig({
       name: 'JetBrains Mono',
       cssVariable: '--font-jetbrains',
       weights: [400, 500],
+      display: 'optional',
       fallbacks: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
     },
   ],

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig, fontProviders } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
@@ -9,6 +9,24 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://kubeli.dev',
   trailingSlash: 'never',
+  // Self-host fonts + auto-generate metric-matched fallbacks -> no font-swap
+  // layout shift (was a Google Fonts CDN <link> with display=swap).
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: 'Inter',
+      cssVariable: '--font-inter',
+      weights: [400, 500, 600, 700],
+      fallbacks: ['ui-sans-serif', 'system-ui', 'Segoe UI', 'Helvetica Neue', 'Arial', 'sans-serif'],
+    },
+    {
+      provider: fontProviders.google(),
+      name: 'JetBrains Mono',
+      cssVariable: '--font-jetbrains',
+      weights: [400, 500],
+      fallbacks: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+    },
+  ],
   integrations: [mdx(), react(), sitemap()],
   vite: {
     plugins: [tailwindcss()]

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -119,6 +119,10 @@ const websiteSchema = {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <!-- Layout-critical: reserve the scrollbar gutter on the very first paint,
+         before global.css loads. Prevents a one-frame width reflow (dev FOUC;
+         also a safety net if the stylesheet is slow in prod). -->
+    <style>html{scrollbar-gutter:stable}</style>
     <link rel="icon" type="image/svg+xml" href="/kubeli.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -318,6 +318,13 @@ const websiteSchema = {
         color: var(--foreground);
       }
 
+      /* Theme button keeps its icon inline; base rule forces display:block. */
+      .mobile-nav-link.theme-toggle {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
 
       /* Hide popover on desktop */
       @media (min-width: 640px) {
@@ -398,8 +405,8 @@ const websiteSchema = {
           </div>
         </div>
 
-        <div class="flex items-center justify-center gap-2 text-xs text-muted-foreground pt-8 border-t border-border">
-          <img src="/signpath-logo.svg" class="h-4 w-auto brightness-0 opacity-60 dark:invert dark:opacity-70" alt="SignPath" />
+        <div class="flex items-start sm:items-center justify-center gap-2 text-xs text-muted-foreground pt-8 border-t border-border">
+          <img src="/signpath-logo.svg" class="h-4 w-auto shrink-0 mt-0.5 sm:mt-0 brightness-0 opacity-60 dark:invert dark:opacity-70" alt="SignPath" />
           <span>Free code signing provided by <a href="https://about.signpath.io" target="_blank" rel="noopener" class="underline hover:text-foreground transition-colors">SignPath.io</a>, certificate by <a href="https://signpath.org" target="_blank" rel="noopener" class="underline hover:text-foreground transition-colors">SignPath Foundation</a>.</span>
         </div>
 

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import { Font } from "astro:assets";
 import pkg from "../../../package.json";
 
 interface Props {
@@ -133,13 +134,9 @@ const websiteSchema = {
       })();
     </script>
 
-    <!-- Inter (matches the Kubeli app). ponytail: CDN link; self-host if a 3rd-party request ever matters. -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-    />
+    <!-- Self-hosted, preloaded, metric-matched fallback (astro:fonts) — no swap CLS. -->
+    <Font cssVariable="--font-inter" preload />
+    <Font cssVariable="--font-jetbrains" />
 
     <!-- Primary Meta Tags -->
     <title>{fullTitle}</title>

--- a/web/src/pages/changelog.astro
+++ b/web/src/pages/changelog.astro
@@ -85,7 +85,7 @@ function renderNote(s: string): string {
         const tagUrl = r.version ? `${repo}/releases/tag/v${r.version}` : `${repo}/releases`;
         return (
           <section class="flex flex-col gap-4 border-t border-border py-8 first:border-t-0 first:pt-0">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div class="flex items-start justify-between gap-3">
               <div class="flex flex-wrap items-center gap-3">
                 <span class="rounded-full bg-accent-strong px-2.5 py-0.5 font-mono text-sm font-medium text-accent-strong-foreground">{r.label}</span>
                 <span class="text-sm text-muted-foreground">Released {fmtDate(r.date)}</span>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -270,7 +270,10 @@ const logos = [
   </section>
 
   <!-- ============ LOGO WALL (flush-left) ============ -->
-  <section class="border-b border-border">
+  <!-- overflow-x-clip: the hover tooltips (position:absolute, nowrap) stay laid
+       out at opacity:0 and would push page width sideways at some breakpoints.
+       clip removes that phantom width while keeping the upward tooltip visible. -->
+  <section class="border-b border-border overflow-x-clip">
     <div class="mx-auto max-w-6xl px-6 sm:px-8 py-10 sm:py-12">
       <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground mb-7">
         Starred on GitHub by engineers at

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -144,6 +144,27 @@
      can't shift page content sideways by the scrollbar width. */
   html {
     scrollbar-gutter: stable;
+    /* Firefox: thin thumb, no track background. */
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--foreground) 22%, transparent) transparent;
+  }
+  /* WebKit/Chromium: overlay-style thin thumb, transparent track. */
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--foreground) 20%, transparent);
+    border-radius: 9999px;
+    border: 3px solid transparent;
+    background-clip: content-box;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--foreground) 35%, transparent);
+    background-clip: content-box;
   }
   body {
     @apply bg-background text-foreground;

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -5,8 +5,10 @@
 @plugin "@tailwindcss/typography";
 
 @theme inline {
-  --font-sans: "Inter Variable", "Inter", ui-sans-serif, system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, "Liberation Mono", monospace;
+  /* astro:fonts vars already carry the family + metric-matched fallback chain.
+     The literal tail only applies if the var is ever missing. */
+  --font-sans: var(--font-inter, "Inter", ui-sans-serif, system-ui, "Segoe UI", Arial, sans-serif);
+  --font-mono: var(--font-jetbrains, "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace);
   --color-accent-strong: var(--accent-strong);
   --color-accent-strong-foreground: var(--accent-strong-foreground);
   --color-surface-inverse: var(--surface-inverse);

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -140,6 +140,11 @@
   * {
     @apply border-border outline-ring/50;
   }
+  /* Reserve the scrollbar gutter so locking body scroll (mobile menu open)
+     can't shift page content sideways by the scrollbar width. */
+  html {
+    scrollbar-gutter: stable;
+  }
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
Closes #355

Mobile fixes from the #339 redesign follow-up.

## Changes
1. **Changelog download control** — kept on the same row as the version badge + release date at all breakpoints (was stacking as a full-width button below on mobile). One-row layout, control right-aligned.
2. **SignPath footer** — logo top-aligned with wrapping text on mobile (`items-center` was centering the icon against the 2-line text).
3. **Mobile menu Theme button** — icon stays inline with the "Theme" label. The base `.mobile-nav-link { display: block }` was overriding the button's flex, stacking the icon above the text.

## Test
- `npm run build` clean (9 pages).
- Verified at mobile widths: changelog row, footer alignment, theme button.