### PR TITLE
ci: ignore quick-xml DoS advisories (no upgrade path)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -223,7 +223,10 @@ jobs:
 
       - name: Run cargo-audit
         working-directory: src-tauri
-        run: cargo audit
+        # Ignores mirror src-tauri/deny.toml. quick-xml DoS (RUSTSEC-2026-0194/0195)
+        # is patched only in >= 0.41; transitive via plist -> tauri which pin 0.39
+        # (no upgrade path), and only parses trusted local plists -> not reachable.
+        run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
 
   lockfile-lint:
     name: Lockfile Integrity Check

--- a/src-tauri/deny.toml
+++ b/src-tauri/deny.toml
@@ -35,6 +35,13 @@ ignore = [
     # in the OIDC ID-token signature path against the trusted IdP, which would
     # require an attacker-controlled timing oracle — low practical risk.
     "RUSTSEC-2023-0071",
+
+    # quick-xml DoS (memory exhaustion / quadratic parse), patched only in
+    # >= 0.41. Transitive via plist -> tauri, both of which pin quick-xml 0.39;
+    # no upgrade path until tauri bumps plist. Only parses local Info.plist at
+    # build/runtime (trusted input), so the DoS surface is not attacker-reachable.
+    "RUSTSEC-2026-0194", # quick-xml quadratic duplicate-attribute check
+    "RUSTSEC-2026-0195", # quick-xml unbounded namespace-declaration allocation
 ]
 
 # -- Licenses: ensure all crate licenses are acceptable --


### PR DESCRIPTION
## Why

Two fresh RustSec advisories on `quick-xml` started failing **Cargo Audit** and **Cargo Deny** on every PR (and `main`):

- RUSTSEC-2026-0194 — quadratic run time checking a start tag for duplicate attributes (DoS, high)
- RUSTSEC-2026-0195 — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS, high)

## No upgrade path

Both are patched only in `quick-xml >= 0.41`. Here quick-xml is transitive: `plist -> tauri`, both pinning `0.39`. `cargo update` finds no compatible bump — nothing upgrades until Tauri bumps `plist`.

## Why ignoring is safe

quick-xml in this tree only parses local `Info.plist` files (trusted, build/runtime input). The DoS surface requires attacker-controlled XML, which is not reachable in a desktop app. Same rationale as the existing transitive-advisory ignores in `deny.toml`.

## Change

- Add both IDs to `src-tauri/deny.toml` `[advisories].ignore` (cargo-deny).
- Add `--ignore` for both to the `cargo audit` invocation in `security.yml`, with a comment pointing back to deny.toml.

Both jobs pass locally (exit 0). Split out of the font PR (#357) so the security decision is greppable in history rather than buried under a UI commit.