### PR TITLE
ci: incremental FTP deploy for landing page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,21 +82,20 @@ jobs:
           name: web-dist
           path: dist/
 
-      - name: Deploy to FTP
-        env:
-          FTP_HOST: ${{ secrets.FTP_HOST }}
-          FTP_USER: ${{ secrets.FTP_USER }}
-          FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
-          DEPLOY_LANDING_FTP_PATH: ${{ secrets.DEPLOY_LANDING_FTP_PATH }}
-        run: |
-          cd dist
-          find . -type f | while read -r file; do
-            REMOTE_PATH="${file#./}"
-            echo "Uploading $REMOTE_PATH..."
-            curl -s -T "$file" --user "$FTP_USER:$FTP_PASSWORD" \
-              "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/$REMOTE_PATH" --ftp-create-dirs
-          done
-          echo "Landing page deployed to production"
+      # Incremental sync: compares local file hashes against the server-side
+      # .ftp-deploy-sync-state.json and uploads only changed/new files, deleting
+      # ones it previously uploaded that are now gone. Files it never uploaded
+      # (release installers sharing this web root) are not in the state file, so
+      # they are left untouched — no dangerous-clean-slate. Cuts the job from
+      # "re-upload every file" to "upload the diff".
+      - name: Deploy to FTP (incremental)
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_HOST }}
+          username: ${{ secrets.FTP_USER }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local-dir: dist/
+          server-dir: ${{ secrets.DEPLOY_LANDING_FTP_PATH }}/
 
   tauri-versions:
     name: Tauri Version Sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       # they are left untouched — no dangerous-clean-slate. Cuts the job from
       # "re-upload every file" to "upload the diff".
       - name: Deploy to FTP (incremental)
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@8e83cea8672e3fbcbb9fdafff34debf6ae4c5f65 # v4.3.5
         with:
           server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USER }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -512,22 +512,18 @@ jobs:
           bun run build
           echo "Landing page built successfully"
 
-      - name: Deploy landing page to FTP
-        env:
-          FTP_HOST: ${{ secrets.FTP_HOST }}
-          FTP_USER: ${{ secrets.FTP_USER }}
-          FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
-          DEPLOY_LANDING_FTP_PATH: ${{ secrets.DEPLOY_LANDING_FTP_PATH }}
-        run: |
-          # Upload all landing page files
-          cd web/dist
-          find . -type f | while read -r file; do
-            REMOTE_PATH="${file#./}"
-            echo "Uploading $REMOTE_PATH..."
-            curl -s -T "$file" --user "$FTP_USER:$FTP_PASSWORD" \
-              "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/$REMOTE_PATH" --ftp-create-dirs
-          done
-          echo "Landing page deployed"
+      # Incremental sync (same as ci.yml): hash-diff against the server-side
+      # .ftp-deploy-sync-state.json, upload only changed/new, delete only files
+      # this action previously uploaded. The release installers uploaded above
+      # to the same path are not in the state file, so they stay untouched.
+      - name: Deploy landing page to FTP (incremental)
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_HOST }}
+          username: ${{ secrets.FTP_USER }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local-dir: web/dist/
+          server-dir: ${{ secrets.DEPLOY_LANDING_FTP_PATH }}/
 
       - name: Publish release
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -517,7 +517,7 @@ jobs:
       # this action previously uploaded. The release installers uploaded above
       # to the same path are not in the state file, so they stay untouched.
       - name: Deploy landing page to FTP (incremental)
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@8e83cea8672e3fbcbb9fdafff34debf6ae4c5f65 # v4.3.5
         with:
           server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USER }}


### PR DESCRIPTION
## Problem

Both landing-page deploys upload **every** file on every run:

- `ci.yml` › **Deploy Landing Page** (each push to `main`)
- `publish.yml` › **Deploy landing page to FTP** (each release)

```sh
find . -type f | while read -r file; do curl -T "$file" ftp://…; done
```

Nothing changed? Still re-uploads the whole `dist/`. Removed files are never cleaned up. Wasted job time.

## Fix

Replace both loops with [`SamKirkland/FTP-Deploy-Action`](https://github.com/SamKirkland/FTP-Deploy-Action) — purpose-built for incremental FTP:

- Keeps `.ftp-deploy-sync-state.json` on the server with a **hash per uploaded file**.
- Each run: hash-diff local vs state → upload only changed/new, delete only files it previously uploaded that are now gone.
- **Content-hash, not mtime** → fresh CI checkouts don't trigger a full re-upload (which `lftp --only-newer` would). rsync isn't an option (FTP only, no SSH).

## Why delete is safe on the shared web root

`DEPLOY_LANDING_FTP_PATH` also holds the release installers (`Kubeli_*.dmg/.exe/.AppImage`, uploaded separately in `publish.yml`). The action only deletes files **listed in its own sync-state**; anything it never uploaded (the installers) isn't in that file and is left untouched. No `dangerous-clean-slate`.

## Notes / caveats

- **First run after merge** uploads the full site once to seed the state file, then every later deploy ships only the diff.
- `server-dir` appends a trailing `/` to the existing secret (the action requires it); matches how the old code concatenated `$DEPLOY_LANDING_FTP_PATH/$path`.
- A small public `.ftp-deploy-sync-state.json` lands at the web root — only lists already-public filenames + hashes, not sensitive.
- Plain `ftp` kept (parity with the old `ftp://`); can switch to `ftps` if the host supports it.
- Version-tag pinned (`@v4.3.5`) to match repo convention; can SHA-pin if you prefer for a creds-bearing deploy.

No local test possible (needs FTP secrets) — verify on the first deploy after merge: job log should show only changed files uploaded.