### PR TITLE
perf: selector-based Zustand subscriptions app-wide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,9 @@ export default function Home() {
   // Dispatch any deep link that launched the app (cold start), once Tauri is ready
   useStartupDeepLinks(isTauri);
 
-  const { isConnected, fetchClusters, connect } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const fetchClusters = useClusterStore((s) => s.fetchClusters);
+  const connect = useClusterStore((s) => s.connect);
 
   // Initialize app: detect Tauri, then stream the cluster list in. isReady is
   // set before fetchClusters resolves — first paint must not wait on disk I/O

--- a/src/app/__tests__/home.test.tsx
+++ b/src/app/__tests__/home.test.tsx
@@ -5,8 +5,8 @@ jest.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
 
-jest.mock("@/lib/stores/cluster-store", () => ({
-  useClusterStore: () => ({
+jest.mock("@/lib/stores/cluster-store", () => {
+  const state = {
     clusters: [],
     currentCluster: null,
     isConnected: false,
@@ -17,8 +17,12 @@ jest.mock("@/lib/stores/cluster-store", () => ({
     connect: jest.fn(),
     lastConnectionErrorContext: null,
     lastConnectionErrorMessage: null,
-  }),
-}));
+  };
+  const useClusterStore = (selector?: (s: Record<string, unknown>) => unknown) =>
+    selector ? selector(state) : state;
+  useClusterStore.getState = () => state;
+  return { useClusterStore };
+});
 
 jest.mock("@/lib/stores/ui-store", () => {
   const state = {

--- a/src/components/features/ai/AIAssistant.tsx
+++ b/src/components/features/ai/AIAssistant.tsx
@@ -34,21 +34,20 @@ export function AIAssistant() {
   const [showHistory, setShowHistory] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const {
-    currentSessionId,
-    isSessionActive,
-    isThinking,
-    isStreaming,
-    error,
-    interrupt,
-    stopSession,
-    clearError,
-    getConversation,
-    clearConversation,
-    loadSavedSession,
-  } = useAIStore();
+  const currentSessionId = useAIStore((s) => s.currentSessionId);
+  const isSessionActive = useAIStore((s) => s.isSessionActive);
+  const isThinking = useAIStore((s) => s.isThinking);
+  const isStreaming = useAIStore((s) => s.isStreaming);
+  const error = useAIStore((s) => s.error);
+  const interrupt = useAIStore((s) => s.interrupt);
+  const stopSession = useAIStore((s) => s.stopSession);
+  const clearError = useAIStore((s) => s.clearError);
+  const getConversation = useAIStore((s) => s.getConversation);
+  const clearConversation = useAIStore((s) => s.clearConversation);
+  const loadSavedSession = useAIStore((s) => s.loadSavedSession);
 
-  const { currentCluster, isConnected } = useClusterStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const isConnected = useClusterStore((s) => s.isConnected);
 
   // View context for AI awareness
   const viewContext = useViewContext();
@@ -63,7 +62,8 @@ export function AIAssistant() {
     [t, viewContext]
   );
   const { textareaRef, handleSend: sendMessage } = useAISession(sessionOptions);
-  const { setPendingPodLogs, setAIAssistantOpen } = useUIStore();
+  const setPendingPodLogs = useUIStore((s) => s.setPendingPodLogs);
+  const setAIAssistantOpen = useUIStore((s) => s.setAIAssistantOpen);
 
   // Handle pending analysis from context menus
   usePendingAnalysis();

--- a/src/components/features/ai/components/ProviderBadge.tsx
+++ b/src/components/features/ai/components/ProviderBadge.tsx
@@ -14,7 +14,7 @@ const STYLES: Record<AiCliProvider, { className: string; label: string }> = {
  * Badge showing which AI CLI provider is being used.
  */
 export function ProviderBadge() {
-  const { settings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
   const provider: AiCliProvider = settings.aiCliProvider || "claude";
   const style = STYLES[provider] ?? STYLES.claude;
 

--- a/src/components/features/ai/dialogs/ApprovalModal.tsx
+++ b/src/components/features/ai/dialogs/ApprovalModal.tsx
@@ -33,7 +33,9 @@ const SEVERITY_STYLES = {
  */
 export function ApprovalModal({ open, onOpenChange }: ApprovalModalProps) {
   const t = useTranslations("ai");
-  const { pendingApproval, approveAction, rejectAction } = useAIStore();
+  const pendingApproval = useAIStore((s) => s.pendingApproval);
+  const approveAction = useAIStore((s) => s.approveAction);
+  const rejectAction = useAIStore((s) => s.rejectAction);
 
   if (!pendingApproval) return null;
 

--- a/src/components/features/ai/hooks/__tests__/useAIEvents.test.ts
+++ b/src/components/features/ai/hooks/__tests__/useAIEvents.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
 import { useAIEvents } from "../useAIEvents";
 import { useAIStore } from "@/lib/stores/ai-store";
+import type { ExtractState } from "zustand";
 import type { AIEventData } from "../../types";
 
 jest.mock("@tauri-apps/api/event", () => ({
@@ -15,6 +16,12 @@ jest.mock("sonner", () => ({
 jest.mock("@/lib/stores/ai-store");
 
 const mockUseAIStore = useAIStore as jest.MockedFunction<typeof useAIStore>;
+
+type AIState = ExtractState<typeof useAIStore>;
+
+const setAIStoreState = (state: Partial<Record<keyof AIState, unknown>>) =>
+  mockUseAIStore.mockImplementation(((selector: (s: AIState) => unknown) =>
+    selector(state as AIState)) as unknown as typeof useAIStore);
 
 describe("useAIEvents", () => {
   const appendMessageChunk = jest.fn();
@@ -48,7 +55,7 @@ describe("useAIEvents", () => {
       emit = handler;
       return Promise.resolve(jest.fn());
     });
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       appendMessageChunk,
       finalizeStreaming,
       setThinking,
@@ -56,7 +63,7 @@ describe("useAIEvents", () => {
       addToolCall,
       setApprovalRequest,
       markSessionEnded,
-    } as unknown as ReturnType<typeof useAIStore>);
+    });
   });
 
   it("sets the error and finalizes streaming state on an Error event", () => {

--- a/src/components/features/ai/hooks/__tests__/useAISession.test.ts
+++ b/src/components/features/ai/hooks/__tests__/useAISession.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from "@testing-library/react";
 import { useAISession } from "../useAISession";
 import { useAIStore } from "@/lib/stores/ai-store";
 import { useClusterStore } from "@/lib/stores/cluster-store";
+import type { ExtractState } from "zustand";
 
 // Mock the stores
 jest.mock("@/lib/stores/ai-store");
@@ -9,6 +10,17 @@ jest.mock("@/lib/stores/cluster-store");
 
 const mockUseAIStore = useAIStore as jest.MockedFunction<typeof useAIStore>;
 const mockUseClusterStore = useClusterStore as jest.MockedFunction<typeof useClusterStore>;
+
+type AIState = ExtractState<typeof useAIStore>;
+type ClusterState = ExtractState<typeof useClusterStore>;
+
+const setAIStoreState = (state: Partial<Record<keyof AIState, unknown>>) =>
+  mockUseAIStore.mockImplementation(((selector: (s: AIState) => unknown) =>
+    selector(state as AIState)) as unknown as typeof useAIStore);
+
+const setClusterStoreState = (state: Partial<Record<keyof ClusterState, unknown>>) =>
+  mockUseClusterStore.mockImplementation(((selector: (s: ClusterState) => unknown) =>
+    selector(state as ClusterState)) as unknown as typeof useClusterStore);
 
 describe("useAISession", () => {
   const mockStartSession = jest.fn();
@@ -18,18 +30,18 @@ describe("useAISession", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: false,
       isStreaming: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
 
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: { context: "test-cluster" },
       currentNamespace: "default",
-    } as ReturnType<typeof useClusterStore>);
+    });
   });
 
   it("returns textareaRef", () => {
@@ -44,23 +56,23 @@ describe("useAISession", () => {
   });
 
   it("returns canSend as false when no cluster", () => {
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: null,
       currentNamespace: null,
-    } as ReturnType<typeof useClusterStore>);
+    });
 
     const { result } = renderHook(() => useAISession());
     expect(result.current.canSend).toBe(false);
   });
 
   it("returns canSend as false when streaming", () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       isStreaming: true,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
 
     const { result } = renderHook(() => useAISession());
     expect(result.current.canSend).toBe(false);
@@ -91,13 +103,13 @@ describe("useAISession", () => {
   });
 
   it("handleSend returns false when streaming", async () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       isStreaming: true,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
 
     const { result } = renderHook(() => useAISession());
 
@@ -125,13 +137,13 @@ describe("useAISession", () => {
   });
 
   it("handleSend skips starting session when already active", async () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       isStreaming: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
     mockSendMessage.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useAISession());
@@ -145,13 +157,13 @@ describe("useAISession", () => {
   });
 
   it("handleSend returns true on success", async () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       isStreaming: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
     mockSendMessage.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useAISession());
@@ -165,13 +177,13 @@ describe("useAISession", () => {
   });
 
   it("handleSend sets error and returns false on failure", async () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       isStreaming: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
     mockSendMessage.mockRejectedValue(new Error("Network error"));
 
     const { result } = renderHook(() => useAISession());
@@ -186,13 +198,13 @@ describe("useAISession", () => {
   });
 
   it("handleSend calls onError callback on failure", async () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       isStreaming: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
     mockSendMessage.mockRejectedValue(new Error("Network error"));
 
     const onError = jest.fn();
@@ -206,13 +218,13 @@ describe("useAISession", () => {
   });
 
   it("handleSend trims input message", async () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       isStreaming: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
-    } as ReturnType<typeof useAIStore>);
+    });
     mockSendMessage.mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useAISession());

--- a/src/components/features/ai/hooks/__tests__/usePendingAnalysis.test.ts
+++ b/src/components/features/ai/hooks/__tests__/usePendingAnalysis.test.ts
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { usePendingAnalysis } from "../usePendingAnalysis";
 import { useAIStore } from "@/lib/stores/ai-store";
 import { useClusterStore } from "@/lib/stores/cluster-store";
+import type { ExtractState } from "zustand";
 
 // Mock the stores
 jest.mock("@/lib/stores/ai-store");
@@ -9,6 +10,17 @@ jest.mock("@/lib/stores/cluster-store");
 
 const mockUseAIStore = useAIStore as jest.MockedFunction<typeof useAIStore>;
 const mockUseClusterStore = useClusterStore as jest.MockedFunction<typeof useClusterStore>;
+
+type AIState = ExtractState<typeof useAIStore>;
+type ClusterState = ExtractState<typeof useClusterStore>;
+
+const setAIStoreState = (state: Partial<Record<keyof AIState, unknown>>) =>
+  mockUseAIStore.mockImplementation(((selector: (s: AIState) => unknown) =>
+    selector(state as AIState)) as unknown as typeof useAIStore);
+
+const setClusterStoreState = (state: Partial<Record<keyof ClusterState, unknown>>) =>
+  mockUseClusterStore.mockImplementation(((selector: (s: ClusterState) => unknown) =>
+    selector(state as ClusterState)) as unknown as typeof useClusterStore);
 
 describe("usePendingAnalysis", () => {
   const mockStartSession = jest.fn();
@@ -21,18 +33,18 @@ describe("usePendingAnalysis", () => {
     jest.useFakeTimers();
 
     // Default mock implementations
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
       setError: mockSetError,
       pendingAnalysis: null,
       clearPendingAnalysis: mockClearPendingAnalysis,
-    } as ReturnType<typeof useAIStore>);
+    });
 
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: null,
-    } as ReturnType<typeof useClusterStore>);
+    });
   });
 
   afterEach(() => {
@@ -50,7 +62,7 @@ describe("usePendingAnalysis", () => {
   });
 
   it("does nothing when currentCluster is null", () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
@@ -61,7 +73,7 @@ describe("usePendingAnalysis", () => {
         namespace: "default",
       },
       clearPendingAnalysis: mockClearPendingAnalysis,
-    } as ReturnType<typeof useAIStore>);
+    });
 
     renderHook(() => usePendingAnalysis());
 
@@ -71,7 +83,7 @@ describe("usePendingAnalysis", () => {
   });
 
   it("does nothing when cluster context does not match", () => {
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
@@ -82,11 +94,11 @@ describe("usePendingAnalysis", () => {
         namespace: "default",
       },
       clearPendingAnalysis: mockClearPendingAnalysis,
-    } as ReturnType<typeof useAIStore>);
+    });
 
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: { context: "test-cluster" },
-    } as ReturnType<typeof useClusterStore>);
+    });
 
     renderHook(() => usePendingAnalysis());
 
@@ -99,7 +111,7 @@ describe("usePendingAnalysis", () => {
     mockStartSession.mockResolvedValue(undefined);
     mockSendMessage.mockResolvedValue(undefined);
 
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: false,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
@@ -110,11 +122,11 @@ describe("usePendingAnalysis", () => {
         namespace: "default",
       },
       clearPendingAnalysis: mockClearPendingAnalysis,
-    } as ReturnType<typeof useAIStore>);
+    });
 
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: { context: "test-cluster" },
-    } as ReturnType<typeof useClusterStore>);
+    });
 
     renderHook(() => usePendingAnalysis());
 
