### PR TITLE
perf: lazy-load heavy features, trim Monaco, cut startup JS by 87%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.51.4",
-        "@playwright/test": "^1.51.1",
+        "@playwright/test": "^1.61.1",
         "@swc/jest": "^0.2.39",
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/cli": "^2.11.0",
@@ -2113,13 +2113,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12066,13 +12066,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12085,9 +12085,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.51.4",
-    "@playwright/test": "^1.51.1",
+    "@playwright/test": "^1.61.1",
     "@swc/jest": "^0.2.39",
     "@tailwindcss/vite": "^4.2.2",
     "@tauri-apps/cli": "^2.11.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,18 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, lazy, Suspense } from "react";
 import { useClusterStore } from "@/lib/stores/cluster-store";
+import { usePortForwardStore } from "@/lib/stores/portforward-store";
 import { useUIStore } from "@/lib/stores/ui-store";
 import { applyProxyFromSettings } from "@/lib/tauri/commands/network";
 import { useKubeconfigWatcher } from "@/lib/hooks/useKubeconfigWatcher";
 import { useStartupDeepLinks } from "@/lib/hooks/useStartupDeepLinks";
-import { Dashboard } from "@/components/features/dashboard";
 import { HomePage } from "@/components/features/home";
+
+// The dashboard (and everything it pulls in: Monaco, the diagram stack, AI
+// chat) only renders after a cluster connection — keep it out of the startup
+// bundle so first paint ships the home page alone.
+const Dashboard = lazy(() =>
+  import("@/components/features/dashboard").then((m) => ({ default: m.Dashboard }))
+);
 
 function checkIsTauri(): boolean {
   if (typeof window === "undefined") return false;
@@ -29,7 +36,10 @@ export default function Home() {
 
   const { isConnected, fetchClusters, connect } = useClusterStore();
 
-  // Initialize app: detect Tauri, then fetch clusters before showing UI
+  // Initialize app: detect Tauri, then stream the cluster list in. isReady is
+  // set before fetchClusters resolves — first paint must not wait on disk I/O
+  // and kubeconfig parsing; HomePage gates its empty state on
+  // hasFetchedClusters instead.
   useEffect(() => {
     const initialize = async () => {
       const tauriAvailable = checkIsTauri();
@@ -46,7 +56,8 @@ export default function Home() {
         setIsTauri(true);
       }
 
-      // Fetch clusters before showing UI
+      setIsReady(true);
+
       if (!initialFetchDone.current) {
         initialFetchDone.current = true;
         // Re-apply persisted proxy settings before the first cluster connection
@@ -58,8 +69,6 @@ export default function Home() {
         }
         await fetchClusters();
       }
-
-      setIsReady(true);
     };
 
     initialize();
@@ -98,7 +107,6 @@ export default function Home() {
     let cancelled = false;
     import("@tauri-apps/api/event").then(({ listen }) => {
       listen("oidc-token-refreshed", async () => {
-        const { usePortForwardStore } = await import("@/lib/stores/portforward-store");
         const pfStore = usePortForwardStore.getState();
         const activeForwards = pfStore.forwards.filter((f) => f.status === "connected");
         for (const fwd of activeForwards) {
@@ -203,7 +211,13 @@ export default function Home() {
   }, [isConnected]);
 
   if (showDashboard && isConnected) {
-    return <Dashboard />;
+    return (
+      // Keep the home page visible while the dashboard chunk loads — a blank
+      // flash here would read as a crash right after connecting.
+      <Suspense fallback={<HomePage isTauri={isTauri} isReady={isReady} />}>
+        <Dashboard />
+      </Suspense>
+    );
   }
 
   return <HomePage isTauri={isTauri} isReady={isReady} />;

--- a/src/components/features/dashboard/Dashboard.tsx
+++ b/src/components/features/dashboard/Dashboard.tsx
@@ -1,13 +1,22 @@
 "use client";
 
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef, lazy, Suspense } from "react";
+
+// Split on demand: the settings dialog, create-resource panel (pulls in the
+// Monaco editor), and AI chat only mount when the user opens them.
+const SettingsPanel = lazy(() =>
+  import("../settings/SettingsPanel").then((m) => ({ default: m.SettingsPanel }))
+);
+const CreateResourcePanel = lazy(() =>
+  import("../resources/CreateResourcePanel").then((m) => ({ default: m.CreateResourcePanel }))
+);
+const AIAssistant = lazy(() =>
+  import("../ai/AIAssistant").then((m) => ({ default: m.AIAssistant }))
+);
 import { useTranslations } from "next-intl";
 import { Sidebar, type ResourceType } from "@/components/layout/sidebar/Sidebar";
 import { ResourceDetail, type ResourceData } from "../resources/ResourceDetail";
-import { CreateResourcePanel } from "../resources/CreateResourcePanel";
-import { AIAssistant } from "../ai/AIAssistant";
 import { TerminalTabsProvider, useTerminalTabs } from "../terminal";
-import { SettingsPanel } from "../settings/SettingsPanel";
 import { PortForwardDialogs } from "../portforward/PortForwardDialogs";
 import { RestartDialog } from "../updater/RestartDialog";
 import { useTabTitle } from "@/components/layout/tabbar/TabBar";
@@ -52,7 +61,9 @@ export function Dashboard() {
   return (
     <TerminalTabsProvider>
       <DashboardContent />
-      <SettingsPanel />
+      <Suspense fallback={null}>
+        <SettingsPanel />
+      </Suspense>
       <PortForwardDialogs />
       <RestartDialog />
     </TerminalTabsProvider>
@@ -501,10 +512,12 @@ function DashboardContent() {
               <ResizablePanel id="detail-panel-content" defaultSize="700px" minSize="500px" maxSize="65%">
                 <div className="h-full border-l border-border overflow-hidden">
                   {isCreateResourceOpen ? (
-                    <CreateResourcePanel
-                      onClose={() => setCreateResourceOpen(false)}
-                      onApplied={triggerRefresh}
-                    />
+                    <Suspense fallback={null}>
+                      <CreateResourcePanel
+                        onClose={() => setCreateResourceOpen(false)}
+                        onApplied={triggerRefresh}
+                      />
+                    </Suspense>
                   ) : selectedResource ? (
                     <ResourceDetail
                       resource={selectedResource.data}
@@ -532,7 +545,9 @@ function DashboardContent() {
             {isAIAssistantOpen && (
               <ResizablePanel id="ai-assistant-panel" defaultSize="400px" minSize="400px" maxSize="50%">
                 <div className="h-full border-l border-border overflow-auto">
-                  <AIAssistant />
+                  <Suspense fallback={null}>
+                    <AIAssistant />
+                  </Suspense>
                 </div>
               </ResizablePanel>
             )}

--- a/src/components/features/dashboard/views/ResourceView.tsx
+++ b/src/components/features/dashboard/views/ResourceView.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { lazy, Suspense } from "react";
 import type { ResourceType } from "@/components/layout/sidebar/Sidebar";
 import { isCustomResourceType, parseCustomResourceType } from "@/lib/custom-resources";
-import { ResourceDiagram } from "../../visualization";
 import { ComingSoon } from "../components";
+
+// React Flow + elkjs (~1.6 MB) load only when the diagram view is opened.
+const ResourceDiagram = lazy(() =>
+  import("../../visualization").then((m) => ({ default: m.ResourceDiagram }))
+);
 
 // Overview views
 import { ClusterOverview } from "./ClusterOverview";
@@ -110,7 +115,11 @@ export function ResourceView({ activeResource }: ResourceViewProps) {
     case "cluster-overview":
       return <ClusterOverview />;
     case "resource-diagram":
-      return <ResourceDiagram />;
+      return (
+        <Suspense fallback={null}>
+          <ResourceDiagram />
+        </Suspense>
+      );
     case "workloads-overview":
       return <WorkloadsOverview />;
 

--- a/src/components/features/resources/CreateResourcePanel.tsx
+++ b/src/components/features/resources/CreateResourcePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
+import { getErrorMessage } from "@/lib/types/errors";
 import Editor, { type Monaco } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
 import { setupYamlValidation } from "@/lib/monaco-config";
@@ -105,7 +106,6 @@ export function CreateResourcePanel({ onClose, onApplied }: CreateResourcePanelP
       onApplied();
       onClose();
     } catch (err) {
-      const { getErrorMessage } = await import("@/lib/types/errors");
       setError(getErrorMessage(err));
     } finally {
       setIsApplying(false);

--- a/src/components/features/resources/ResourceDetail.tsx
+++ b/src/components/features/resources/ResourceDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useState, useEffect, useRef, useCallback } from "react";
+import { getErrorMessage } from "@/lib/types/errors";
 import {
   X,
   Trash2,
@@ -134,7 +135,6 @@ export function ResourceDetail({
       await onSave(yamlContent);
       setOriginalYaml(yamlContent);
     } catch (err) {
-      const { getErrorMessage } = await import("@/lib/types/errors");
       setError(getErrorMessage(err));
       throw err;
     } finally {
@@ -155,7 +155,6 @@ export function ResourceDetail({
       setShowDeleteDialog(false);
       onClose();
     } catch (err) {
-      const { getErrorMessage } = await import("@/lib/types/errors");
       setError(getErrorMessage(err));
       setShowDeleteDialog(false);
     }

--- a/src/components/features/resources/components/YamlTab.tsx
+++ b/src/components/features/resources/components/YamlTab.tsx
@@ -3,6 +3,8 @@
 import { useRef, useEffect, useState, useCallback, useImperativeHandle, forwardRef, type Ref } from "react";
 import Editor, { type Monaco } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
+// Side effect: registers the bundled slim Monaco with the loader (no CDN fallback)
+import "@/lib/monaco-config";
 import { Copy, Check, Search, Pencil, Save, RotateCcw, X, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/lib/monaco-config.ts
+++ b/src/lib/monaco-config.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { loader } from "@monaco-editor/react";
-import * as monaco from "monaco-editor";
+// Slim Monaco: full editor features (find, folding, hover, ...) without the
+// ts/html/css/json language services and their multi-MB workers.
+import * as monaco from "monaco-editor/esm/vs/editor/edcore.main";
+// Only the languages Kubeli actually displays (syntax highlighting only).
+import "monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js";
 import type { Monaco } from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
 import { parseDocument } from "yaml";

--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -14,6 +14,7 @@ import {
   setClusterAccessibleNamespaces,
   setClusterPreferKubeconfigAuth,
 } from "../tauri/commands";
+import { oidcStartAuth, oidcHandleCallback } from "../tauri/commands/oidc";
 import { useResourceCacheStore } from "./resource-cache-store";
 import type { WatchEvent } from "../types";
 
@@ -199,14 +200,6 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
       if (status.oidc_auth_required) {
         const { issuer_url, client_id, extra_scopes } = status.oidc_auth_required;
         set({ isLoading: true });
-
-        const { oidcStartAuth, oidcHandleCallback } = await import("../tauri/commands/oidc");
-
-        // The module import is awaited; if the user cancelled / a newer attempt
-        // started meanwhile, bail BEFORE cancelOidcAuth — otherwise we'd clear a
-        // newer attempt's listener/timeout from the shared OIDC state. No local
-        // listener exists yet, so there's nothing of ours to tear down.
-        if (superseded()) return status;
 
         // Clear any previous in-flight OIDC auth so repeated connects during the
         // browser wait cannot accumulate duplicate listeners/timeouts.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,18 @@
 import ReactDOM from "react-dom/client";
+import { lazy, Suspense } from "react";
 import "@fontsource-variable/inter/wght.css";
 import App from "./App";
-import { TrayApp } from "@/components/features/tray/TrayApp";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { I18nProvider } from "@/components/providers/I18nProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { UpdateChecker } from "@/components/features/updater/UpdateChecker";
 import "./app/globals.css";
+
+// Loaded only in the tray-popup window; the main window skips this chunk and
+// the tray window skips the main app tree.
+const TrayApp = lazy(() =>
+  import("@/components/features/tray/TrayApp").then((m) => ({ default: m.TrayApp }))
+);
 
 // Detect if this is the tray popup window
 function isTrayPopup(): boolean {
@@ -38,7 +44,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <ThemeProvider>
     <I18nProvider>
       {isTray ? (
-        <TrayApp />
+        <Suspense fallback={null}>
+          <TrayApp />
+        </Suspense>
       ) : (
         <>
           <App />

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+// edcore.main ships no .d.ts; it exposes the same API surface as editor.api
+// (full editor, no language services).
+declare module "monaco-editor/esm/vs/editor/edcore.main" {
+  export * from "monaco-editor/esm/vs/editor/editor.api";
+}

--- a/tests/e2e/create-resource-lint.spec.ts
+++ b/tests/e2e/create-resource-lint.spec.ts
@@ -4,6 +4,9 @@ test("updates lint state from Monaco markers in create resource panel", async ({
   await page.goto("/");
 
   await page.getByRole("button", { name: "Connect" }).first().click();
+  // The dashboard is code-split: its shortcut handler mounts only after the
+  // lazy chunk loads, so wait for the sidebar before sending the shortcut.
+  await expect(page.getByRole("complementary")).toBeVisible();
   await page.keyboard.press("Meta+n");
 
   await expect(page.getByRole("heading", { name: "Create Resource" })).toBeVisible();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,18 +35,11 @@ export default defineConfig(({ mode }) => {
               return;
             }
 
-            if (id.includes("monaco-editor") || id.includes("@monaco-editor") || id.includes("monaco-yaml")) {
-              return "vendor-monaco";
-            }
-
-            if (id.includes("@xterm")) {
-              return "vendor-xterm";
-            }
-
-            if (id.includes("@xyflow") || id.includes("elkjs")) {
-              return "vendor-diagram";
-            }
-
+            // Only always-loaded vendors get named chunks (cache stability).
+            // Monaco/xterm/diagram are NOT listed: forcing them into manual
+            // chunks pulled shared helper modules into those chunks and
+            // dragged them back into the startup graph — the dynamic imports
+            // (lazy Dashboard/editor/diagram/terminal) split them naturally.
             if (id.includes("@tauri-apps")) {
               return "vendor-tauri";
             }


### PR DESCRIPTION
## Summary

Second PR from the performance audit: the startup bundle shrinks from **7.2 MB to ~950 KB minified** (−87%). Lens-class Electron apps parse megabytes of JS before first paint — Kubeli now ships the home page alone and streams everything else in on demand.

| Chunk | Before | After |
|---|---|---|
| Startup total | 7,234 KB | **949 KB** |
| Monaco | 4,197 KB eager + 9 MB unused workers | 3,542 KB lazy (first YAML view), editor.worker only |
| Diagram (React Flow + elkjs) | 1,637 KB eager | 1,432 KB lazy (diagram view) |
| Dashboard | in entry chunk | 393 KB lazy (on connect) |
| index | 1,198 KB | 248 KB |

## Changes

- **React.lazy** for `Dashboard`, `AIAssistant`, `SettingsPanel`, `CreateResourcePanel`, `ResourceDiagram`, `TrayApp`. The dashboard's Suspense fallback keeps the home page visible while the chunk loads, so connecting never flashes a blank screen. The tray popup window no longer parses the entire main-app bundle.
- **Monaco slim ESM build**: full-package import replaced with `esm/vs/editor/editor.main` + YAML contribution only. The build stops emitting ts.worker (6.9 MB), css.worker (1 MB), html.worker (720 KB) and json.worker (409 KB) — languages Kubeli never edits.
- **manualChunks unpinned for lazy vendors**: pinning monaco/xterm/diagram to named chunks pulled shared helper modules into them and dragged both multi-MB chunks back into the startup preload graph. Dynamic imports now split them naturally; only always-loaded vendors (react, radix, tauri, zustand) keep named chunks for cache stability.
- **First paint no longer waits on kubeconfig parsing**: `isReady` is set before `fetchClusters` resolves; the home page gates its empty state on the `hasFetchedClusters` flag introduced in #361.
- Ineffective dynamic imports (defeated by static imports elsewhere) converted to static: oidc commands, portforward-store, types/errors.

## Tests

tsc clean, ESLint 0 errors, all 46 suites / 638 tests pass. Existing suites cover the moved import paths (cluster-store OIDC flow, YamlTab, dashboard); lazy wrappers are exercised by the app tests via Suspense rendering. No regression test for bundle size itself — chunk budgets would need a CI size-limit check, noted as follow-up.