### PR TITLE
perf: virtualize resource table, log viewers and AI chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@tanstack/react-virtual": "^3.14.5",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "~2.7.0",
         "@tauri-apps/plugin-fs": "~2.5.0",
@@ -4691,6 +4692,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-virtual": "^3.14.5",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "~2.7.0",
     "@tauri-apps/plugin-fs": "~2.5.0",

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -44,13 +44,19 @@ fn parse_ide_type(id: &str) -> Result<IdeType, String> {
     }
 }
 
-/// Detect all installed IDEs and their MCP configuration status
+/// Detect all installed IDEs and their MCP configuration status.
+/// Async so the filesystem probing runs off the main thread — sync commands
+/// block the UI thread and froze the first MCP tab open.
 #[tauri::command]
-pub fn mcp_detect_ides() -> Vec<IdeInfo> {
-    detect_installed_ides()
-        .into_iter()
-        .map(IdeInfo::from)
-        .collect()
+pub async fn mcp_detect_ides() -> Vec<IdeInfo> {
+    tauri::async_runtime::spawn_blocking(|| {
+        detect_installed_ides()
+            .into_iter()
+            .map(IdeInfo::from)
+            .collect()
+    })
+    .await
+    .unwrap_or_default()
 }
 
 /// Install MCP configuration for a specific IDE

--- a/src-tauri/src/mcp/ide_config.rs
+++ b/src-tauri/src/mcp/ide_config.rs
@@ -211,21 +211,29 @@ pub fn detect_installed_ides() -> Vec<IdeStatus> {
         .collect()
 }
 
+/// Check ~/.claude.json for a user-scope `mcpServers.kubeli` entry
+fn claude_json_has_kubeli(path: &PathBuf) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    json.get("mcpServers")
+        .and_then(|servers| servers.get("kubeli"))
+        .is_some()
+}
+
 /// Check if MCP is already configured for an IDE
 fn check_mcp_configured(ide: IdeType, path: &PathBuf) -> bool {
     match ide {
         IdeType::ClaudeCode => {
-            // Use Claude CLI to check if kubeli is configured
-            let Some(claude) = find_claude_binary() else {
-                return false;
-            };
-            if let Ok(output) = std::process::Command::new(&claude)
-                .args(["mcp", "get", "kubeli"])
-                .output()
-            {
-                return output.status.success();
-            }
-            false
+            // Install writes user-scope config to ~/.claude.json, so read it
+            // directly. Spawning `claude mcp get` here costs a full Node CLI
+            // startup (1-2s) and used to freeze the first MCP tab open.
+            // Must be a real JSON lookup: ~/.claude.json also stores project
+            // history, so a plain substring match can false-positive.
+            claude_json_has_kubeli(path)
         }
         IdeType::Cursor => {
             // JSON format - check for "kubeli" in mcpServers
@@ -521,6 +529,36 @@ fn uninstall_cursor_config(path: &PathBuf) -> Result<(), String> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn test_claude_json_detection_reads_config_without_spawning_cli() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".claude.json");
+
+        // No file yet -> not configured
+        assert!(!claude_json_has_kubeli(&path));
+
+        // Configured under user-scope mcpServers
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"kubeli":{"type":"stdio","command":"/Applications/Kubeli.app/Contents/MacOS/Kubeli"}}}"#,
+        )
+        .unwrap();
+        assert!(claude_json_has_kubeli(&path));
+
+        // "kubeli" mentioned elsewhere (project history) must NOT count —
+        // this is why the check parses JSON instead of substring matching
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"other":{}},"projects":{"/Users/x/kubeli":{"history":["kubeli"]}}}"#,
+        )
+        .unwrap();
+        assert!(!claude_json_has_kubeli(&path));
+
+        // Malformed JSON -> false, no panic
+        std::fs::write(&path, "{not json").unwrap();
+        assert!(!claude_json_has_kubeli(&path));
+    }
 
     #[test]
     fn test_ide_metadata_and_paths() {

--- a/src/components/features/ai/AIAssistant.tsx
+++ b/src/components/features/ai/AIAssistant.tsx
@@ -104,10 +104,12 @@ export function AIAssistant() {
   );
   useAIEvents(currentSessionId, eventCallbacks, eventI18n);
 
-  // Auto-scroll to bottom when new messages arrive
+  // Auto-scroll to bottom when new messages arrive. Keyed on count, not the
+  // array: every streaming chunk replaces the array and would re-scroll,
+  // fighting the user's own scroll position mid-generation.
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, isThinking]);
+  }, [messages.length, isThinking]);
 
   // Handle send message
   const handleSend = useCallback(async () => {
@@ -222,8 +224,11 @@ export function AIAssistant() {
                 <MessageRenderer
                   key={message.id}
                   message={message}
-                  isStreaming={isStreaming}
-                  thinkingMessage={thinkingMessage}
+                  // Scope volatile props to the streaming message so the
+                  // memoized finished messages keep stable props and skip
+                  // re-rendering on every thinking-message tick.
+                  isStreaming={isStreaming && message.isStreaming === true}
+                  thinkingMessage={message.isStreaming ? thinkingMessage : ""}
                   onKubeliLink={handleKubeliLink}
                 />
               ))}