@@ -130,7 +142,7 @@ describe("usePendingAnalysis", () => {
   it("skips starting session when already active", async () => {
     mockSendMessage.mockResolvedValue(undefined);
 
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
@@ -141,11 +153,11 @@ describe("usePendingAnalysis", () => {
         namespace: "default",
       },
       clearPendingAnalysis: mockClearPendingAnalysis,
-    } as ReturnType<typeof useAIStore>);
+    });
 
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: { context: "test-cluster" },
-    } as ReturnType<typeof useClusterStore>);
+    });
 
     renderHook(() => usePendingAnalysis());
 
@@ -162,7 +174,7 @@ describe("usePendingAnalysis", () => {
   it("sets error when sendMessage fails", async () => {
     mockSendMessage.mockRejectedValue(new Error("Send failed"));
 
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       isSessionActive: true,
       startSession: mockStartSession,
       sendMessage: mockSendMessage,
@@ -173,11 +185,11 @@ describe("usePendingAnalysis", () => {
         namespace: "default",
       },
       clearPendingAnalysis: mockClearPendingAnalysis,
-    } as ReturnType<typeof useAIStore>);
+    });
 
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: { context: "test-cluster" },
-    } as ReturnType<typeof useClusterStore>);
+    });
 
     renderHook(() => usePendingAnalysis());
 

