### PR TITLE
fix(web): apply layout-critical style on first paint

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -17,9 +17,13 @@ export default defineConfig({
       name: 'Inter',
       cssVariable: '--font-inter',
       weights: [400, 500, 600, 700],
-      // optional: with the preload above the woff2 is ready before first paint,
-      // so Inter shows immediately and never flashes/swaps (no FOUT).
-      display: 'optional',
+      // block, not optional: optional shows the metric-fallback for the whole
+      // pageview whenever the woff2 misses the ~100ms block window (e.g. a hard
+      // reload past the cache) -> inconsistent "wrong font this load, right the
+      // next". block keeps text invisible (fallback metrics reserve the box, so
+      // 0 CLS) until the real font paints. Both faces are preloaded same-origin
+      // subsets, so that invisible window is a few ms -> no FOIT, always Inter.
+      display: 'block',
       fallbacks: ['ui-sans-serif', 'system-ui', 'Segoe UI', 'Helvetica Neue', 'Arial', 'sans-serif'],
     },
     {
@@ -27,7 +31,7 @@ export default defineConfig({
       name: 'JetBrains Mono',
       cssVariable: '--font-jetbrains',
       weights: [400, 500],
-      display: 'optional',
+      display: 'block',
       fallbacks: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
     },
   ],

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -119,10 +119,21 @@ const websiteSchema = {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <!-- Layout-critical: reserve the scrollbar gutter on the very first paint,
-         before global.css loads. Prevents a one-frame width reflow (dev FOUC;
-         also a safety net if the stylesheet is slow in prod). -->
-    <style>html{scrollbar-gutter:stable}</style>
+    <!-- Layout-critical, applied on the very first paint (is:inline keeps it
+         verbatim in <head>; without it Astro bundles the rule into the CSS that
+         Vite injects via JS *after* first paint in dev, so it never lands early).
+         - scrollbar-gutter: no width shift when the mobile menu locks scroll.
+         - font-family: paint text in the metric-matched fallback immediately.
+           --font-inter is defined inline in this head by astro:fonts below, so
+           the var resolves at first paint; the Tailwind bundle later maps the
+           same stack onto body. Kills the dev/first-load heading reflow (text
+           was flashing in the browser-default font before the bundle applied). -->
+    <style is:inline>
+      html {
+        scrollbar-gutter: stable;
+        font-family: var(--font-inter, ui-sans-serif, system-ui, sans-serif);
+      }
+    </style>
     <link rel="icon" type="image/svg+xml" href="/kubeli.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -151,7 +151,7 @@ const websiteSchema = {
 
     <!-- Self-hosted, preloaded, metric-matched fallback (astro:fonts) — no swap CLS. -->
     <Font cssVariable="--font-inter" preload />
-    <Font cssVariable="--font-jetbrains" />
+    <Font cssVariable="--font-jetbrains" preload />
 
     <!-- Primary Meta Tags -->
     <title>{fullTitle}</title>


### PR DESCRIPTION
## Problem

On refresh, the **Changelog** heading (and other text) briefly rendered in the wrong metrics, then snapped to Inter — "renders komisch aber gleiche Schrift". Also the merged scrollbar-gutter safety style never actually applied at first paint.

## Root cause

The critical `<style>html{scrollbar-gutter:stable}</style>` in `BaseLayout.astro` lacked `is:inline`. Astro therefore treated it as a component style and **bundled it into the external stylesheet** instead of leaving it in `<head>`. That bundle is render-blocking in prod (so prod happened to be fine via `global.css`), but in **dev Vite injects it via JS after first paint** — so first paint had no font-family from the bundle and text flashed in the browser-default font before Inter's metric-matched stack applied.

## Fix

- Add `is:inline` so the critical rule survives verbatim in `<head>` at first paint.
- Set `font-family: var(--font-inter, …)` on `html` in that inline block. `--font-inter` is defined inline in the head by astro:fonts, so the metric-matched fallback resolves on the very first paint. The Tailwind bundle later maps the same stack onto `body` — same computed result, no reflow.

## Verify

`npm run build` → inline `<style>` with `scrollbar-gutter` + `font-family` now present in `dist/**/index.html` `<head>`; dev server serves it at first paint too. Prod pipeline unchanged (preload + `display:optional` + size-adjust fallback), this is a first-paint safety net + the dev fix.