### PR TITLE
ci: bump FTP action to node24, pin macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       # they are left untouched — no dangerous-clean-slate. Cuts the job from
       # "re-upload every file" to "upload the diff".
       - name: Deploy to FTP (incremental)
-        uses: SamKirkland/FTP-Deploy-Action@8e83cea8672e3fbcbb9fdafff34debf6ae4c5f65 # v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@110f9186c050f71550953127052e77650219c287 # v4.4.0
         with:
           server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USER }}
@@ -320,7 +320,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-15]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,11 +119,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
+          - platform: macos-15
             label: macOS-aarch64
             args: '--target aarch64-apple-darwin'
             rust_target: aarch64-apple-darwin
-          - platform: macos-latest
+          - platform: macos-15
             label: macOS-x86_64
             args: '--target x86_64-apple-darwin'
             rust_target: x86_64-apple-darwin
@@ -517,7 +517,7 @@ jobs:
       # this action previously uploaded. The release installers uploaded above
       # to the same path are not in the state file, so they stay untouched.
       - name: Deploy landing page to FTP (incremental)
-        uses: SamKirkland/FTP-Deploy-Action@8e83cea8672e3fbcbb9fdafff34debf6ae4c5f65 # v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@110f9186c050f71550953127052e77650219c287 # v4.4.0
         with:
           server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USER }}


### PR DESCRIPTION
Clears the three annotations on the release workflow.

## Node 20 deprecation (warning)
`SamKirkland/FTP-Deploy-Action@v4.3.5` targets Node 20 (deprecated; runners force it onto Node 24). Bumped to **v4.4.0**, which ships `using: node24` — confirmed in its `action.yml`. Still SHA-pinned (`110f9186…` # v4.4.0). Same major (v4), inputs unchanged, so no config change needed.

## macos-latest migration (2 notices)
`macos-latest` migrates to **macOS 26** mid-June 2026. Pinned the release build matrix (aarch64 + x86_64) and the disabled macOS CI matrix to **macos-15** — keeps the codesigning/notarization toolchain on a known image rather than auto-jumping to a new OS on a release pipeline. Both entries run on the ARM runner and cross-compile the x86_64 target via the Rust target, unchanged.

No local test possible (workflow-only). FTP + build behavior is identical; only the runtime image and action runtime move.