--- a/src/components/features/ai/hooks/useAIEvents.ts
+++ b/src/components/features/ai/hooks/useAIEvents.ts
@@ -34,15 +34,13 @@ export function useAIEvents(
   callbacks: AIEventsCallbacks,
   i18n: AIEventsI18n
 ) {
-  const {
-    appendMessageChunk,
-    finalizeStreaming,
-    setThinking,
-    setError,
-    addToolCall,
-    setApprovalRequest,
-    markSessionEnded,
-  } = useAIStore();
+  const appendMessageChunk = useAIStore((s) => s.appendMessageChunk);
+  const finalizeStreaming = useAIStore((s) => s.finalizeStreaming);
+  const setThinking = useAIStore((s) => s.setThinking);
+  const setError = useAIStore((s) => s.setError);
+  const addToolCall = useAIStore((s) => s.addToolCall);
+  const setApprovalRequest = useAIStore((s) => s.setApprovalRequest);
+  const markSessionEnded = useAIStore((s) => s.markSessionEnded);
 
   useEffect(() => {
     if (!sessionId) return;

--- a/src/components/features/ai/hooks/useAISession.ts
+++ b/src/components/features/ai/hooks/useAISession.ts
@@ -19,15 +19,14 @@ interface UseAISessionOptions {
 export function useAISession(options: UseAISessionOptions = {}) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const {
-    isSessionActive,
-    isStreaming,
-    startSession,
-    sendMessage,
-    setError,
-  } = useAIStore();
+  const isSessionActive = useAIStore((s) => s.isSessionActive);
+  const isStreaming = useAIStore((s) => s.isStreaming);
+  const startSession = useAIStore((s) => s.startSession);
+  const sendMessage = useAIStore((s) => s.sendMessage);
+  const setError = useAIStore((s) => s.setError);
 
-  const { currentCluster, currentNamespace } = useClusterStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const currentNamespace = useClusterStore((s) => s.currentNamespace);
 
   const handleSend = useCallback(
     async (input: string) => {

--- a/src/components/features/ai/hooks/usePendingAnalysis.ts
+++ b/src/components/features/ai/hooks/usePendingAnalysis.ts
@@ -9,16 +9,14 @@ import { useClusterStore } from "@/lib/stores/cluster-store";
  * Used when user triggers AI analysis from resource context menus.
  */
 export function usePendingAnalysis() {
-  const {
-    isSessionActive,
-    startSession,
-    sendMessage,
-    setError,
-    pendingAnalysis,
-    clearPendingAnalysis,
-  } = useAIStore();
+  const isSessionActive = useAIStore((s) => s.isSessionActive);
+  const startSession = useAIStore((s) => s.startSession);
+  const sendMessage = useAIStore((s) => s.sendMessage);
+  const setError = useAIStore((s) => s.setError);
+  const pendingAnalysis = useAIStore((s) => s.pendingAnalysis);
+  const clearPendingAnalysis = useAIStore((s) => s.clearPendingAnalysis);
 
-  const { currentCluster } = useClusterStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
 
   useEffect(() => {
     if (!pendingAnalysis || !currentCluster) return;

--- a/src/components/features/ai/hooks/useViewContext.ts
+++ b/src/components/features/ai/hooks/useViewContext.ts
@@ -26,9 +26,10 @@ export interface ViewContext {
 }
 
 export function useViewContext(): ViewContext {
-  const { tabs, activeTabId } = useTabsStore();
-  const { logTabs } = useLogStore();
-  const { selectedNamespaces } = useClusterStore();
+  const tabs = useTabsStore((s) => s.tabs);
+  const activeTabId = useTabsStore((s) => s.activeTabId);
+  const logTabs = useLogStore((s) => s.logTabs);
+  const selectedNamespaces = useClusterStore((s) => s.selectedNamespaces);
 
   let selectedResource: ViewContext["selectedResource"] | undefined;
   try {

--- a/src/components/features/dashboard/Dashboard.tsx
+++ b/src/components/features/dashboard/Dashboard.tsx
@@ -96,7 +96,13 @@ function isNotFoundError(error: unknown): boolean {
 function DashboardContent() {
   useDeepLinkNavigation();
   const t = useTranslations();
-  const { tabs: resourceTabs, activeTabId, navigateCurrentTab, openTab, closeTab, setActiveTab, restoreTabs } = useTabsStore();
+  const resourceTabs = useTabsStore((s) => s.tabs);
+  const activeTabId = useTabsStore((s) => s.activeTabId);
+  const navigateCurrentTab = useTabsStore((s) => s.navigateCurrentTab);
+  const openTab = useTabsStore((s) => s.openTab);
+  const closeTab = useTabsStore((s) => s.closeTab);
+  const setActiveTab = useTabsStore((s) => s.setActiveTab);
+  const restoreTabs = useTabsStore((s) => s.restoreTabs);
   const getTabTitle = useTabTitle();
   const activeTab = resourceTabs.find((t) => t.id === activeTabId) || resourceTabs[0];
   const activeResource = activeTab?.type ?? "cluster-overview";
@@ -106,7 +112,9 @@ function DashboardContent() {
     },
     [navigateCurrentTab, getTabTitle]
   );
-  const { isConnected, currentCluster, setCurrentNamespace } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const setCurrentNamespace = useClusterStore((s) => s.setCurrentNamespace);
   const { tabs, isOpen, closePanel } = useTerminalTabs();
   const [selectedResource, setSelectedResource] = useState<{ data: ResourceData; type: string } | null>(null);
   const [navigationHistory, setNavigationHistory] = useState<Array<{ data: ResourceData; type: string }>>([]);
@@ -115,9 +123,18 @@ function DashboardContent() {
   const [uninstallDialog, setUninstallDialog] = useState<UninstallDialogState | null>(null);
   const [scaleDialog, setScaleDialog] = useState<ScaleDialogState | null>(null);
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
-  const { getFavorites, removeFavorite } = useFavoritesStore();
-  const { setSettingsOpen, isAIAssistantOpen, toggleAIAssistant, pendingPodLogs, triggerRefresh, triggerSearchFocus, isCreateResourceOpen, setCreateResourceOpen } = useUIStore();
-  const { isThinking, isStreaming } = useAIStore();
+  const getFavorites = useFavoritesStore((s) => s.getFavorites);
+  const removeFavorite = useFavoritesStore((s) => s.removeFavorite);
+  const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
+  const isAIAssistantOpen = useUIStore((s) => s.isAIAssistantOpen);
+  const toggleAIAssistant = useUIStore((s) => s.toggleAIAssistant);
+  const pendingPodLogs = useUIStore((s) => s.pendingPodLogs);
+  const triggerRefresh = useUIStore((s) => s.triggerRefresh);
+  const triggerSearchFocus = useUIStore((s) => s.triggerSearchFocus);
+  const isCreateResourceOpen = useUIStore((s) => s.isCreateResourceOpen);
+  const setCreateResourceOpen = useUIStore((s) => s.setCreateResourceOpen);
+  const isThinking = useAIStore((s) => s.isThinking);
+  const isStreaming = useAIStore((s) => s.isStreaming);
   const isAIProcessing = isThinking || isStreaming;
   const detailRequestIdRef = useRef(0);
 
@@ -381,7 +398,7 @@ function DashboardContent() {
     }
   };
 
-  const { triggerResourceDeleteRefresh } = useUIStore();
+  const triggerResourceDeleteRefresh = useUIStore((s) => s.triggerResourceDeleteRefresh);
 
   const handleDeleteResource = async () => {
     if (!selectedResource) return;

--- a/src/components/features/dashboard/views/ClusterOverview.tsx
+++ b/src/components/features/dashboard/views/ClusterOverview.tsx
@@ -18,7 +18,7 @@ import { MetricsProgressBar } from "../components/MetricsProgressBar";
 
 export function ClusterOverview() {
   const t = useTranslations();
-  const { currentCluster } = useClusterStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
   const { data: pods } = usePods();
   const { data: deployments } = useDeployments();
   const { data: services } = useServices();

--- a/src/components/features/dashboard/views/WorkloadsOverview.tsx
+++ b/src/components/features/dashboard/views/WorkloadsOverview.tsx
@@ -18,7 +18,7 @@ import { StatusRow } from "../components/StatusRow";
 
 export function WorkloadsOverview() {
   const t = useTranslations("workloads");
-  const { currentNamespace } = useClusterStore();
+  const currentNamespace = useClusterStore((s) => s.currentNamespace);
   const { data: pods } = usePods();
   const { data: deployments } = useDeployments();
   const { data: replicaSets } = useReplicaSets();

--- a/src/components/features/dashboard/views/networking/ServicesView.tsx
+++ b/src/components/features/dashboard/views/networking/ServicesView.tsx
@@ -32,8 +32,10 @@ export function ServicesView() {
   const { openResourceDetail, handleDeleteFromContext } = useResourceDetail();
   const [sortKey, setSortKey] = useState<string | null>("created_at");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-  const { currentCluster } = useClusterStore();
-  const { addFavorite, removeFavorite, isFavorite } = useFavoritesStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const addFavorite = useFavoritesStore((s) => s.addFavorite);
+  const removeFavorite = useFavoritesStore((s) => s.removeFavorite);
+  const isFavorite = useFavoritesStore((s) => s.isFavorite);
   const clusterContext = currentCluster?.context || "";
 
   // Refresh when a resource is deleted from detail panel

--- a/src/components/features/dashboard/views/workloads/DeploymentsView.tsx
+++ b/src/components/features/dashboard/views/workloads/DeploymentsView.tsx
@@ -30,8 +30,10 @@ export function DeploymentsView() {
   const openOrActivateTab = useTabsStore((s) => s.openOrActivateTab);
   const [sortKey, setSortKey] = useState<string | null>("created_at");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-  const { currentCluster } = useClusterStore();
-  const { addFavorite, removeFavorite, isFavorite } = useFavoritesStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const addFavorite = useFavoritesStore((s) => s.addFavorite);
+  const removeFavorite = useFavoritesStore((s) => s.removeFavorite);
+  const isFavorite = useFavoritesStore((s) => s.isFavorite);
   const clusterContext = currentCluster?.context || "";
 
   // Refresh when a resource is deleted from detail panel

--- a/src/components/features/dashboard/views/workloads/PodsView.tsx
+++ b/src/components/features/dashboard/views/workloads/PodsView.tsx
@@ -86,9 +86,12 @@ export function PodsView() {
   };
   const [sortKey, setSortKey] = useState<string | null>("created_at");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-  const { currentCluster } = useClusterStore();
-  const { addFavorite, removeFavorite, isFavorite } = useFavoritesStore();
-  const { pendingPodLogs, setPendingPodLogs } = useUIStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const addFavorite = useFavoritesStore((s) => s.addFavorite);
+  const removeFavorite = useFavoritesStore((s) => s.removeFavorite);
+  const isFavorite = useFavoritesStore((s) => s.isFavorite);
+  const pendingPodLogs = useUIStore((s) => s.pendingPodLogs);
+  const setPendingPodLogs = useUIStore((s) => s.setPendingPodLogs);
   const clusterContext = currentCluster?.context || "";
 
   // Refresh when a resource is deleted from detail panel (only if not watching)

--- a/src/components/features/home/components/ClusterGrid.tsx
+++ b/src/components/features/home/components/ClusterGrid.tsx
@@ -41,19 +41,17 @@ export function ClusterGrid() {
   const updateSettings = useUIStore((s) => s.updateSettings);
   const openSettingsTab = useUIStore((s) => s.openSettingsTab);
 
-  const {
-    clusters,
-    currentCluster,
-    isConnected,
-    isLoading,
-    hasFetchedClusters,
-    fetchClusters,
-    connect,
-    oidcPendingContext,
-    cancelConnect,
-    saveAccessibleNamespaces,
-    clearAccessibleNamespaces,
-  } = useClusterStore();
+  const clusters = useClusterStore((s) => s.clusters);
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const isLoading = useClusterStore((s) => s.isLoading);
+  const hasFetchedClusters = useClusterStore((s) => s.hasFetchedClusters);
+  const fetchClusters = useClusterStore((s) => s.fetchClusters);
+  const connect = useClusterStore((s) => s.connect);
+  const oidcPendingContext = useClusterStore((s) => s.oidcPendingContext);
+  const cancelConnect = useClusterStore((s) => s.cancelConnect);
+  const saveAccessibleNamespaces = useClusterStore((s) => s.saveAccessibleNamespaces);
+  const clearAccessibleNamespaces = useClusterStore((s) => s.clearAccessibleNamespaces);
   const { forwards } = usePortForward();
 
   // Configure namespaces dialog state

--- a/src/components/features/home/components/ConnectionErrorAlert.tsx
+++ b/src/components/features/home/components/ConnectionErrorAlert.tsx
@@ -15,14 +15,12 @@ export function ConnectionErrorAlert() {
   const tc = useTranslations("cluster");
   const [isDownloading, setIsDownloading] = useState(false);
 
-  const {
-    error,
-    lastConnectionErrorContext,
-    lastConnectionErrorMessage,
-    oidcTimedOutContext,
-    setError,
-    fallbackToKubeconfigAuth,
-  } = useClusterStore();
+  const error = useClusterStore((s) => s.error);
+  const lastConnectionErrorContext = useClusterStore((s) => s.lastConnectionErrorContext);
+  const lastConnectionErrorMessage = useClusterStore((s) => s.lastConnectionErrorMessage);
+  const oidcTimedOutContext = useClusterStore((s) => s.oidcTimedOutContext);
+  const setError = useClusterStore((s) => s.setError);
+  const fallbackToKubeconfigAuth = useClusterStore((s) => s.fallbackToKubeconfigAuth);
 
   const canDownloadDebugLog = Boolean(
     error &&

--- a/src/components/features/home/components/HomeTitlebar.tsx
+++ b/src/components/features/home/components/HomeTitlebar.tsx
@@ -6,7 +6,7 @@ import { useUpdater } from "@/lib/hooks/useUpdater";
 
 export function HomeTitlebar() {
   const tu = useTranslations("updates");
-  const { setSettingsOpen } = useUIStore();
+  const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
   const {
     available,
     update,

--- a/src/components/features/logs/LogViewer.tsx
+++ b/src/components/features/logs/LogViewer.tsx
@@ -122,9 +122,10 @@ export function LogViewer({ namespace, podName, initialContainer, logTabId, onOp
   });
 
   // Send selected log text to AI
-  const { setPendingAnalysis } = useAIStore();
-  const { currentCluster, currentNamespace } = useClusterStore();
-  const { setAIAssistantOpen } = useUIStore();
+  const setPendingAnalysis = useAIStore((s) => s.setPendingAnalysis);
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const currentNamespace = useClusterStore((s) => s.currentNamespace);
+  const setAIAssistantOpen = useUIStore((s) => s.setAIAssistantOpen);
 
   const handleSendSelectionToAI = useCallback(
     (selectedText: string) => {

--- a/src/components/features/logs/hooks/__tests__/useLogAnalysis.test.ts
+++ b/src/components/features/logs/hooks/__tests__/useLogAnalysis.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useLogAnalysis } from "../useLogAnalysis";
 import type { LogEntry } from "@/lib/types";
+import type { ExtractState } from "zustand";
 
 // Mock stores
 jest.mock("@/lib/stores/ai-store", () => ({
@@ -31,6 +32,22 @@ const mockUseClusterStore = useClusterStore as jest.MockedFunction<typeof useClu
 const mockUseUIStore = useUIStore as jest.MockedFunction<typeof useUIStore>;
 const mockAiCheckCliAvailable = aiCheckCliAvailable as jest.MockedFunction<typeof aiCheckCliAvailable>;
 const mockAiCheckCodexCliAvailable = aiCheckCodexCliAvailable as jest.MockedFunction<typeof aiCheckCodexCliAvailable>;
+
+type AIState = ExtractState<typeof useAIStore>;
+type ClusterState = ExtractState<typeof useClusterStore>;
+type UIState = ExtractState<typeof useUIStore>;
+
+const setAIStoreState = (state: Partial<Record<keyof AIState, unknown>>) =>
+  mockUseAIStore.mockImplementation(((selector: (s: AIState) => unknown) =>
+    selector(state as AIState)) as unknown as typeof useAIStore);
+
+const setClusterStoreState = (state: Partial<Record<keyof ClusterState, unknown>>) =>
+  mockUseClusterStore.mockImplementation(((selector: (s: ClusterState) => unknown) =>
+    selector(state as ClusterState)) as unknown as typeof useClusterStore);
+
+const setUIStoreState = (state: Partial<Record<keyof UIState, unknown>>) =>
+  mockUseUIStore.mockImplementation(((selector: (s: UIState) => unknown) =>
+    selector(state as UIState)) as unknown as typeof useUIStore);
 
 const createLogEntry = (message: string, timestamp: string): LogEntry => ({
   message,
@@ -70,18 +87,18 @@ describe("useLogAnalysis", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseAIStore.mockReturnValue({
+    setAIStoreState({
       setPendingAnalysis: mockSetPendingAnalysis,
-    } as unknown as ReturnType<typeof useAIStore>);
+    });
 
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: { context: "test-cluster" },
       currentNamespace: "default",
-    } as unknown as ReturnType<typeof useClusterStore>);
+    });
 
-    mockUseUIStore.mockReturnValue({
+    setUIStoreState({
       setAIAssistantOpen: mockSetAIAssistantOpen,
-    } as unknown as ReturnType<typeof useUIStore>);
+    });
 
     // Default: CLI available
     mockAiCheckCliAvailable.mockResolvedValue(createCliInfo("authenticated"));
@@ -161,10 +178,10 @@ describe("useLogAnalysis", () => {
   });
 
   it("analyzeWithAI does nothing when no cluster", async () => {
-    mockUseClusterStore.mockReturnValue({
+    setClusterStoreState({
       currentCluster: null,
       currentNamespace: null,
-    } as unknown as ReturnType<typeof useClusterStore>);
+    });
 
     const { result } = renderHook(() => useLogAnalysis(defaultOptions));
 

--- a/src/components/features/logs/hooks/useLogAnalysis.ts
+++ b/src/components/features/logs/hooks/useLogAnalysis.ts
@@ -37,9 +37,10 @@ export function useLogAnalysis({
 }: UseLogAnalysisOptions): UseLogAnalysisReturn {
   const [isAICliAvailable, setIsAICliAvailable] = useState<boolean | null>(null);
 
-  const { setPendingAnalysis } = useAIStore();
-  const { currentCluster, currentNamespace } = useClusterStore();
-  const { setAIAssistantOpen } = useUIStore();
+  const setPendingAnalysis = useAIStore((s) => s.setPendingAnalysis);
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const currentNamespace = useClusterStore((s) => s.currentNamespace);
+  const setAIAssistantOpen = useUIStore((s) => s.setAIAssistantOpen);
 
   // Check AI CLI availability on mount
   useEffect(() => {

--- a/src/components/features/portforward/PortForwardDialogs.tsx
+++ b/src/components/features/portforward/PortForwardDialogs.tsx
@@ -23,8 +23,10 @@ const PORT_MAX = 65535;
 function ForwardPortContent() {
   const t = useTranslations("portForward");
   const tc = useTranslations("common");
-  const { pendingForwardRequest, confirmForward, dismissForwardDialog, checkPort } =
-    usePortForwardStore();
+  const pendingForwardRequest = usePortForwardStore((s) => s.pendingForwardRequest);
+  const confirmForward = usePortForwardStore((s) => s.confirmForward);
+  const dismissForwardDialog = usePortForwardStore((s) => s.dismissForwardDialog);
+  const checkPort = usePortForwardStore((s) => s.checkPort);
   const [localPortValue, setLocalPortValue] = useState("");
   const [portError, setPortError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -156,8 +158,9 @@ function ForwardPortContent() {
 
 function BrowserOpenContent() {
   const t = useTranslations("portForward");
-  const { pendingBrowserOpen, confirmOpenBrowser, dismissBrowserDialog } =
-    usePortForwardStore();
+  const pendingBrowserOpen = usePortForwardStore((s) => s.pendingBrowserOpen);
+  const confirmOpenBrowser = usePortForwardStore((s) => s.confirmOpenBrowser);
+  const dismissBrowserDialog = usePortForwardStore((s) => s.dismissBrowserDialog);
   const [rememberChoice, setRememberChoice] = useState(false);
 
   if (!pendingBrowserOpen) {

--- a/src/components/features/resources/CreateResourcePanel.tsx
+++ b/src/components/features/resources/CreateResourcePanel.tsx
@@ -44,7 +44,8 @@ interface CreateResourcePanelProps {
 export function CreateResourcePanel({ onClose, onApplied }: CreateResourcePanelProps) {
   const t = useTranslations("createResource");
   const tCommon = useTranslations("common");
-  const { resolvedTheme, settings } = useUIStore();
+  const resolvedTheme = useUIStore((s) => s.resolvedTheme);
+  const settings = useUIStore((s) => s.settings);
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
   const validationDispose = useRef<(() => void) | null>(null);

--- a/src/components/features/resources/components/PodMetricsSection.tsx
+++ b/src/components/features/resources/components/PodMetricsSection.tsx
@@ -28,7 +28,7 @@ function SectionHeader({ title }: { title: string }) {
 
 export function PodMetricsSection({ podName, namespace }: PodMetricsSectionProps) {
   const t = useTranslations();
-  const { isConnected } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
   const { available: metricsAvailable } = useMetricsAvailability();
   const { history } = useMetricsHistory(podName, namespace);
   const sectionTitle = t("resourceDetail.metrics");

--- a/src/components/features/resources/components/YamlTab.tsx
+++ b/src/components/features/resources/components/YamlTab.tsx
@@ -56,7 +56,7 @@ export const YamlTab = forwardRef<YamlTabHandle, YamlTabProps>(function YamlTab(
   resourceKey,
 }: YamlTabProps, ref: Ref<YamlTabHandle>) {
   const t = useTranslations();
-  const { resolvedTheme } = useUIStore();
+  const resolvedTheme = useUIStore((s) => s.resolvedTheme);
   const { modKeySymbol } = usePlatform();
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);

--- a/src/components/features/settings/SettingsPanel.tsx
+++ b/src/components/features/settings/SettingsPanel.tsx
@@ -25,7 +25,9 @@ import {
 
 export function SettingsPanel() {
   const t = useTranslations("settings");
-  const { isSettingsOpen, setSettingsOpen, settingsInitialTab } = useUIStore();
+  const isSettingsOpen = useUIStore((s) => s.isSettingsOpen);
+  const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
+  const settingsInitialTab = useUIStore((s) => s.settingsInitialTab);
   const [activeTab, setActiveTab] = useState("appearance");
   const [appVersion, setAppVersion] = useState<string>("0.1.0");
 

--- a/src/components/features/settings/components/AdvancedTab.tsx
+++ b/src/components/features/settings/components/AdvancedTab.tsx
@@ -31,7 +31,9 @@ interface AdvancedTabProps {
 export function AdvancedTab({ appVersion }: AdvancedTabProps) {
   const t = useTranslations("settings");
   const tc = useTranslations("common");
-  const { settings, updateSettings, resetSettings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const updateSettings = useUIStore((s) => s.updateSettings);
+  const resetSettings = useUIStore((s) => s.resetSettings);
   const { available, isDev, simulateUpdate, clearSimulation } = useUpdater();
 
   return (

--- a/src/components/features/settings/components/AiTab.tsx
+++ b/src/components/features/settings/components/AiTab.tsx
@@ -26,7 +26,8 @@ interface AiTabProps {
 export function AiTab({ aiCli }: AiTabProps) {
   const t = useTranslations("settings");
   const tc = useTranslations("common");
-  const { settings, updateSettings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const updateSettings = useUIStore((s) => s.updateSettings);
   const { isWindows } = usePlatform();
 
   const cliTranslations = {

--- a/src/components/features/settings/components/AppearanceTab.tsx
+++ b/src/components/features/settings/components/AppearanceTab.tsx
@@ -21,7 +21,10 @@ import { ThemeSelector } from "./ThemeSelector";
 
 export function AppearanceTab() {
   const t = useTranslations("settings");
-  const { settings, setTheme, setLocale, updateSettings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const setTheme = useUIStore((s) => s.setTheme);
+  const setLocale = useUIStore((s) => s.setLocale);
+  const updateSettings = useUIStore((s) => s.updateSettings);
 
   const vibrancyLevel = useMemo((): VibrancyLevel => {
     const validLevels: VibrancyLevel[] = ["off", "standard", "more", "extra"];

--- a/src/components/features/settings/components/GeneralTab.tsx
+++ b/src/components/features/settings/components/GeneralTab.tsx
@@ -14,7 +14,8 @@ import { SettingSection } from "./SettingSection";
 
 export function GeneralTab() {
   const t = useTranslations("settings");
-  const { settings, updateSettings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const updateSettings = useUIStore((s) => s.updateSettings);
 
   return (
     <div className="space-y-6">

--- a/src/components/features/settings/components/LogsTab.tsx
+++ b/src/components/features/settings/components/LogsTab.tsx
@@ -13,7 +13,8 @@ import { SettingSection } from "./SettingSection";
 
 export function LogsTab() {
   const t = useTranslations("settings");
-  const { settings, updateSettings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const updateSettings = useUIStore((s) => s.updateSettings);
 
   return (
     <div className="space-y-6">

--- a/src/components/features/settings/components/NetworkTab.tsx
+++ b/src/components/features/settings/components/NetworkTab.tsx
@@ -17,7 +17,8 @@ import { SettingSection } from "./SettingSection";
 export function NetworkTab() {
   const t = useTranslations("settings");
   const tc = useTranslations("common");
-  const { settings, updateSettings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const updateSettings = useUIStore((s) => s.updateSettings);
   const skippedInitialApply = useRef(false);
 
   // Push proxy changes to the backend (debounced); startup re-apply happens in App.tsx.

--- a/src/components/features/settings/hooks/useAiCli.ts
+++ b/src/components/features/settings/hooks/useAiCli.ts
@@ -18,7 +18,8 @@ const errorInfo = (err: unknown): CliInfo => ({
 });
 
 export function useAiCli(isOpen: boolean) {
-  const { settings, updateSettings } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const updateSettings = useUIStore((s) => s.updateSettings);
   const [claudeCliInfo, setClaudeCliInfo] = useState<CliInfo | null>(null);
   const [codexCliInfo, setCodexCliInfo] = useState<CliInfo | null>(null);
   const [opencodeCliInfo, setOpencodeCliInfo] = useState<CliInfo | null>(null);

--- a/src/components/features/visualization/ResourceDiagram.tsx
+++ b/src/components/features/visualization/ResourceDiagram.tsx
@@ -51,17 +51,15 @@ const nodeTypes = {
 } as const;
 
 function ResourceDiagramInner() {
-  const { isConnected } = useClusterStore();
-  const { resolvedTheme } = useUIStore();
-  const {
-    nodes: storeNodes,
-    edges: storeEdges,
-    isLoading,
-    error,
-    selectedNodeId,
-    setSelectedNode,
-    setSearchQuery,
-  } = useDiagramStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const resolvedTheme = useUIStore((s) => s.resolvedTheme);
+  const storeNodes = useDiagramStore((s) => s.nodes);
+  const storeEdges = useDiagramStore((s) => s.edges);
+  const isLoading = useDiagramStore((s) => s.isLoading);
+  const error = useDiagramStore((s) => s.error);
+  const selectedNodeId = useDiagramStore((s) => s.selectedNodeId);
+  const setSelectedNode = useDiagramStore((s) => s.setSelectedNode);
+  const setSearchQuery = useDiagramStore((s) => s.setSearchQuery);
 
   const colorMode = resolvedTheme === "light" ? "light" : "dark";
 

--- a/src/components/features/visualization/useDiagramLayout.ts
+++ b/src/components/features/visualization/useDiagramLayout.ts
@@ -25,18 +25,17 @@ const DEFAULT_EXTENT: [[number, number], [number, number]] = [
 export function useDiagramLayout(
   setNodes: (nodes: Node<FlowNodeData>[]) => void,
 ) {
-  const { selectedNamespaces, isConnected } = useClusterStore();
-  const {
-    nodes: storeNodes,
-    edges: storeEdges,
-    lodLevel,
-    selectedNodeId,
-    highlightedNodeIds,
-    visibleNodeTypes,
-    fetchGraph,
-    setNodePositionsAndSizes,
-    setLODLevel,
-  } = useDiagramStore();
+  const selectedNamespaces = useClusterStore((s) => s.selectedNamespaces);
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const storeNodes = useDiagramStore((s) => s.nodes);
+  const storeEdges = useDiagramStore((s) => s.edges);
+  const lodLevel = useDiagramStore((s) => s.lodLevel);
+  const selectedNodeId = useDiagramStore((s) => s.selectedNodeId);
+  const highlightedNodeIds = useDiagramStore((s) => s.highlightedNodeIds);
+  const visibleNodeTypes = useDiagramStore((s) => s.visibleNodeTypes);
+  const fetchGraph = useDiagramStore((s) => s.fetchGraph);
+  const setNodePositionsAndSizes = useDiagramStore((s) => s.setNodePositionsAndSizes);
+  const setLODLevel = useDiagramStore((s) => s.setLODLevel);
 
   const { calculatePositions, isCalculating } = useLayout();
 

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -52,30 +52,29 @@ export function Sidebar({
   const tNav = useTranslations("navigation");
   const tCluster = useTranslations("cluster");
 
-  const {
-    currentCluster,
-    selectedNamespaces,
-    namespaces,
-    namespaceSource,
-    toggleNamespace,
-    selectAllNamespaces,
-    isConnected,
-    disconnect,
-    latencyMs,
-    isReconnecting,
-    reconnectAttempts,
-    isHealthy,
-    saveAccessibleNamespaces,
-    clearAccessibleNamespaces,
-  } = useClusterStore();
+  const currentCluster = useClusterStore((s) => s.currentCluster);
+  const selectedNamespaces = useClusterStore((s) => s.selectedNamespaces);
+  const namespaces = useClusterStore((s) => s.namespaces);
+  const namespaceSource = useClusterStore((s) => s.namespaceSource);
+  const toggleNamespace = useClusterStore((s) => s.toggleNamespace);
+  const selectAllNamespaces = useClusterStore((s) => s.selectAllNamespaces);
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const disconnect = useClusterStore((s) => s.disconnect);
+  const latencyMs = useClusterStore((s) => s.latencyMs);
+  const isReconnecting = useClusterStore((s) => s.isReconnecting);
+  const reconnectAttempts = useClusterStore((s) => s.reconnectAttempts);
+  const isHealthy = useClusterStore((s) => s.isHealthy);
+  const saveAccessibleNamespaces = useClusterStore((s) => s.saveAccessibleNamespaces);
+  const clearAccessibleNamespaces = useClusterStore((s) => s.clearAccessibleNamespaces);
 
   const [configureNsOpen, setConfigureNsOpen] = useState(false);
   const handleConfigureNamespaces = useCallback(() => setConfigureNsOpen(true), []);
 
-  const { setSettingsOpen } = useUIStore();
+  const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
   const { forwards, stopForward } = usePortForward();
-  const { getFavorites, removeFavorite, getRecentResources } =
-    useFavoritesStore();
+  const getFavorites = useFavoritesStore((s) => s.getFavorites);
+  const removeFavorite = useFavoritesStore((s) => s.removeFavorite);
+  const getRecentResources = useFavoritesStore((s) => s.getRecentResources);
   const {
     namespaceOpen,
     setNamespaceOpen,

--- a/src/components/layout/tabbar/TabBar.tsx
+++ b/src/components/layout/tabbar/TabBar.tsx
@@ -30,8 +30,12 @@ import { useTabTitle } from "./hooks/useTabTitle";
 export { useTabTitle };
 
 export function TabBar() {
-  const { tabs, activeTabId, setActiveTab, closeTab, openTab, reorderTabs } =
-    useTabsStore();
+  const tabs = useTabsStore((s) => s.tabs);
+  const activeTabId = useTabsStore((s) => s.activeTabId);
+  const setActiveTab = useTabsStore((s) => s.setActiveTab);
+  const closeTab = useTabsStore((s) => s.closeTab);
+  const openTab = useTabsStore((s) => s.openTab);
+  const reorderTabs = useTabsStore((s) => s.reorderTabs);
   const scrollRef = useRef<HTMLDivElement>(null);
   const t = useTranslations("tabs");
   const getTabTitle = useTabTitle();

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -5,7 +5,11 @@ import { useUIStore } from "@/lib/stores/ui-store";
 import { usePlatform } from "@/lib/hooks/usePlatform";
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const { settings, resolvedTheme, setResolvedTheme, setSettingsOpen, isSettingsOpen } = useUIStore();
+  const settings = useUIStore((s) => s.settings);
+  const resolvedTheme = useUIStore((s) => s.resolvedTheme);
+  const setResolvedTheme = useUIStore((s) => s.setResolvedTheme);
+  const setSettingsOpen = useUIStore((s) => s.setSettingsOpen);
+  const isSettingsOpen = useUIStore((s) => s.isSettingsOpen);
   const { platform } = usePlatform();
 
   // Global keyboard shortcuts

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -11,7 +11,7 @@ import { useUIStore } from "@/lib/stores/ui-store"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { resolvedTheme } = useUIStore()
+  const resolvedTheme = useUIStore((s) => s.resolvedTheme)
 
   return (
     <Sonner

--- a/src/lib/hooks/k8s/resources/extensions.ts
+++ b/src/lib/hooks/k8s/resources/extensions.ts
@@ -54,12 +54,10 @@ export function useCustomResources(
   definition: CustomResourceDefinitionRef,
   options: UseK8sResourcesOptions = {}
 ): UseK8sResourcesReturn<CustomResourceInfo> {
-  const {
-    isConnected,
-    selectedNamespaces,
-    namespaceSource,
-    namespaces: configuredNamespaces,
-  } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const selectedNamespaces = useClusterStore((s) => s.selectedNamespaces);
+  const namespaceSource = useClusterStore((s) => s.namespaceSource);
+  const configuredNamespaces = useClusterStore((s) => s.namespaces);
   const namespace =
     options.namespace ?? (selectedNamespaces.length === 1 ? selectedNamespaces[0] : "");
   const isMultiNs = !options.namespace && selectedNamespaces.length > 1;
@@ -68,7 +66,8 @@ export function useCustomResources(
     !options.namespace &&
     selectedNamespaces.length === 0;
   const displayName = `Custom Resources:${definition.group}:${definition.kind}`;
-  const { getCache, setCache } = useResourceCacheStore();
+  const getCache = useResourceCacheStore((s) => s.getCache);
+  const setCache = useResourceCacheStore((s) => s.setCache);
   const cacheKey = `${displayName}:${options.namespace ?? (isConfiguredAllNs
     ? `configured:${configuredNamespaces.slice().sort().join(",")}`
     : isMultiNs

--- a/src/lib/hooks/k8s/useClusterScoped.ts
+++ b/src/lib/hooks/k8s/useClusterScoped.ts
@@ -15,8 +15,9 @@ export function useClusterScopedResource<T>(
   listFn: () => Promise<T[]>,
   options: UseK8sResourcesOptions = {}
 ): UseK8sResourcesReturn<T> {
-  const { isConnected } = useClusterStore();
-  const { getCache, setCache } = useResourceCacheStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const getCache = useResourceCacheStore((s) => s.getCache);
+  const setCache = useResourceCacheStore((s) => s.setCache);
   const cacheKey = `${displayName}:`;
 
   const [data, setData] = useState<T[]>(() => getCache<T>(cacheKey));
@@ -36,7 +37,7 @@ export function useClusterScopedResource<T>(
     } finally {
       setIsLoading(false);
     }
-  }, [isConnected, listFn, displayName, cacheKey, setCache]);
+  }, [isConnected, listFn, cacheKey, setCache]);
 
   useEffect(() => {
     if (isConnected) {

--- a/src/lib/hooks/k8s/useK8sResource.ts
+++ b/src/lib/hooks/k8s/useK8sResource.ts
@@ -20,11 +20,15 @@ export function useK8sResource<T>(
   config: ResourceHookConfig<T>,
   options: UseK8sResourcesOptions = {}
 ): UseK8sResourcesReturn<T> {
-  const { isConnected, selectedNamespaces, namespaceSource, namespaces: configuredNamespaces } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const selectedNamespaces = useClusterStore((s) => s.selectedNamespaces);
+  const namespaceSource = useClusterStore((s) => s.namespaceSource);
+  const configuredNamespaces = useClusterStore((s) => s.namespaces);
   const isMultiNs = !options.namespace && selectedNamespaces.length > 1;
   const isConfiguredAllNs = namespaceSource === "configured" && !options.namespace && selectedNamespaces.length === 0;
   const namespace = options.namespace ?? (selectedNamespaces.length === 1 ? selectedNamespaces[0] : "");
-  const { getCache, setCache } = useResourceCacheStore();
+  const getCache = useResourceCacheStore((s) => s.getCache);
+  const setCache = useResourceCacheStore((s) => s.setCache);
   const cacheKey = `${config.displayName}:${options.namespace ?? (isConfiguredAllNs ? `configured:${configuredNamespaces.slice().sort().join(",")}` : isMultiNs ? selectedNamespaces.slice().sort().join(",") : namespace)}`;
 
   const [data, setData] = useState<T[]>(() => getCache<T>(cacheKey));

--- a/src/lib/hooks/k8s/useOptionalNamespace.ts
+++ b/src/lib/hooks/k8s/useOptionalNamespace.ts
@@ -16,11 +16,15 @@ export function useOptionalNamespaceResource<T>(
   listFn: (namespace?: string) => Promise<T[]>,
   options: UseK8sResourcesOptions = {}
 ): UseK8sResourcesReturn<T> {
-  const { isConnected, selectedNamespaces, namespaceSource, namespaces: configuredNamespaces } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const selectedNamespaces = useClusterStore((s) => s.selectedNamespaces);
+  const namespaceSource = useClusterStore((s) => s.namespaceSource);
+  const configuredNamespaces = useClusterStore((s) => s.namespaces);
   const isMultiNs = !options.namespace && selectedNamespaces.length > 1;
   const isConfiguredAllNs = namespaceSource === "configured" && !options.namespace && selectedNamespaces.length === 0;
   const namespace = options.namespace ?? (selectedNamespaces.length === 1 ? selectedNamespaces[0] : "");
-  const { getCache, setCache } = useResourceCacheStore();
+  const getCache = useResourceCacheStore((s) => s.getCache);
+  const setCache = useResourceCacheStore((s) => s.setCache);
   const cacheKey = `${displayName}:${options.namespace ?? (isConfiguredAllNs ? `configured:${configuredNamespaces.slice().sort().join(",")}` : isMultiNs ? selectedNamespaces.slice().sort().join(",") : namespace)}`;
 
   const [data, setData] = useState<T[]>(() => getCache<T>(cacheKey));

--- a/src/lib/hooks/useMetrics.ts
+++ b/src/lib/hooks/useMetrics.ts
@@ -49,7 +49,7 @@ export function useClusterMetrics(options: UseMetricsOptions = {}): UseClusterMe
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [metricsAvailable, setMetricsAvailable] = useState(false);
-  const { isConnected } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
@@ -96,7 +96,7 @@ export function useNodeMetrics(options: UseMetricsOptions = {}): UseNodeMetricsR
   const [data, setData] = useState<NodeMetrics[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { isConnected } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
@@ -139,7 +139,8 @@ export function usePodMetrics(
   const [data, setData] = useState<PodMetrics[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { isConnected, currentNamespace } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
+  const currentNamespace = useClusterStore((s) => s.currentNamespace);
   const ns = namespace ?? currentNamespace;
   const pollCount = useRef(0);
   /** Track whether kubelet direct endpoint is available */
@@ -212,7 +213,7 @@ export function usePodMetrics(
 export function useMetricsAvailability(): { available: boolean; checking: boolean } {
   const [available, setAvailable] = useState(false);
   const [checking, setChecking] = useState(true);
-  const { isConnected } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
 
   useEffect(() => {
     if (!isConnected) {

--- a/src/lib/hooks/useMetricsHistory.ts
+++ b/src/lib/hooks/useMetricsHistory.ts
@@ -92,7 +92,7 @@ export function useMetricsHistory(
   podName: string,
   namespace: string,
 ): MetricsHistoryResult {
-  const { isConnected } = useClusterStore();
+  const isConnected = useClusterStore((s) => s.isConnected);
   const key = `${namespace}/${podName}`;
   const [history, setHistory] = useState<MetricsSnapshot[]>(() => [...getHistory(key)]);
   const [polled, setPolled] = useState(() => getHistory(key).length > 0);

--- a/src/lib/hooks/usePortForward.ts
+++ b/src/lib/hooks/usePortForward.ts
@@ -13,20 +13,18 @@ export interface UsePortForwardOptions {
 
  
 export function usePortForward(_options?: UsePortForwardOptions) {
-  const {
-    forwards,
-    isLoading,
-    error,
-    initialize,
-    startForward,
-    stopForward,
-    stopAllForwards,
-    checkPort,
-    getForward,
-    refreshForwards,
-    requestForward,
-    dismissForwardDialog,
-  } = usePortForwardStore();
+  const forwards = usePortForwardStore((s) => s.forwards);
+  const isLoading = usePortForwardStore((s) => s.isLoading);
+  const error = usePortForwardStore((s) => s.error);
+  const initialize = usePortForwardStore((s) => s.initialize);
+  const startForward = usePortForwardStore((s) => s.startForward);
+  const stopForward = usePortForwardStore((s) => s.stopForward);
+  const stopAllForwards = usePortForwardStore((s) => s.stopAllForwards);
+  const checkPort = usePortForwardStore((s) => s.checkPort);
+  const getForward = usePortForwardStore((s) => s.getForward);
+  const refreshForwards = usePortForwardStore((s) => s.refreshForwards);
+  const requestForward = usePortForwardStore((s) => s.requestForward);
+  const dismissForwardDialog = usePortForwardStore((s) => s.dismissForwardDialog);
 
   // Initialize only once across all hook instances
   useEffect(() => {

--- a/src/lib/hooks/useUpdater.tsx
+++ b/src/lib/hooks/useUpdater.tsx
@@ -46,29 +46,27 @@ export function useUpdater(options: UseUpdaterOptions = {}) {
   }
   const toastStrings = toastStringsRef.current;
 
-  const {
-    checking,
-    available,
-    downloading,
-    progress,
-    error,
-    update,
-    isSimulated,
-    readyToRestart,
-    downloadComplete,
-    checkerDismissed,
-    setChecking,
-    setAvailable,
-    setDownloading,
-    setProgress,
-    setError,
-    setReadyToRestart,
-    setDownloadComplete,
-    setCheckerDismissed,
-    setHasAutoChecked,
-    simulateUpdate,
-    clearSimulation,
-  } = useUpdaterStore();
+  const checking = useUpdaterStore((s) => s.checking);
+  const available = useUpdaterStore((s) => s.available);
+  const downloading = useUpdaterStore((s) => s.downloading);
+  const progress = useUpdaterStore((s) => s.progress);
+  const error = useUpdaterStore((s) => s.error);
+  const update = useUpdaterStore((s) => s.update);
+  const isSimulated = useUpdaterStore((s) => s.isSimulated);
+  const readyToRestart = useUpdaterStore((s) => s.readyToRestart);
+  const downloadComplete = useUpdaterStore((s) => s.downloadComplete);
+  const checkerDismissed = useUpdaterStore((s) => s.checkerDismissed);
+  const setChecking = useUpdaterStore((s) => s.setChecking);
+  const setAvailable = useUpdaterStore((s) => s.setAvailable);
+  const setDownloading = useUpdaterStore((s) => s.setDownloading);
+  const setProgress = useUpdaterStore((s) => s.setProgress);
+  const setError = useUpdaterStore((s) => s.setError);
+  const setReadyToRestart = useUpdaterStore((s) => s.setReadyToRestart);
+  const setDownloadComplete = useUpdaterStore((s) => s.setDownloadComplete);
+  const setCheckerDismissed = useUpdaterStore((s) => s.setCheckerDismissed);
+  const setHasAutoChecked = useUpdaterStore((s) => s.setHasAutoChecked);
+  const simulateUpdate = useUpdaterStore((s) => s.simulateUpdate);
+  const clearSimulation = useUpdaterStore((s) => s.clearSimulation);
   const isTauriReady = useCallback(() => {
     if (typeof window === "undefined") return false;
     return "__TAURI_INTERNALS__" in window || "__TAURI__" in window;

--- a/src/lib/stores/__tests__/updater-store.test.ts
+++ b/src/lib/stores/__tests__/updater-store.test.ts
@@ -1,0 +1,32 @@
+import { useUpdaterStore } from "../updater-store";
+
+describe("updater-store", () => {
+  beforeEach(() => {
+    useUpdaterStore.getState().reset();
+  });
+
+  describe("setProgress", () => {
+    it("rounds progress to whole percent", () => {
+      useUpdaterStore.getState().setProgress(42.7);
+      expect(useUpdaterStore.getState().progress).toBe(43);
+    });
+
+    it("does not notify subscribers for sub-percent changes", () => {
+      useUpdaterStore.getState().setProgress(10);
+
+      const listener = jest.fn();
+      const unsubscribe = useUpdaterStore.subscribe(listener);
+
+      // Chunk events within the same whole percent must not trigger renders
+      useUpdaterStore.getState().setProgress(10.1);
+      useUpdaterStore.getState().setProgress(10.4);
+      expect(listener).not.toHaveBeenCalled();
+
+      useUpdaterStore.getState().setProgress(11);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(useUpdaterStore.getState().progress).toBe(11);
+
+      unsubscribe();
+    });
+  });
+});

--- a/src/lib/stores/updater-store.ts
+++ b/src/lib/stores/updater-store.ts
@@ -66,7 +66,13 @@ export const useUpdaterStore = create<UpdaterState>((set) => ({
 
   setDownloading: (downloading) => set({ downloading }),
 
-  setProgress: (progress) => set({ progress }),
+  // Quantize to whole percent: download events fire per chunk; sub-percent
+  // writes would re-render every subscriber hundreds of times per download.
+  setProgress: (progress) =>
+    set((state) => {
+      const rounded = Math.round(progress);
+      return rounded === state.progress ? state : { progress: rounded };
+    }),
 
   setError: (error) => set({ error, checking: false, downloading: false }),
 


### PR DESCRIPTION
## Summary

Every selector-less `useXStore()` call subscribed its component to the whole store — so each 30s health-check tick, every AI streaming chunk, and every updater download event re-rendered large parts of the app (Dashboard, Sidebar, all open views).

- Convert all 78 selector-less store calls (~248 selectors, 46 files) to the per-field selector idiom already used in the codebase (`useStore((s) => s.field)`), including renames (`tabs → resourceTabs`, `namespaces → configuredNamespaces`, `nodes → storeNodes`).
- `updater-store.setProgress`: quantize to whole percent and skip no-op writes — download chunk events no longer flood subscribers (regression test included).
- Test suites that mocked store hooks with `mockReturnValue(state)` now apply the selector via `mockImplementation`.
- Drop a now-redundant `displayName` dep in `useClusterScopedResource` (flagged by exhaustive-deps after conversion).

No behavior changes intended; render behavior only.

## Test plan
- [x] 640 frontend tests green (incl. new updater-store quantization test)
- [x] Coverage gate passes locally
- [x] `tsc --noEmit` clean, ESLint 0 warnings
- [x] Grep confirms zero remaining selector-less store calls in `src/`

Part of the performance track (1.2); follow-ups: virtualization (1.3), diagram/ELK (1.4).