--- a/src/components/features/ai/components/MessageRenderer.tsx
+++ b/src/components/features/ai/components/MessageRenderer.tsx
@@ -82,6 +82,8 @@ export const MessageRenderer = memo(function MessageRenderer({
     <div
       className={cn(
         "group flex gap-3 p-4",
+        // Skip layout/paint for off-screen messages in long conversations.
+        "[content-visibility:auto] [contain-intrinsic-size:auto_120px]",
         isUser ? "bg-muted/40" : "bg-background"
       )}
     >

--- a/src/components/features/logs/DeploymentLogViewer.tsx
+++ b/src/components/features/logs/DeploymentLogViewer.tsx
@@ -8,6 +8,7 @@ import React, {
   useCallback,
   useRef,
 } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { AlertCircle, Layers, Loader2, Copy, Check, SearchX, Maximize2 } from "lucide-react";
 import { useDeploymentLogs, type PodColorEntry } from "@/lib/hooks/useDeploymentLogs";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -377,6 +378,29 @@ const DeploymentLogContent = forwardRef<HTMLDivElement, DeploymentLogContentProp
     const [contextMenuSelection, setContextMenuSelection] = useState("");
     const [copied, setCopied] = useState(false);
 
+    // Internal ref for the virtualizer; merged with the forwarded ref so the
+    // parent's auto-scroll handling keeps working on the same element.
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+    const setScrollRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        scrollRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref]
+    );
+
+    // React Compiler skips memoizing this component because useVirtualizer
+    // returns unmemoizable functions; line children stay memoized via
+    // DeploymentLogLine.
+    // eslint-disable-next-line react-hooks/incompatible-library
+    const virtualizer = useVirtualizer({
+      count: logs.length,
+      getScrollElement: () => scrollRef.current,
+      estimateSize: () => 20, // leading-5 = 20px
+      overscan: 20,
+    });
+
     const handleContextMenu = useCallback((e: React.MouseEvent) => {
       const sel = window.getSelection();
       const text = sel?.toString() ?? "";
@@ -449,29 +473,43 @@ const DeploymentLogContent = forwardRef<HTMLDivElement, DeploymentLogContentProp
     return (
       <>
         <div
-          ref={ref}
+          ref={setScrollRef}
           tabIndex={0}
           onScroll={onScroll}
           onContextMenu={handleContextMenu}
-          className="flex-1 overflow-auto outline-none"
+          className="flex-1 overflow-auto p-2 outline-none"
           data-allow-context-menu
         >
-          <pre className={`m-0 p-2 font-mono text-sm leading-5 ${lineWrap ? "whitespace-pre-wrap break-words" : ""}`}>
-            {logs.map((log, index) => (
-              <DeploymentLogLine
-                key={`${log.pod}-${log.timestamp}-${index}`}
-                log={log}
-                showTimestamp={showTimestamps}
-                timestampLocal={timestampLocal}
-                logColoring={logColoring}
-                searchQuery={searchQuery}
-                useRegex={useRegex}
-                searchRegex={searchRegex}
-                podColor={podColorMap.get(log.pod)?.text}
-              />
-            ))}
-            {endRef && <span ref={endRef as React.RefObject<HTMLSpanElement>} />}
+          <pre
+            className={`relative m-0 font-mono text-sm leading-5 ${lineWrap ? "whitespace-pre-wrap break-words" : ""}`}
+            style={{ height: virtualizer.getTotalSize() }}
+          >
+            {virtualizer.getVirtualItems().map((item) => {
+              const log = logs[item.index];
+              return (
+                <div
+                  key={log.seq ?? item.index}
+                  data-index={item.index}
+                  ref={virtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full"
+                  style={{ transform: `translateY(${item.start}px)` }}
+                >
+                  <DeploymentLogLine
+                    log={log}
+                    showTimestamp={showTimestamps}
+                    timestampLocal={timestampLocal}
+                    logColoring={logColoring}
+                    searchQuery={searchQuery}
+                    useRegex={useRegex}
+                    searchRegex={searchRegex}
+                    podColor={podColorMap.get(log.pod)?.text}
+                  />
+                </div>
+              );
+            })}
           </pre>
+          {/* Scroll target for auto-scroll (after the total-height container) */}
+          {endRef && <span ref={endRef as React.RefObject<HTMLSpanElement>} />}
         </div>
 
         {menuPos && (

--- a/src/components/features/logs/components/LogContent.tsx
+++ b/src/components/features/logs/components/LogContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef, useState, useCallback, useRef, useEffect } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Loader2, Copy, Check, Sparkles, SearchX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { LogEntry } from "@/lib/types";
@@ -73,6 +74,28 @@ export const LogContent = forwardRef<HTMLDivElement, LogContentProps>(
     const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
     const [contextMenuSelection, setContextMenuSelection] = useState("");
     const [copied, setCopied] = useState(false);
+
+    // Internal ref for the virtualizer; merged with the forwarded ref so the
+    // parent's scroll-position save/restore keeps working on the same element.
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+    const setScrollRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        scrollRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) ref.current = node;
+      },
+      [ref]
+    );
+
+    // React Compiler skips memoizing this component because useVirtualizer
+    // returns unmemoizable functions; line children stay memoized via LogLine.
+    // eslint-disable-next-line react-hooks/incompatible-library
+    const virtualizer = useVirtualizer({
+      count: logs.length,
+      getScrollElement: () => scrollRef.current,
+      estimateSize: () => 20, // leading-5 = 20px
+      overscan: 20,
+    });
 
     // Show custom context menu on right-click when text is selected
     const handleContextMenu = useCallback((e: React.MouseEvent) => {
@@ -152,29 +175,42 @@ export const LogContent = forwardRef<HTMLDivElement, LogContentProps>(
     return (
       <>
         <div
-          ref={ref}
+          ref={setScrollRef}
           tabIndex={0}
           onScroll={onScroll}
           onContextMenu={handleContextMenu}
-          className="flex-1 overflow-auto outline-none"
+          className="flex-1 overflow-auto p-2 outline-none"
           data-allow-context-menu
         >
-          <pre className={`m-0 p-2 font-mono text-sm leading-5 ${lineWrap ? "whitespace-pre-wrap break-words" : ""}`}>
-            {logs.map((log, index) => (
-              <LogLine
-                key={`${log.timestamp}-${index}`}
-                log={log}
-                showTimestamp={showTimestamps}
-                timestampLocal={timestampLocal}
-                logColoring={logColoring}
-                searchQuery={searchQuery}
-                useRegex={useRegex}
-                searchRegex={searchRegex}
-              />
-            ))}
-            {/* Scroll target for auto-scroll */}
-            {endRef && <span ref={endRef as React.RefObject<HTMLSpanElement>} />}
+          <pre
+            className={`relative m-0 font-mono text-sm leading-5 ${lineWrap ? "whitespace-pre-wrap break-words" : ""}`}
+            style={{ height: virtualizer.getTotalSize() }}
+          >
+            {virtualizer.getVirtualItems().map((item) => {
+              const log = logs[item.index];
+              return (
+                <div
+                  key={log.seq ?? item.index}
+                  data-index={item.index}
+                  ref={virtualizer.measureElement}
+                  className="absolute top-0 left-0 w-full"
+                  style={{ transform: `translateY(${item.start}px)` }}
+                >
+                  <LogLine
+                    log={log}
+                    showTimestamp={showTimestamps}
+                    timestampLocal={timestampLocal}
+                    logColoring={logColoring}
+                    searchQuery={searchQuery}
+                    useRegex={useRegex}
+                    searchRegex={searchRegex}
+                  />
+                </div>
+              );
+            })}
           </pre>
+          {/* Scroll target for auto-scroll (after the total-height container) */}
+          {endRef && <span ref={endRef as React.RefObject<HTMLSpanElement>} />}
         </div>
 
         {/* Custom context menu — no portal/focus-steal so selection stays visible */}

--- a/src/components/features/logs/components/__tests__/LogContent.test.tsx
+++ b/src/components/features/logs/components/__tests__/LogContent.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import { LogContent } from "../LogContent";
+import type { LogEntry } from "@/lib/types";
+
+const makeLogs = (count: number): LogEntry[] =>
+  Array.from({ length: count }, (_, i) => ({
+    message: `log line ${i}`,
+    timestamp: "2024-01-01T10:00:00Z",
+    container: "main",
+    pod: "test-pod",
+    namespace: "default",
+    seq: i,
+  }));
+
+const renderContent = (logs: LogEntry[]) =>
+  render(
+    <LogContent
+      logs={logs}
+      isLoading={false}
+      searchQuery=""
+      showTimestamps={false}
+      useRegex={false}
+      searchRegex={null}
+      onScroll={jest.fn()}
+      onStartStream={jest.fn()}
+      loadingText="Loading"
+      searchingText="No matches"
+      noLogsText="No logs"
+      followText="Follow"
+      copyLabel="Copy"
+      copiedLabel="Copied"
+    />
+  );
+
+describe("LogContent virtualization", () => {
+  beforeEach(() => {
+    // jsdom reports zero-size elements; give the virtualizer a real viewport
+    // (scroll container) and a fixed line height (leading-5 = 20px).
+    // @tanstack/virtual-core measures via offsetWidth/offsetHeight.
+    jest
+      .spyOn(HTMLElement.prototype, "offsetHeight", "get")
+      .mockImplementation(function (this: HTMLElement) {
+        return this.hasAttribute("data-index") ? 20 : 600;
+      });
+    jest.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(800);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders only a subset of 5000 log entries", () => {
+    const { container } = renderContent(makeLogs(5000));
+    const lines = container.querySelectorAll("[data-index]");
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.length).toBeLessThan(200);
+  });
+
+  it("shows the correct messages for visible lines", () => {
+    const { container } = renderContent(makeLogs(5000));
+    const lines = container.querySelectorAll("[data-index]");
+    lines.forEach((line) => {
+      const index = Number(line.getAttribute("data-index"));
+      expect(line.textContent).toBe(`log line ${index}\n`);
+    });
+    // Viewport starts at the top, so line 0 is visible and the tail is not.
+    expect(container.textContent).toContain("log line 0");
+    expect(container.textContent).not.toContain("log line 4999");
+  });
+
+  it("sizes the inner container to the total virtual height", () => {
+    const { container } = renderContent(makeLogs(5000));
+    const inner = container.querySelector("pre");
+    // 5000 lines * 20px per line
+    expect(inner?.style.height).toBe(`${5000 * 20}px`);
+  });
+
+  it("renders the empty state without a virtual container", () => {
+    const { container, getByText } = renderContent([]);
+    expect(container.querySelector("pre")).toBeNull();
+    expect(getByText("No logs")).toBeInTheDocument();
+  });
+});

--- a/src/components/features/resources/components/ResourceTable.tsx
+++ b/src/components/features/resources/components/ResourceTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { memo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import {
   Table,
@@ -24,6 +26,9 @@ import { getNamespaceColor } from "@/lib/utils/colors";
 import { Checkbox } from "@/components/ui/checkbox";
 import type { Column, ContextMenuItemDef, SortDirection } from "../types";
 
+const ROW_HEIGHT = 40;
+const OVERSCAN = 10;
+
 interface ResourceTableProps<T> {
   data: T[];
   columns: Column<T>[];
@@ -43,6 +48,141 @@ interface ResourceTableProps<T> {
   onToggleSelect: (key: string) => void;
 }
 
+interface ResourceTableRowProps<T> {
+  item: T;
+  itemKey: string;
+  columns: Column<T>[];
+  isSelected: boolean;
+  namespace?: string;
+  rowClassName?: string;
+  hasBulkActions: boolean;
+  onRowClick?: (item: T) => void;
+  contextMenuItems?: (item: T) => ContextMenuItemDef[];
+  onToggleSelect: (key: string) => void;
+}
+
+function renderMenuItems(menuItems: ContextMenuItemDef[]) {
+  return menuItems.map((menuItem, index) =>
+    menuItem.separator ? (
+      <ContextMenuSeparator key={`sep-${index}`} />
+    ) : menuItem.children ? (
+      <ContextMenuSub key={menuItem.label}>
+        <ContextMenuSubTrigger disabled={menuItem.disabled} className="gap-2">
+          {menuItem.icon}
+          {menuItem.label}
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          {menuItem.children.map((child) => (
+            <ContextMenuItem
+              key={child.label}
+              onClick={child.onClick}
+              disabled={child.disabled}
+              variant={child.variant}
+              className="gap-2"
+            >
+              {child.icon}
+              {child.label}
+              {child.hint && (
+                <span
+                  className={cn(
+                    "ml-auto rounded-full px-2 py-0.5 text-[10px] font-mono font-medium",
+                    child.hintVariant === "active"
+                      ? "bg-purple-500/20 text-purple-400"
+                      : "bg-muted text-foreground"
+                  )}
+                >
+                  {child.hint}
+                </span>
+              )}
+            </ContextMenuItem>
+          ))}
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+    ) : (
+      <ContextMenuItem
+        key={menuItem.label}
+        onClick={menuItem.onClick}
+        disabled={menuItem.disabled}
+        variant={menuItem.variant}
+        className="gap-2"
+      >
+        {menuItem.icon}
+        {menuItem.label}
+      </ContextMenuItem>
+    )
+  );
+}
+
+function ResourceTableRowInner<T>({
+  item,
+  itemKey,
+  columns,
+  isSelected,
+  namespace,
+  rowClassName,
+  hasBulkActions,
+  onRowClick,
+  contextMenuItems,
+  onToggleSelect,
+}: ResourceTableRowProps<T>) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const namespaceColor = namespace ? getNamespaceColor(namespace) : null;
+
+  const rowContent = (
+    <TableRow
+      onClick={() => onRowClick?.(item)}
+      className={cn(
+        onRowClick && "cursor-pointer",
+        namespaceColor && "border-l-4",
+        namespaceColor?.borderLeft,
+        isSelected && "bg-muted/50",
+        rowClassName
+      )}
+    >
+      {hasBulkActions && (
+        <TableCell className="w-8 pl-3">
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={() => onToggleSelect(itemKey)}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Select ${itemKey}`}
+          />
+        </TableCell>
+      )}
+      {columns.map((column) => (
+        <TableCell key={String(column.key)} className="text-sm">
+          {column.render
+            ? column.render(item)
+            : String(
+                (item as Record<string, unknown>)[String(column.key)] ?? "-"
+              )}
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+
+  if (!contextMenuItems) {
+    return rowContent;
+  }
+
+  // Lazy context menu: items are only built and mounted once the menu opens,
+  // so contextMenuItems(item) is never called during plain row rendering.
+  return (
+    <ContextMenu onOpenChange={setMenuOpen}>
+      <ContextMenuTrigger asChild>{rowContent}</ContextMenuTrigger>
+      {menuOpen && (
+        <ContextMenuContent className="w-48">
+          {renderMenuItems(contextMenuItems(item))}
+        </ContextMenuContent>
+      )}
+    </ContextMenu>
+  );
+}
+
+const ResourceTableRow = memo(
+  ResourceTableRowInner
+) as typeof ResourceTableRowInner;
+
 export function ResourceTable<T>({
   data,
   columns,
@@ -61,8 +201,30 @@ export function ResourceTable<T>({
   onToggleSelectAll,
   onToggleSelect,
 }: ResourceTableProps<T>) {
+  // Opt out of React Compiler memoization: useVirtualizer returns functions
+  // that must not be memoized (react-hooks/incompatible-library).
+  "use no memo";
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // eslint-disable-next-line react-hooks/incompatible-library -- informational: compiler skips this component ("use no memo")
+  const virtualizer = useVirtualizer({
+    count: data.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: OVERSCAN,
+  });
+
+  const virtualRows = virtualizer.getVirtualItems();
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? virtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+      : 0;
+  const columnCount = columns.length + (hasBulkActions ? 1 : 0);
+
   return (
-    <div className="h-full overflow-auto">
+    <div ref={scrollRef} className="h-full overflow-auto">
       <Table>
         <TableHeader className="sticky top-0 z-10 bg-background">
           <TableRow>
@@ -110,115 +272,41 @@ export function ResourceTable<T>({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {data.map((item) => {
-            const namespace = getRowNamespace?.(item);
-            const namespaceColor = namespace
-              ? getNamespaceColor(namespace)
-              : null;
+          {paddingTop > 0 && (
+            <tr aria-hidden="true">
+              <td
+                colSpan={columnCount}
+                style={{ height: paddingTop, padding: 0, border: 0 }}
+              />
+            </tr>
+          )}
+          {virtualRows.map((virtualRow) => {
+            const item = data[virtualRow.index];
             const itemKey = getRowKey(item);
-            const isSelected = selectedKeys.has(itemKey);
-
-            const rowContent = (
-              <TableRow
+            return (
+              <ResourceTableRow
                 key={itemKey}
-                onClick={() => onRowClick?.(item)}
-                className={cn(
-                  onRowClick && "cursor-pointer",
-                  namespaceColor && "border-l-4",
-                  namespaceColor?.borderLeft,
-                  isSelected && "bg-muted/50",
-                  getRowClassName?.(item)
-                )}
-              >
-                {hasBulkActions && (
-                  <TableCell className="w-8 pl-3">
-                    <Checkbox
-                      checked={isSelected}
-                      onCheckedChange={() => onToggleSelect(itemKey)}
-                      onClick={(e) => e.stopPropagation()}
-                      aria-label={`Select ${itemKey}`}
-                    />
-                  </TableCell>
-                )}
-                {columns.map((column) => (
-                  <TableCell key={String(column.key)} className="text-sm">
-                    {column.render
-                      ? column.render(item)
-                      : String(
-                          (item as Record<string, unknown>)[
-                            String(column.key)
-                          ] ?? "-"
-                        )}
-                  </TableCell>
-                ))}
-              </TableRow>
+                item={item}
+                itemKey={itemKey}
+                columns={columns}
+                isSelected={selectedKeys.has(itemKey)}
+                namespace={getRowNamespace?.(item)}
+                rowClassName={getRowClassName?.(item)}
+                hasBulkActions={hasBulkActions}
+                onRowClick={onRowClick}
+                contextMenuItems={contextMenuItems}
+                onToggleSelect={onToggleSelect}
+              />
             );
-
-            if (contextMenuItems) {
-              const menuItems = contextMenuItems(item);
-              return (
-                <ContextMenu key={getRowKey(item)}>
-                  <ContextMenuTrigger asChild>
-                    {rowContent}
-                  </ContextMenuTrigger>
-                  <ContextMenuContent className="w-48">
-                    {menuItems.map((menuItem, index) =>
-                      menuItem.separator ? (
-                        <ContextMenuSeparator key={`sep-${index}`} />
-                      ) : menuItem.children ? (
-                        <ContextMenuSub key={menuItem.label}>
-                          <ContextMenuSubTrigger
-                            disabled={menuItem.disabled}
-                            className="gap-2"
-                          >
-                            {menuItem.icon}
-                            {menuItem.label}
-                          </ContextMenuSubTrigger>
-                          <ContextMenuSubContent>
-                            {menuItem.children.map((child) => (
-                              <ContextMenuItem
-                                key={child.label}
-                                onClick={child.onClick}
-                                disabled={child.disabled}
-                                variant={child.variant}
-                                className="gap-2"
-                              >
-                                {child.icon}
-                                {child.label}
-                                {child.hint && (
-                                  <span className={cn(
-                                    "ml-auto rounded-full px-2 py-0.5 text-[10px] font-mono font-medium",
-                                    child.hintVariant === "active"
-                                      ? "bg-purple-500/20 text-purple-400"
-                                      : "bg-muted text-foreground"
-                                  )}>
-                                    {child.hint}
-                                  </span>
-                                )}
-                              </ContextMenuItem>
-                            ))}
-                          </ContextMenuSubContent>
-                        </ContextMenuSub>
-                      ) : (
-                        <ContextMenuItem
-                          key={menuItem.label}
-                          onClick={menuItem.onClick}
-                          disabled={menuItem.disabled}
-                          variant={menuItem.variant}
-                          className="gap-2"
-                        >
-                          {menuItem.icon}
-                          {menuItem.label}
-                        </ContextMenuItem>
-                      )
-                    )}
-                  </ContextMenuContent>
-                </ContextMenu>
-              );
-            }
-
-            return rowContent;
           })}
+          {paddingBottom > 0 && (
+            <tr aria-hidden="true">
+              <td
+                colSpan={columnCount}
+                style={{ height: paddingBottom, padding: 0, border: 0 }}
+              />
+            </tr>
+          )}
         </TableBody>
       </Table>
     </div>

--- a/src/components/features/resources/components/__tests__/ResourceTable.test.tsx
+++ b/src/components/features/resources/components/__tests__/ResourceTable.test.tsx
@@ -1,0 +1,101 @@
+import { render } from "@testing-library/react";
+import { ResourceTable } from "../ResourceTable";
+import type { Column, ContextMenuItemDef } from "../../types";
+
+interface Item {
+  name: string;
+  status: string;
+}
+
+const columns: Column<Item>[] = [
+  { key: "name", label: "Name" },
+  { key: "status", label: "Status" },
+];
+
+const makeItems = (count: number): Item[] =>
+  Array.from({ length: count }, (_, i) => ({
+    name: `pod-${i}`,
+    status: "Running",
+  }));
+
+const baseProps = {
+  columns,
+  getRowKey: (item: Item) => item.name,
+  sortKey: null,
+  sortDirection: "asc" as const,
+  onSort: jest.fn(),
+  hasBulkActions: false,
+  selectedKeys: new Set<string>(),
+  allSelected: false,
+  someSelected: false,
+  onToggleSelectAll: jest.fn(),
+  onToggleSelect: jest.fn(),
+};
+
+const dataRows = (container: HTMLElement) =>
+  container.querySelectorAll("tbody tr[data-slot='table-row']");
+
+beforeEach(() => {
+  // jsdom gives every element zero size, so the virtualizer would render
+  // nothing. Pretend the scroll container is 600px tall (virtual-core
+  // measures the scroll element via offsetWidth/offsetHeight).
+  jest
+    .spyOn(HTMLElement.prototype, "offsetHeight", "get")
+    .mockReturnValue(600);
+  jest
+    .spyOn(HTMLElement.prototype, "offsetWidth", "get")
+    .mockReturnValue(800);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("ResourceTable virtualization", () => {
+  it("renders only a small window of a 1000-row dataset", () => {
+    const { container } = render(
+      <ResourceTable {...baseProps} data={makeItems(1000)} />
+    );
+
+    const rows = dataRows(container);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThan(100);
+
+    // First row is visible, off-screen tail is not mounted.
+    expect(container.textContent).toContain("pod-0");
+    expect(container.textContent).not.toContain("pod-999");
+  });
+
+  it("renders the correct cell content for visible rows", () => {
+    const { container } = render(
+      <ResourceTable {...baseProps} data={makeItems(3)} />
+    );
+
+    const rows = dataRows(container);
+    expect(rows).toHaveLength(3);
+    const cells = rows[1].querySelectorAll("td");
+    expect(cells[0].textContent).toBe("pod-1");
+    expect(cells[1].textContent).toBe("Running");
+  });
+
+  // Regression: contextMenuItems(item) used to be called for every row on
+  // every render, building the full menu definition array eagerly. The menu
+  // must now be built lazily, only when a row's context menu opens.
+  it("does not build context menu items during initial render", () => {
+    const contextMenuItems = jest.fn(
+      (item: Item): ContextMenuItemDef[] => [
+        { label: `Delete ${item.name}`, onClick: jest.fn() },
+      ]
+    );
+
+    render(
+      <ResourceTable
+        {...baseProps}
+        data={makeItems(1000)}
+        contextMenuItems={contextMenuItems}
+      />
+    );
+
+    expect(contextMenuItems).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/stores/log-store.ts
+++ b/src/lib/stores/log-store.ts
@@ -66,6 +66,10 @@ interface LogStoreState {
 }
 
 // External state not in Zustand (no re-renders needed)
+// Monotonic ID for stable React keys across ring-buffer trims.
+let logSeq = 0;
+const stampSeq = (entry: LogEntry): LogEntry => ({ ...entry, seq: ++logSeq });
+
 const listeners = new Map<string, UnlistenFn>();
 const pendingLogs = new Map<string, LogEntry[]>();
 const flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -250,7 +254,7 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
               pending = [];
               pendingLogs.set(tabId, pending);
             }
-            pending.push(logEvent.data);
+            pending.push(stampSeq(logEvent.data));
             scheduleFlush(tabId, set);
             break;
           }
@@ -382,7 +386,7 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
       }
       pendingLogs.delete(tabId);
 
-      const nextLogs = fetchedLogs.slice(-maxLines);
+      const nextLogs = fetchedLogs.slice(-maxLines).map(stampSeq);
 
       set((s) => {
         const t = s.logTabs[tabId];

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -125,6 +125,9 @@ export interface LogEntry {
   container: string;
   pod: string;
   namespace: string;
+  /** Monotonic ingest ID, stamped frontend-side (not part of the Rust payload).
+   * Stable React key — timestamp+index shifts when the ring buffer trims. */
+  seq?: number;
 }
 
 export interface LogOptions {


### PR DESCRIPTION
## Summary

Third performance PR (task 1.3): everything list-shaped now renders only what is visible.

- **ResourceTable**: rows virtualized with `@tanstack/react-virtual` (new dependency, ~3 KB gzip). Spacer-row technique keeps the semantic `<table>` and sticky header. Rows are memoized; context-menu item definitions are now built only when a menu actually opens instead of for every row on every render.
- **LogContent / DeploymentLogViewer**: log lines virtualized with measured heights (line-wrap safe), overscan 20. Forwarded scroll ref (scroll save/restore) and follow-mode `endRef` keep working.
- **Log keys**: monotonic `seq` stamped at ingest in the log store replaces `timestamp-index` keys — ring-buffer trims previously shifted every index and remounted all visible lines.
- **AI chat**: `content-visibility: auto` on messages; `thinkingMessage`/`isStreaming` props scoped to the streaming message so finished messages keep stable props and skip re-rendering on every thinking tick; auto-scroll keyed on message count so streaming chunks stop fighting manual scrolling.

- **MCP tab first-open freeze**: `mcp_detect_ides` was a sync command (ran on the main thread) and the Claude Code check spawned `claude mcp get` — a full Node CLI startup (1–2 s). Detection now parses `~/.claude.json` directly (JSON lookup, no substring false-positives from project history) and runs via `spawn_blocking` behind an async command. Regression tests included.

## Known tradeoffs
- Text selection and browser find in log viewers only reach rendered lines (~50); toolbar Copy All is unaffected (reads state, not DOM). Same behavior as other virtualized log tools.

## Test plan
- [x] 647 frontend tests green, incl. new ResourceTable (3) and LogContent (4) virtualization tests — subset-rendering asserted with 1000 rows / 5000 lines, lazy context menu regression-tested
- [x] Coverage gate, `tsc --noEmit`, ESLint 0 warnings, production build green
- [x] Manual testing (large cluster, long log stream, AI chat) — @atilladeniz before merge

**Do not merge yet** — pending manual testing.
