### PR TITLE
perf: IPC batching, query efficiency, build profile

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6523,7 +6523,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,9 @@ jsonpath-rust = "1.0"
 dirs = "6.0"
 
 # Async Runtime
-tokio = { version = "1.52", features = ["full"] }
+# Enumerated features instead of "full": drops unused subsystems (signal,
+# parking_lot, test-util, ...) from the build
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "sync", "time", "process", "io-util", "net", "fs"] }
 tokio-util = { version = "0.7", features = ["io", "compat"] }
 futures = "0.3"
 futures-util = "0.3"
@@ -114,3 +116,5 @@ debug = 0
 lto = true
 opt-level = "s"
 strip = true
+codegen-units = 1
+panic = "abort"

--- a/src-tauri/src/ai/session_store.rs
+++ b/src-tauri/src/ai/session_store.rs
@@ -2,8 +2,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, Result as SqliteResult};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// Session metadata stored in database
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,76 +109,108 @@ impl SessionStore {
         Ok(())
     }
 
+    /// Run a closure against the connection on the blocking pool
+    async fn with_conn<T, F>(&self, f: F) -> SqliteResult<T>
+    where
+        F: FnOnce(&Connection) -> SqliteResult<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let conn = Arc::clone(&self.conn);
+        tauri::async_runtime::spawn_blocking(move || {
+            let conn = conn.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            f(&conn)
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Err(rusqlite::Error::InvalidParameterName(format!(
+                "session store task panicked: {e}"
+            )))
+        })
+    }
+
     /// Save a new session
     pub async fn save_session(&self, session: &SessionRecord) -> SqliteResult<()> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "INSERT OR REPLACE INTO sessions
-             (session_id, cluster_context, created_at, last_active_at, permission_mode, title)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                session.session_id,
-                session.cluster_context,
-                session.created_at.to_rfc3339(),
-                session.last_active_at.to_rfc3339(),
-                session.permission_mode,
-                session.title,
-            ],
-        )?;
-        Ok(())
+        let session = session.clone();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "INSERT OR REPLACE INTO sessions
+                 (session_id, cluster_context, created_at, last_active_at, permission_mode, title)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    session.session_id,
+                    session.cluster_context,
+                    session.created_at.to_rfc3339(),
+                    session.last_active_at.to_rfc3339(),
+                    session.permission_mode,
+                    session.title,
+                ],
+            )?;
+            Ok(())
+        })
+        .await
     }
 
     /// Update session's last active timestamp
     #[allow(dead_code)]
     pub async fn update_session_activity(&self, session_id: &str) -> SqliteResult<()> {
-        let conn = self.conn.lock().await;
-        let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "UPDATE sessions SET last_active_at = ?1 WHERE session_id = ?2",
-            params![now, session_id],
-        )?;
-        Ok(())
+        let session_id = session_id.to_string();
+        self.with_conn(move |conn| {
+            let now = Utc::now().to_rfc3339();
+            conn.execute(
+                "UPDATE sessions SET last_active_at = ?1 WHERE session_id = ?2",
+                params![now, session_id],
+            )?;
+            Ok(())
+        })
+        .await
     }
 
     /// Update session title
     pub async fn update_session_title(&self, session_id: &str, title: &str) -> SqliteResult<()> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "UPDATE sessions SET title = ?1 WHERE session_id = ?2",
-            params![title, session_id],
-        )?;
-        Ok(())
+        let session_id = session_id.to_string();
+        let title = title.to_string();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE sessions SET title = ?1 WHERE session_id = ?2",
+                params![title, session_id],
+            )?;
+            Ok(())
+        })
+        .await
     }
 
     /// Load a session by ID
     #[allow(dead_code)]
     pub async fn load_session(&self, session_id: &str) -> SqliteResult<Option<SessionRecord>> {
-        let conn = self.conn.lock().await;
-        let mut stmt = conn.prepare(
-            "SELECT session_id, cluster_context, created_at, last_active_at, permission_mode, title
-             FROM sessions WHERE session_id = ?1",
-        )?;
+        let session_id = session_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT session_id, cluster_context, created_at, last_active_at, permission_mode, title
+                 FROM sessions WHERE session_id = ?1",
+            )?;
 
-        let result = stmt.query_row(params![session_id], |row| {
-            Ok(SessionRecord {
-                session_id: row.get(0)?,
-                cluster_context: row.get(1)?,
-                created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?)
-                    .unwrap_or_default()
-                    .with_timezone(&Utc),
-                last_active_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?)
-                    .unwrap_or_default()
-                    .with_timezone(&Utc),
-                permission_mode: row.get(4)?,
-                title: row.get(5)?,
-            })
-        });
+            let result = stmt.query_row(params![session_id], |row| {
+                Ok(SessionRecord {
+                    session_id: row.get(0)?,
+                    cluster_context: row.get(1)?,
+                    created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?)
+                        .unwrap_or_default()
+                        .with_timezone(&Utc),
+                    last_active_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?)
+                        .unwrap_or_default()
+                        .with_timezone(&Utc),
+                    permission_mode: row.get(4)?,
+                    title: row.get(5)?,
+                })
+            });
 
-        match result {
-            Ok(session) => Ok(Some(session)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e),
-        }
+            match result {
+                Ok(session) => Ok(Some(session)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e),
+            }
+        })
+        .await
     }
 
     /// List all sessions for a cluster
@@ -187,85 +218,97 @@ impl SessionStore {
         &self,
         cluster_context: &str,
     ) -> SqliteResult<Vec<SessionSummary>> {
-        let conn = self.conn.lock().await;
-        let mut stmt = conn.prepare(
-            "SELECT s.session_id, s.cluster_context, s.created_at, s.last_active_at, s.title,
-                    COUNT(m.message_id) as message_count
-             FROM sessions s
-             LEFT JOIN messages m ON s.session_id = m.session_id
-             WHERE s.cluster_context = ?1
-             GROUP BY s.session_id
-             ORDER BY s.last_active_at DESC",
-        )?;
+        let cluster_context = cluster_context.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT s.session_id, s.cluster_context, s.created_at, s.last_active_at, s.title,
+                        COUNT(m.message_id) as message_count
+                 FROM sessions s
+                 LEFT JOIN messages m ON s.session_id = m.session_id
+                 WHERE s.cluster_context = ?1
+                 GROUP BY s.session_id
+                 ORDER BY s.last_active_at DESC",
+            )?;
 
-        let rows = stmt.query_map(params![cluster_context], |row| {
-            Ok(SessionSummary {
-                session_id: row.get(0)?,
-                cluster_context: row.get(1)?,
-                created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?)
-                    .unwrap_or_default()
-                    .with_timezone(&Utc),
-                last_active_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?)
-                    .unwrap_or_default()
-                    .with_timezone(&Utc),
-                title: row.get(4)?,
-                message_count: row.get(5)?,
-            })
-        })?;
+            let rows = stmt.query_map(params![cluster_context], |row| {
+                Ok(SessionSummary {
+                    session_id: row.get(0)?,
+                    cluster_context: row.get(1)?,
+                    created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?)
+                        .unwrap_or_default()
+                        .with_timezone(&Utc),
+                    last_active_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?)
+                        .unwrap_or_default()
+                        .with_timezone(&Utc),
+                    title: row.get(4)?,
+                    message_count: row.get(5)?,
+                })
+            })?;
 
-        let mut sessions = Vec::new();
-        for row in rows {
-            sessions.push(row?);
-        }
-        Ok(sessions)
+            let mut sessions = Vec::new();
+            for row in rows {
+                sessions.push(row?);
+            }
+            Ok(sessions)
+        })
+        .await
     }
 
     /// Delete a session and all its messages
     pub async fn delete_session(&self, session_id: &str) -> SqliteResult<()> {
-        let conn = self.conn.lock().await;
-        // Messages will be deleted by CASCADE
-        conn.execute(
-            "DELETE FROM sessions WHERE session_id = ?1",
-            params![session_id],
-        )?;
-        Ok(())
+        let session_id = session_id.to_string();
+        self.with_conn(move |conn| {
+            // Messages will be deleted by CASCADE
+            conn.execute(
+                "DELETE FROM sessions WHERE session_id = ?1",
+                params![session_id],
+            )?;
+            Ok(())
+        })
+        .await
     }
 
     /// Delete all sessions for a cluster
     pub async fn delete_sessions_for_cluster(&self, cluster_context: &str) -> SqliteResult<()> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "DELETE FROM sessions WHERE cluster_context = ?1",
-            params![cluster_context],
-        )?;
-        Ok(())
+        let cluster_context = cluster_context.to_string();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "DELETE FROM sessions WHERE cluster_context = ?1",
+                params![cluster_context],
+            )?;
+            Ok(())
+        })
+        .await
     }
 
     /// Save a message
     pub async fn save_message(&self, message: &MessageRecord) -> SqliteResult<()> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "INSERT INTO messages
-             (message_id, session_id, role, content, tool_calls, timestamp)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                message.message_id,
-                message.session_id,
-                message.role,
-                message.content,
-                message.tool_calls,
-                message.timestamp.to_rfc3339(),
-            ],
-        )?;
+        let message = message.clone();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "INSERT INTO messages
+                 (message_id, session_id, role, content, tool_calls, timestamp)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    message.message_id,
+                    message.session_id,
+                    message.role,
+                    message.content,
+                    message.tool_calls,
+                    message.timestamp.to_rfc3339(),
+                ],
+            )?;
 
-        // Update session activity
-        let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "UPDATE sessions SET last_active_at = ?1 WHERE session_id = ?2",
-            params![now, message.session_id],
-        )?;
+            // Update session activity
+            let now = Utc::now().to_rfc3339();
+            conn.execute(
+                "UPDATE sessions SET last_active_at = ?1 WHERE session_id = ?2",
+                params![now, message.session_id],
+            )?;
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 
     /// Update a message (e.g., when streaming completes)
@@ -275,42 +318,50 @@ impl SessionStore {
         content: &str,
         tool_calls: Option<&str>,
     ) -> SqliteResult<()> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "UPDATE messages SET content = ?1, tool_calls = ?2 WHERE message_id = ?3",
-            params![content, tool_calls, message_id],
-        )?;
-        Ok(())
+        let message_id = message_id.to_string();
+        let content = content.to_string();
+        let tool_calls = tool_calls.map(|s| s.to_string());
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE messages SET content = ?1, tool_calls = ?2 WHERE message_id = ?3",
+                params![content, tool_calls, message_id],
+            )?;
+            Ok(())
+        })
+        .await
     }
 
     /// Get all messages for a session
     pub async fn get_messages(&self, session_id: &str) -> SqliteResult<Vec<MessageRecord>> {
-        let conn = self.conn.lock().await;
-        let mut stmt = conn.prepare(
-            "SELECT message_id, session_id, role, content, tool_calls, timestamp
-             FROM messages
-             WHERE session_id = ?1
-             ORDER BY timestamp ASC",
-        )?;
+        let session_id = session_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT message_id, session_id, role, content, tool_calls, timestamp
+                 FROM messages
+                 WHERE session_id = ?1
+                 ORDER BY timestamp ASC",
+            )?;
 
-        let rows = stmt.query_map(params![session_id], |row| {
-            Ok(MessageRecord {
-                message_id: row.get(0)?,
-                session_id: row.get(1)?,
-                role: row.get(2)?,
-                content: row.get(3)?,
-                tool_calls: row.get(4)?,
-                timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(5)?)
-                    .unwrap_or_default()
-                    .with_timezone(&Utc),
-            })
-        })?;
+            let rows = stmt.query_map(params![session_id], |row| {
+                Ok(MessageRecord {
+                    message_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role: row.get(2)?,
+                    content: row.get(3)?,
+                    tool_calls: row.get(4)?,
+                    timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(5)?)
+                        .unwrap_or_default()
+                        .with_timezone(&Utc),
+                })
+            })?;
 
-        let mut messages = Vec::new();
-        for row in rows {
-            messages.push(row?);
-        }
-        Ok(messages)
+            let mut messages = Vec::new();
+            for row in rows {
+                messages.push(row?);
+            }
+            Ok(messages)
+        })
+        .await
     }
 
     /// Get recent messages for context (last N messages)
@@ -319,35 +370,38 @@ impl SessionStore {
         session_id: &str,
         limit: usize,
     ) -> SqliteResult<Vec<MessageRecord>> {
-        let conn = self.conn.lock().await;
-        let mut stmt = conn.prepare(
-            "SELECT message_id, session_id, role, content, tool_calls, timestamp
-             FROM messages
-             WHERE session_id = ?1
-             ORDER BY timestamp DESC
-             LIMIT ?2",
-        )?;
+        let session_id = session_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT message_id, session_id, role, content, tool_calls, timestamp
+                 FROM messages
+                 WHERE session_id = ?1
+                 ORDER BY timestamp DESC
+                 LIMIT ?2",
+            )?;
 
-        let rows = stmt.query_map(params![session_id, limit as i64], |row| {
-            Ok(MessageRecord {
-                message_id: row.get(0)?,
-                session_id: row.get(1)?,
-                role: row.get(2)?,
-                content: row.get(3)?,
-                tool_calls: row.get(4)?,
-                timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(5)?)
-                    .unwrap_or_default()
-                    .with_timezone(&Utc),
-            })
-        })?;
+            let rows = stmt.query_map(params![session_id, limit as i64], |row| {
+                Ok(MessageRecord {
+                    message_id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role: row.get(2)?,
+                    content: row.get(3)?,
+                    tool_calls: row.get(4)?,
+                    timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(5)?)
+                        .unwrap_or_default()
+                        .with_timezone(&Utc),
+                })
+            })?;
 
-        let mut messages = Vec::new();
-        for row in rows {
-            messages.push(row?);
-        }
-        // Reverse to get chronological order
-        messages.reverse();
-        Ok(messages)
+            let mut messages = Vec::new();
+            for row in rows {
+                messages.push(row?);
+            }
+            // Reverse to get chronological order
+            messages.reverse();
+            Ok(messages)
+        })
+        .await
     }
 
     /// Build conversation history string for resuming context
@@ -372,25 +426,29 @@ impl SessionStore {
     /// Get database statistics
     #[allow(dead_code)]
     pub async fn get_stats(&self) -> SqliteResult<(i64, i64)> {
-        let conn = self.conn.lock().await;
-        let session_count: i64 =
-            conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))?;
-        let message_count: i64 =
-            conn.query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))?;
-        Ok((session_count, message_count))
+        self.with_conn(|conn| {
+            let session_count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))?;
+            let message_count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))?;
+            Ok((session_count, message_count))
+        })
+        .await
     }
 
     /// Clean up old sessions (older than N days)
     pub async fn cleanup_old_sessions(&self, days: i64) -> SqliteResult<usize> {
-        let conn = self.conn.lock().await;
-        let cutoff = Utc::now() - chrono::Duration::days(days);
-        let cutoff_str = cutoff.to_rfc3339();
+        self.with_conn(move |conn| {
+            let cutoff = Utc::now() - chrono::Duration::days(days);
+            let cutoff_str = cutoff.to_rfc3339();
 
-        let count = conn.execute(
-            "DELETE FROM sessions WHERE last_active_at < ?1",
-            params![cutoff_str],
-        )?;
-        Ok(count)
+            let count = conn.execute(
+                "DELETE FROM sessions WHERE last_active_at < ?1",
+                params![cutoff_str],
+            )?;
+            Ok(count)
+        })
+        .await
     }
 }
 

--- a/src-tauri/src/commands/clusters/kubeconfig.rs
+++ b/src-tauri/src/commands/clusters/kubeconfig.rs
@@ -5,8 +5,35 @@ use tauri_plugin_store::StoreExt;
 
 use crate::commands::cluster_settings::ClusterSettings;
 
-/// Load kubeconfig using configured sources (or default)
+/// Short-lived cache of the parsed sources: list_clusters and a subsequent
+/// connect_cluster both need the same parse - without this every connect
+/// re-reads and re-parses every configured kubeconfig file.
+static SOURCES_CACHE: tokio::sync::Mutex<Option<(std::time::Instant, Option<KubeConfig>)>> =
+    tokio::sync::Mutex::const_new(None);
+const SOURCES_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Drop the cached parse - called whenever the configured sources change so
+/// an add/remove is visible immediately.
+pub fn invalidate_sources_cache() {
+    if let Ok(mut cache) = SOURCES_CACHE.try_lock() {
+        *cache = None;
+    }
+}
+
+/// Load kubeconfig using configured sources (or default), cached briefly.
 pub(super) async fn load_kubeconfig_from_sources(app: &AppHandle) -> Option<KubeConfig> {
+    let mut cache = SOURCES_CACHE.lock().await;
+    if let Some((at, cfg)) = cache.as_ref() {
+        if at.elapsed() < SOURCES_CACHE_TTL {
+            return cfg.clone();
+        }
+    }
+    let fresh = load_kubeconfig_from_sources_uncached(app).await;
+    *cache = Some((std::time::Instant::now(), fresh.clone()));
+    fresh
+}
+
+async fn load_kubeconfig_from_sources_uncached(app: &AppHandle) -> Option<KubeConfig> {
     // Try to load sources config from store
     let sources_config = {
         let store = app.store("kubeconfig-sources.json").ok()?;

--- a/src-tauri/src/commands/clusters/mod.rs
+++ b/src-tauri/src/commands/clusters/mod.rs
@@ -1,5 +1,5 @@
 mod commands;
-mod kubeconfig;
+pub(crate) mod kubeconfig;
 mod types;
 
 pub use commands::*;

--- a/src-tauri/src/commands/graph.rs
+++ b/src-tauri/src/commands/graph.rs
@@ -1,5 +1,5 @@
 use crate::k8s::AppState;
-use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::apps::v1::{Deployment, ReplicaSet};
 use k8s_openapi::api::core::v1::{Namespace, Pod};
 use kube::api::{Api, ListParams};
 use kube::ResourceExt;
@@ -123,6 +123,43 @@ fn get_deployment_status(deployment: &Deployment) -> NodeStatus {
     }
 }
 
+/// List a namespaced resource either cluster-wide or per selected namespace.
+/// With a namespace filter this queries only those namespaces server-side
+/// instead of listing the whole cluster and filtering in memory.
+async fn list_scoped<K>(
+    client: &kube::Client,
+    namespaces: &[String],
+    errors: &mut Vec<String>,
+    label: &str,
+) -> Vec<K>
+where
+    K: kube::Resource<Scope = k8s_openapi::NamespaceResourceScope>
+        + Clone
+        + serde::de::DeserializeOwned
+        + std::fmt::Debug,
+    <K as kube::Resource>::DynamicType: Default,
+{
+    let lp = ListParams::default();
+    if namespaces.is_empty() {
+        match Api::<K>::all(client.clone()).list(&lp).await {
+            Ok(list) => list.items,
+            Err(e) => {
+                errors.push(format!("{label}: {e}"));
+                Vec::new()
+            }
+        }
+    } else {
+        let mut out = Vec::new();
+        for ns in namespaces {
+            match Api::<K>::namespaced(client.clone(), ns).list(&lp).await {
+                Ok(list) => out.extend(list.items),
+                Err(e) => errors.push(format!("{label} ({ns}): {e}")),
+            }
+        }
+        out
+    }
+}
+
 /// Generate nested sub-flow resource graph (Namespaces -> Deployments -> Pods)
 /// Structure: Namespace (group) contains Deployment (group) contains Pods
 #[command]
@@ -139,10 +176,6 @@ pub async fn generate_resource_graph(
     // Track child counts for sizing
     let mut ns_child_count: HashMap<String, usize> = HashMap::new();
     let mut deploy_child_count: HashMap<String, usize> = HashMap::new();
-
-    // Track deployment selectors for pod matching
-    let mut deployment_selectors: HashMap<String, (String, HashMap<String, String>)> =
-        HashMap::new();
 
     let list_params = ListParams::default();
     let filter_ns = !namespaces.is_empty();
@@ -182,135 +215,132 @@ pub async fn generate_resource_graph(
     }
 
     // 2. Fetch Deployments (nested group nodes inside namespaces)
-    let deployments: Api<Deployment> = Api::all(client.clone());
+    for deployment in
+        list_scoped::<Deployment>(&client, &namespaces, &mut errors, "Deployments").await
+    {
+        let ns = deployment.namespace().unwrap_or_default();
+        let name = deployment.name_any();
+        let uid = deployment.metadata.uid.clone().unwrap_or_default();
+        let id = format!("deploy-{}-{}", ns, name);
 
-    match deployments.list(&list_params).await {
-        Ok(deployment_list) => {
-            for deployment in deployment_list.items {
-                let ns = deployment.namespace().unwrap_or_default();
-                if filter_ns && !ns_set.contains(ns.as_str()) {
-                    continue;
-                }
-                let name = deployment.name_any();
-                let uid = deployment.metadata.uid.clone().unwrap_or_default();
-                let id = format!("deploy-{}-{}", ns, name);
+        let status = get_deployment_status(&deployment);
+        let ready = deployment
+            .status
+            .as_ref()
+            .and_then(|s| s.ready_replicas)
+            .unwrap_or(0);
+        let desired = deployment
+            .spec
+            .as_ref()
+            .and_then(|s| s.replicas)
+            .unwrap_or(0);
 
-                let status = get_deployment_status(&deployment);
-                let ready = deployment
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.ready_replicas)
-                    .unwrap_or(0);
-                let desired = deployment
-                    .spec
-                    .as_ref()
-                    .and_then(|s| s.replicas)
-                    .unwrap_or(0);
+        // Initialize child count for this deployment
+        deploy_child_count.insert(id.clone(), 0);
 
-                // Store selector for pod matching
-                if let Some(selector) = deployment
-                    .spec
-                    .as_ref()
-                    .and_then(|s| s.selector.match_labels.clone())
-                {
-                    deployment_selectors
-                        .insert(id.clone(), (ns.clone(), selector.into_iter().collect()));
-                }
+        // Parent is always the namespace group node
+        let ns_id = format!("ns-{}", ns);
+        *ns_child_count.entry(ns_id.clone()).or_insert(0) += 1;
+        let parent_id = Some(ns_id);
 
-                // Initialize child count for this deployment
-                deploy_child_count.insert(id.clone(), 0);
-
-                // Parent is always the namespace group node
-                let ns_id = format!("ns-{}", ns);
-                *ns_child_count.entry(ns_id.clone()).or_insert(0) += 1;
-                let parent_id = Some(ns_id);
-
-                // Deployments are ALSO groups (they contain pods)
-                nodes.push(GraphNode {
-                    id,
-                    uid,
-                    name,
-                    namespace: Some(ns),
-                    node_type: NodeType::Deployment,
-                    status,
-                    labels: btree_to_hashmap(deployment.metadata.labels),
-                    parent_id,
-                    ready_status: None,
-                    replicas: Some(format!("{}/{}", ready, desired)),
-                    is_group: true, // Deployment is a group containing pods
-                    child_count: None,
-                });
-            }
-        }
-        Err(e) => errors.push(format!("Deployments: {e}")),
+        // Deployments are ALSO groups (they contain pods)
+        nodes.push(GraphNode {
+            id,
+            uid,
+            name,
+            namespace: Some(ns),
+            node_type: NodeType::Deployment,
+            status,
+            labels: btree_to_hashmap(deployment.metadata.labels),
+            parent_id,
+            ready_status: None,
+            replicas: Some(format!("{}/{}", ready, desired)),
+            is_group: true, // Deployment is a group containing pods
+            child_count: None,
+        });
     }
 
-    // 3. Fetch Pods (leaf nodes inside deployments)
-    let pods: Api<Pod> = Api::all(client.clone());
-
-    match pods.list(&list_params).await {
-        Ok(pod_list) => {
-            for pod in pod_list.items {
-                let ns = pod.namespace().unwrap_or_default();
-                if filter_ns && !ns_set.contains(ns.as_str()) {
-                    continue;
-                }
-                let name = pod.name_any();
-                let uid = pod.metadata.uid.clone().unwrap_or_default();
-                let id = format!("pod-{}-{}", ns, name);
-
-                let status = get_pod_status(&pod);
-                let labels = btree_to_hashmap(pod.metadata.labels.clone());
-
-                // Calculate ready status
-                let container_statuses = pod
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.container_statuses.as_ref());
-                let ready_status = container_statuses.map(|statuses| {
-                    let ready = statuses.iter().filter(|cs| cs.ready).count();
-                    format!("{}/{}", ready, statuses.len())
-                });
-
-                // Find parent deployment by matching labels
-                let mut parent_deployment_id: Option<String> = None;
-                for (deploy_id, (deploy_ns, selector)) in &deployment_selectors {
-                    if *deploy_ns == ns && !selector.is_empty() {
-                        let matches = selector.iter().all(|(k, v)| labels.get(k) == Some(v));
-                        if matches {
-                            parent_deployment_id = Some(deploy_id.clone());
-                            *deploy_child_count.entry(deploy_id.clone()).or_insert(0) += 1;
-                            break;
-                        }
-                    }
-                }
-
-                // Parent is the deployment if found, otherwise the namespace directly
-                let parent_id = if let Some(deploy_id) = parent_deployment_id {
-                    Some(deploy_id)
-                } else {
-                    let ns_id = format!("ns-{}", ns);
-                    *ns_child_count.entry(ns_id.clone()).or_insert(0) += 1;
-                    Some(ns_id)
-                };
-
-                nodes.push(GraphNode {
-                    id,
-                    uid,
-                    name,
-                    namespace: Some(ns),
-                    node_type: NodeType::Pod,
-                    status,
-                    labels,
-                    parent_id,
-                    ready_status,
-                    replicas: None,
-                    is_group: false, // Pods are leaf nodes
-                    child_count: None,
-                });
-            }
+    // 3. Fetch ReplicaSets (metadata only) to resolve Pod -> Deployment via
+    // owner references instead of label matching (labels can collide; owner
+    // refs are authoritative and O(1) per pod).
+    let mut rs_to_deploy: HashMap<String, String> = HashMap::new();
+    for rs in list_scoped::<ReplicaSet>(&client, &namespaces, &mut errors, "ReplicaSets").await {
+        let ns = rs.namespace().unwrap_or_default();
+        let Some(uid) = rs.metadata.uid.clone() else {
+            continue;
+        };
+        if let Some(owner) = rs
+            .metadata
+            .owner_references
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|o| o.kind == "Deployment")
+        {
+            rs_to_deploy.insert(uid, format!("deploy-{}-{}", ns, owner.name));
         }
-        Err(e) => errors.push(format!("Pods: {e}")),
+    }
+
+    // 4. Fetch Pods (leaf nodes inside deployments)
+    for pod in list_scoped::<Pod>(&client, &namespaces, &mut errors, "Pods").await {
+        let ns = pod.namespace().unwrap_or_default();
+        let name = pod.name_any();
+        let uid = pod.metadata.uid.clone().unwrap_or_default();
+        let id = format!("pod-{}-{}", ns, name);
+
+        let status = get_pod_status(&pod);
+        let labels = btree_to_hashmap(pod.metadata.labels.clone());
+
+        // Calculate ready status
+        let container_statuses = pod
+            .status
+            .as_ref()
+            .and_then(|s| s.container_statuses.as_ref());
+        let ready_status = container_statuses.map(|statuses| {
+            let ready = statuses.iter().filter(|cs| cs.ready).count();
+            format!("{}/{}", ready, statuses.len())
+        });
+
+        // Resolve parent deployment via owner references:
+        // Pod -> ReplicaSet (owner uid) -> Deployment
+        let parent_deployment_id = pod
+            .metadata
+            .owner_references
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|o| o.kind == "ReplicaSet")
+            .and_then(|o| rs_to_deploy.get(&o.uid))
+            // Only attach to deployments that made it into the graph
+            .filter(|deploy_id| deploy_child_count.contains_key(*deploy_id))
+            .cloned();
+        if let Some(deploy_id) = &parent_deployment_id {
+            *deploy_child_count.entry(deploy_id.clone()).or_insert(0) += 1;
+        }
+
+        // Parent is the deployment if found, otherwise the namespace directly
+        let parent_id = if let Some(deploy_id) = parent_deployment_id {
+            Some(deploy_id)
+        } else {
+            let ns_id = format!("ns-{}", ns);
+            *ns_child_count.entry(ns_id.clone()).or_insert(0) += 1;
+            Some(ns_id)
+        };
+
+        nodes.push(GraphNode {
+            id,
+            uid,
+            name,
+            namespace: Some(ns),
+            node_type: NodeType::Pod,
+            status,
+            labels,
+            parent_id,
+            ready_status,
+            replicas: None,
+            is_group: false, // Pods are leaf nodes
+            child_count: None,
+        });
     }
 
     // Update child counts for namespaces and deployments

--- a/src-tauri/src/commands/helm.rs
+++ b/src-tauri/src/commands/helm.rs
@@ -146,6 +146,10 @@ struct HelmChartMetadataData {
 /// Helm stores data as: base64 -> base64 -> gzip compressed JSON
 /// Note: k8s-openapi's ByteString may or may not decode the outer base64 layer,
 /// so we try both approaches for robustness.
+/// Cap on decompressed release size - protects against gzip bombs in
+/// hostile release secrets.
+const MAX_HELM_RELEASE_BYTES: u64 = 64 * 1024 * 1024;
+
 fn decode_helm_release(data: &str) -> Result<HelmReleaseData, KubeliError> {
     // First base64 decode
     let decoded1 = BASE64.decode(data)?;
@@ -160,14 +164,22 @@ fn decode_helm_release(data: &str) -> Result<HelmReleaseData, KubeliError> {
         BASE64.decode(&decoded1)?
     };
 
-    // Gzip decompress
-    let mut decoder = GzDecoder::new(&gzip_data[..]);
+    // Gzip decompress (bounded)
+    let mut decoder = GzDecoder::new(&gzip_data[..]).take(MAX_HELM_RELEASE_BYTES);
     let mut decompressed = String::new();
     decoder.read_to_string(&mut decompressed)?;
 
     // Parse JSON
     serde_json::from_str(&decompressed)
         .map_err(|e| KubeliError::unknown(format!("Failed to parse helm release JSON: {}", e)))
+}
+
+/// Decode on the blocking pool - decompress + JSON parse of multi-MB
+/// releases must not stall the async runtime.
+async fn decode_helm_release_blocking(data: String) -> Result<HelmReleaseData, KubeliError> {
+    tauri::async_runtime::spawn_blocking(move || decode_helm_release(&data))
+        .await
+        .map_err(|e| KubeliError::unknown(format!("Helm decode task failed: {e}")))?
 }
 
 /// Get the latest revision number for a release from a list of secrets
@@ -238,7 +250,8 @@ pub async fn list_helm_releases(
         {
             if let Some(data) = secret.data.as_ref().and_then(|d| d.get("release")) {
                 let data_str = String::from_utf8_lossy(&data.0);
-                if let Ok(release_data) = decode_helm_release(&data_str) {
+                if let Ok(release_data) = decode_helm_release_blocking(data_str.into_owned()).await
+                {
                     let info = HelmReleaseInfo {
                         name: release_data.name.clone(),
                         namespace: ns.clone(),
@@ -459,7 +472,9 @@ pub async fn get_helm_release(
     let client = state.k8s.get_client().await?;
 
     let api: Api<Secret> = Api::namespaced(client.clone(), &namespace);
-    let lp = ListParams::default().labels("owner=helm");
+    // Server-side filter on the release name - avoids downloading every
+    // release secret in the namespace just to pick one.
+    let lp = ListParams::default().labels(&format!("owner=helm,name={}", name));
 
     let secrets: Vec<Secret> = api.list(&lp).await?.items;
 
@@ -476,7 +491,7 @@ pub async fn get_helm_release(
         .ok_or("Release data not found")?;
 
     let data_str = String::from_utf8_lossy(&data.0);
-    let release_data = decode_helm_release(&data_str)?;
+    let release_data = decode_helm_release_blocking(data_str.into_owned()).await?;
 
     Ok(HelmReleaseDetail {
         name: release_data.name,
@@ -506,7 +521,7 @@ pub async fn get_helm_release_history(
     let client = state.k8s.get_client().await?;
 
     let api: Api<Secret> = Api::namespaced(client, &namespace);
-    let lp = ListParams::default().labels("owner=helm");
+    let lp = ListParams::default().labels(&format!("owner=helm,name={}", name));
 
     let secrets: Vec<Secret> = api.list(&lp).await?.items;
 
@@ -521,7 +536,7 @@ pub async fn get_helm_release_history(
 
         if let Some(data) = secret.data.as_ref().and_then(|d| d.get("release")) {
             let data_str = String::from_utf8_lossy(&data.0);
-            if let Ok(release_data) = decode_helm_release(&data_str) {
+            if let Ok(release_data) = decode_helm_release_blocking(data_str.into_owned()).await {
                 history.push(HelmReleaseHistoryEntry {
                     revision: release_data.version,
                     status: HelmReleaseStatus::from(release_data.info.status.as_str()),
@@ -576,7 +591,7 @@ pub async fn uninstall_helm_release(
     let api: Api<Secret> = Api::namespaced(client, &namespace);
 
     // Find all secrets for this release (all revisions)
-    let lp = ListParams::default().labels("owner=helm");
+    let lp = ListParams::default().labels(&format!("owner=helm,name={}", name));
     let secrets: Vec<Secret> = api.list(&lp).await?.items;
 
     let prefix = format!("sh.helm.release.v1.{}.", name);

--- a/src-tauri/src/commands/kubeconfig.rs
+++ b/src-tauri/src/commands/kubeconfig.rs
@@ -53,6 +53,7 @@ pub(crate) fn allow_sources_in_fs_scope(app: &AppHandle) {
 
 /// Save sources config to Tauri store
 fn save_sources_config(app: &AppHandle, config: &KubeconfigSourcesConfig) -> Result<(), String> {
+    crate::commands::clusters::kubeconfig::invalidate_sources_cache();
     let store = app
         .store(STORE_FILENAME)
         .map_err(|e| format!("Failed to open store: {}", e))?;

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -25,9 +25,16 @@ pub struct LogEntry {
 #[serde(tag = "type", content = "data")]
 pub enum LogEvent {
     Line(LogEntry),
+    /// Batch of lines flushed together (every 50 ms or 100 lines) so a busy
+    /// pod does not cause one IPC event per line.
+    Lines(Vec<LogEntry>),
     Error(KubeliError),
-    Started { stream_id: String },
-    Stopped { stream_id: String },
+    Started {
+        stream_id: String,
+    },
+    Stopped {
+        stream_id: String,
+    },
 }
 
 /// Options for streaming logs
@@ -213,22 +220,47 @@ pub async fn stream_pod_logs(
                 use futures::StreamExt;
                 let mut lines_stream = stream.lines();
 
-                while let Some(result) = lines_stream.next().await {
-                    // Check stop flag
+                // Batch lines: flush every FLUSH_INTERVAL or MAX_BATCH lines,
+                // whichever comes first. One IPC event per line would flood
+                // the webview on busy pods.
+                const FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+                const MAX_BATCH: usize = 100;
+                let mut batch: Vec<LogEntry> = Vec::new();
+                let flush = |batch: &mut Vec<LogEntry>| {
+                    if !batch.is_empty() {
+                        let _ = app.emit(&event_name, LogEvent::Lines(std::mem::take(batch)));
+                    }
+                };
+
+                loop {
                     if stop_flag.load(Ordering::SeqCst) {
                         tracing::info!("Log stream {} stopped by user", stream_id_clone);
+                        flush(&mut batch);
                         break;
                     }
 
-                    match result {
-                        Ok(line) => {
-                            let entry =
-                                parse_log_line(&line, &container_name, &pod_name, &namespace);
-                            let _ = app.emit(&event_name, LogEvent::Line(entry));
+                    match tokio::time::timeout(FLUSH_INTERVAL, lines_stream.next()).await {
+                        // Flush interval elapsed without a new line
+                        Err(_) => flush(&mut batch),
+                        Ok(Some(Ok(line))) => {
+                            batch.push(parse_log_line(
+                                &line,
+                                &container_name,
+                                &pod_name,
+                                &namespace,
+                            ));
+                            if batch.len() >= MAX_BATCH {
+                                flush(&mut batch);
+                            }
                         }
-                        Err(e) => {
+                        Ok(Some(Err(e))) => {
                             tracing::error!("Log stream read error: {}", e);
+                            flush(&mut batch);
                             let _ = app.emit(&event_name, LogEvent::Error(KubeliError::from(e)));
+                            break;
+                        }
+                        Ok(None) => {
+                            flush(&mut batch);
                             break;
                         }
                     }

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -59,18 +59,24 @@ pub async fn mcp_detect_ides() -> Vec<IdeInfo> {
     .unwrap_or_default()
 }
 
-/// Install MCP configuration for a specific IDE
+/// Install MCP configuration for a specific IDE.
+/// Async + blocking pool: config writes do file I/O and must not run on the
+/// main thread (same reasoning as mcp_detect_ides).
 #[tauri::command]
-pub fn mcp_install_ide(ide_id: String) -> Result<(), String> {
+pub async fn mcp_install_ide(ide_id: String) -> Result<(), String> {
     let ide = parse_ide_type(&ide_id)?;
-    install_mcp_config(ide)
+    tauri::async_runtime::spawn_blocking(move || install_mcp_config(ide))
+        .await
+        .map_err(|e| format!("Install task failed: {e}"))?
 }
 
 /// Uninstall MCP configuration for a specific IDE
 #[tauri::command]
-pub fn mcp_uninstall_ide(ide_id: String) -> Result<(), String> {
+pub async fn mcp_uninstall_ide(ide_id: String) -> Result<(), String> {
     let ide = parse_ide_type(&ide_id)?;
-    uninstall_mcp_config(ide)
+    tauri::async_runtime::spawn_blocking(move || uninstall_mcp_config(ide))
+        .await
+        .map_err(|e| format!("Uninstall task failed: {e}"))?
 }
 
 /// Check if running in debug/development mode

--- a/src-tauri/src/commands/metrics.rs
+++ b/src-tauri/src/commands/metrics.rs
@@ -764,17 +764,23 @@ pub async fn get_pod_metrics_direct(
     }))
     .await;
 
+    // Partial failures are skipped, but if EVERY node failed the command
+    // must fail: the frontend falls back to metrics-server on error - an
+    // empty Ok would silently disable that fallback.
+    let (oks, errs): (Vec<_>, Vec<_>) = summaries.into_iter().partition(Result::is_ok);
+    if oks.is_empty() {
+        if let Some(Err(e)) = errs.into_iter().next() {
+            return Err(e);
+        }
+    } else {
+        for e in errs.into_iter().flat_map(Result::err) {
+            tracing::warn!("Skipping node in kubelet metrics: {e}");
+        }
+    }
+
     let mut all_pods: Vec<PodMetrics> = Vec::new();
 
-    for summary in summaries {
-        let summary = match summary {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!("Skipping node in kubelet metrics: {e}");
-                continue;
-            }
-        };
-
+    for summary in oks.into_iter().flat_map(Result::ok) {
         for pod in summary.pods {
             // Filter by namespace if specified
             if let Some(ns) = &namespace {

--- a/src-tauri/src/commands/metrics.rs
+++ b/src-tauri/src/commands/metrics.rs
@@ -108,6 +108,18 @@ pub struct ClusterMemorySummary {
     pub percentage: f64,
 }
 
+/// Map a metrics API error to a user-facing message: a 404/NotFound means
+/// metrics-server is simply not installed; anything else is a real error.
+fn classify_metrics_error(context: &str, e: &kube::Error) -> String {
+    if let kube::Error::Api(ae) = e {
+        if ae.code == 404 {
+            return "Metrics server not available. Please install metrics-server in your cluster."
+                .to_string();
+        }
+    }
+    format!("{context}: {e}")
+}
+
 /// Check if metrics-server is available
 async fn check_metrics_available(client: &Client) -> bool {
     let ar = ApiResource {
@@ -122,43 +134,45 @@ async fn check_metrics_available(client: &Client) -> bool {
     api.list(&ListParams::default().limit(1)).await.is_ok()
 }
 
-/// Parse CPU quantity string to nanocores
+/// Parse CPU quantity string to nanocores. Parses the numeric part as f64:
+/// quantities like "1.5" cores or "2.5m" are valid and must not become 0.
 fn parse_cpu_to_nanocores(cpu: &str) -> u64 {
     let cpu = cpu.trim();
-    if cpu.ends_with('n') {
-        cpu.trim_end_matches('n').parse().unwrap_or(0)
-    } else if cpu.ends_with('u') {
-        cpu.trim_end_matches('u').parse::<u64>().unwrap_or(0) * 1000
-    } else if cpu.ends_with('m') {
-        cpu.trim_end_matches('m').parse::<u64>().unwrap_or(0) * 1_000_000
+    let (num, mult) = if let Some(v) = cpu.strip_suffix('n') {
+        (v, 1.0)
+    } else if let Some(v) = cpu.strip_suffix('u') {
+        (v, 1e3)
+    } else if let Some(v) = cpu.strip_suffix('m') {
+        (v, 1e6)
     } else {
         // Whole cores
-        (cpu.parse::<f64>().unwrap_or(0.0) * 1_000_000_000.0) as u64
-    }
+        (cpu, 1e9)
+    };
+    (num.parse::<f64>().unwrap_or(0.0) * mult).round() as u64
 }
 
-/// Parse memory quantity string to bytes
+/// Parse memory quantity string to bytes. Parses the numeric part as f64:
+/// "1.5Gi" is a valid quantity and must not become 0.
 fn parse_memory_to_bytes(mem: &str) -> u64 {
     let mem = mem.trim();
-    if mem.ends_with("Ki") {
-        mem.trim_end_matches("Ki").parse::<u64>().unwrap_or(0) * 1024
-    } else if mem.ends_with("Mi") {
-        mem.trim_end_matches("Mi").parse::<u64>().unwrap_or(0) * 1024 * 1024
-    } else if mem.ends_with("Gi") {
-        mem.trim_end_matches("Gi").parse::<u64>().unwrap_or(0) * 1024 * 1024 * 1024
-    } else if mem.ends_with("Ti") {
-        mem.trim_end_matches("Ti").parse::<u64>().unwrap_or(0) * 1024 * 1024 * 1024 * 1024
-    } else if mem.ends_with('K') || mem.ends_with('k') {
-        mem.trim_end_matches(['K', 'k']).parse::<u64>().unwrap_or(0) * 1000
-    } else if mem.ends_with('M') {
-        mem.trim_end_matches('M').parse::<u64>().unwrap_or(0) * 1000 * 1000
-    } else if mem.ends_with('G') {
-        mem.trim_end_matches('G').parse::<u64>().unwrap_or(0) * 1000 * 1000 * 1000
-    } else if mem.ends_with('T') {
-        mem.trim_end_matches('T').parse::<u64>().unwrap_or(0) * 1000 * 1000 * 1000 * 1000
-    } else {
-        mem.parse().unwrap_or(0)
+    // Binary suffixes must be checked before their decimal prefixes
+    const UNITS: &[(&str, f64)] = &[
+        ("Ki", 1024.0),
+        ("Mi", 1048576.0),
+        ("Gi", 1073741824.0),
+        ("Ti", 1099511627776.0),
+        ("K", 1e3),
+        ("k", 1e3),
+        ("M", 1e6),
+        ("G", 1e9),
+        ("T", 1e12),
+    ];
+    for (suffix, mult) in UNITS {
+        if let Some(v) = mem.strip_suffix(suffix) {
+            return (v.parse::<f64>().unwrap_or(0.0) * mult).round() as u64;
+        }
     }
+    mem.parse::<f64>().unwrap_or(0.0).round() as u64
 }
 
 /// Format nanocores to human readable string
@@ -206,14 +220,8 @@ pub async fn get_node_metrics(
 ) -> Result<Vec<NodeMetrics>, String> {
     let client = state.k8s.get_client().await.map_err(|e| e.to_string())?;
 
-    if !check_metrics_available(&client).await {
-        return Err(
-            "Metrics server not available. Please install metrics-server in your cluster."
-                .to_string(),
-        );
-    }
-
-    // Get node metrics from metrics API
+    // No pre-check probe: the real query below fails with a classifiable
+    // 404 when metrics-server is missing - probing first doubles latency.
     let ar = ApiResource {
         group: "metrics.k8s.io".to_string(),
         version: "v1beta1".to_string(),
@@ -255,13 +263,13 @@ pub async fn get_node_metrics(
     let metrics_list = if let Some(name) = node_name {
         match metrics_api.get(&name).await {
             Ok(m) => vec![m],
-            Err(e) => return Err(format!("Failed to get node metrics: {}", e)),
+            Err(e) => return Err(classify_metrics_error("Failed to get node metrics", &e)),
         }
     } else {
         metrics_api
             .list(&ListParams::default())
             .await
-            .map_err(|e| format!("Failed to list node metrics: {}", e))?
+            .map_err(|e| classify_metrics_error("Failed to list node metrics", &e))?
             .items
     };
 
@@ -330,13 +338,8 @@ pub async fn get_pod_metrics(
 ) -> Result<Vec<PodMetrics>, String> {
     let client = state.k8s.get_client().await.map_err(|e| e.to_string())?;
 
-    if !check_metrics_available(&client).await {
-        return Err(
-            "Metrics server not available. Please install metrics-server in your cluster."
-                .to_string(),
-        );
-    }
-
+    // No pre-check probe: the real query below fails with a classifiable
+    // 404 when metrics-server is missing.
     let ar = ApiResource {
         group: "metrics.k8s.io".to_string(),
         version: "v1beta1".to_string(),
@@ -356,13 +359,13 @@ pub async fn get_pod_metrics(
         let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), &ns, &ar);
         match api.get(&name).await {
             Ok(m) => vec![m],
-            Err(e) => return Err(format!("Failed to get pod metrics: {}", e)),
+            Err(e) => return Err(classify_metrics_error("Failed to get pod metrics", &e)),
         }
     } else {
         metrics_api
             .list(&ListParams::default())
             .await
-            .map_err(|e| format!("Failed to list pod metrics: {}", e))?
+            .map_err(|e| classify_metrics_error("Failed to list pod metrics", &e))?
             .items
     };
 
@@ -733,32 +736,44 @@ pub async fn get_pod_metrics_direct(
         .await
         .map_err(|e| format!("Failed to list nodes: {}", e))?;
 
+    // Query all kubelets concurrently; a single unreachable node must not
+    // fail (or serialize) the whole scrape - its pods are simply skipped.
+    let summaries = futures::future::join_all(nodes.items.iter().filter_map(|node| {
+        let node_name = node.metadata.name.clone()?;
+        let client = client.clone();
+        Some(async move {
+            // Query kubelet via API server proxy: /api/v1/nodes/{node}/proxy/stats/summary
+            let url = format!("/api/v1/nodes/{}/proxy/stats/summary", node_name);
+            let req = hyper::Request::builder()
+                .uri(&url)
+                .body(Vec::new())
+                .map_err(|e| format!("Failed to build request: {}", e))?;
+
+            let resp = client
+                .request::<Vec<u8>>(req)
+                .await
+                .map_err(|e| format!("Failed to query kubelet on node {}: {}", node_name, e))?;
+
+            serde_json::from_slice::<kubelet_stats::Summary>(&resp).map_err(|e| {
+                format!(
+                    "Failed to parse kubelet stats from node {}: {}",
+                    node_name, e
+                )
+            })
+        })
+    }))
+    .await;
+
     let mut all_pods: Vec<PodMetrics> = Vec::new();
 
-    for node in &nodes.items {
-        let node_name = match &node.metadata.name {
-            Some(n) => n.clone(),
-            None => continue,
+    for summary in summaries {
+        let summary = match summary {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("Skipping node in kubelet metrics: {e}");
+                continue;
+            }
         };
-
-        // Query kubelet via API server proxy: /api/v1/nodes/{node}/proxy/stats/summary
-        let url = format!("/api/v1/nodes/{}/proxy/stats/summary", node_name);
-        let req = hyper::Request::builder()
-            .uri(&url)
-            .body(Vec::new())
-            .map_err(|e| format!("Failed to build request: {}", e))?;
-
-        let resp = client
-            .request::<Vec<u8>>(req)
-            .await
-            .map_err(|e| format!("Failed to query kubelet on node {}: {}", node_name, e))?;
-
-        let summary: kubelet_stats::Summary = serde_json::from_slice(&resp).map_err(|e| {
-            format!(
-                "Failed to parse kubelet stats from node {}: {}",
-                node_name, e
-            )
-        })?;
 
         for pod in summary.pods {
             // Filter by namespace if specified
@@ -833,4 +848,32 @@ pub async fn get_pod_metrics_direct(
 
     tracing::info!("Got direct kubelet metrics for {} pods", all_pods.len());
     Ok(all_pods)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_cpu_to_nanocores, parse_memory_to_bytes};
+
+    #[test]
+    fn parses_fractional_quantities() {
+        // Regression: fractional values parsed as u64 silently became 0
+        assert_eq!(parse_memory_to_bytes("1.5Gi"), 1_610_612_736);
+        assert_eq!(parse_cpu_to_nanocores("2.5m"), 2_500_000);
+        assert_eq!(parse_cpu_to_nanocores("1.5"), 1_500_000_000);
+    }
+
+    #[test]
+    fn parses_integer_quantities() {
+        assert_eq!(parse_cpu_to_nanocores("250m"), 250_000_000);
+        assert_eq!(parse_cpu_to_nanocores("100n"), 100);
+        assert_eq!(parse_memory_to_bytes("128Mi"), 134_217_728);
+        assert_eq!(parse_memory_to_bytes("1G"), 1_000_000_000);
+        assert_eq!(parse_memory_to_bytes("128974848"), 128_974_848);
+    }
+
+    #[test]
+    fn invalid_quantities_fall_back_to_zero() {
+        assert_eq!(parse_cpu_to_nanocores("garbage"), 0);
+        assert_eq!(parse_memory_to_bytes(""), 0);
+    }
 }

--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -1140,7 +1140,9 @@ async fn get_helm_release_yaml(
 ) -> Result<ResourceYaml, KubeliError> {
     let ns = namespace.ok_or("Namespace required for helm releases")?;
     let api: Api<Secret> = Api::namespaced(client, &ns);
-    let lp = ListParams::default().labels("owner=helm");
+    // Server-side filter on the release name - avoids downloading every
+    // release secret in the namespace.
+    let lp = ListParams::default().labels(&format!("owner=helm,name={}", name));
     let secrets: Vec<Secret> = api.list(&lp).await?.items;
 
     let prefix = format!("sh.helm.release.v1.{}.v", name);
@@ -1166,23 +1168,29 @@ async fn get_helm_release_yaml(
         .and_then(|d| d.get("release"))
         .ok_or("Release data not found in secret")?;
 
-    // Decode: base64 -> (maybe base64) -> gzip -> json
-    let data_str = String::from_utf8_lossy(&data.0);
-    let decoded1 = BASE64.decode(data_str.as_ref())?;
+    // Decode: base64 -> (maybe base64) -> gzip -> json. Runs on the blocking
+    // pool with a decompression cap - multi-MB releases must not stall the
+    // async runtime, gzip bombs must not OOM it.
+    const MAX_HELM_RELEASE_BYTES: u64 = 64 * 1024 * 1024;
+    let data_str = String::from_utf8_lossy(&data.0).into_owned();
+    let yaml = tauri::async_runtime::spawn_blocking(move || -> Result<String, KubeliError> {
+        let decoded1 = BASE64.decode(&data_str)?;
 
-    let gzip_data = if decoded1.len() >= 2 && decoded1[0] == 0x1f && decoded1[1] == 0x8b {
-        decoded1
-    } else {
-        BASE64.decode(&decoded1)?
-    };
+        let gzip_data = if decoded1.len() >= 2 && decoded1[0] == 0x1f && decoded1[1] == 0x8b {
+            decoded1
+        } else {
+            BASE64.decode(&decoded1)?
+        };
 
-    let mut decoder = GzDecoder::new(&gzip_data[..]);
-    let mut decompressed = String::new();
-    decoder.read_to_string(&mut decompressed)?;
+        let mut decoder = GzDecoder::new(&gzip_data[..]).take(MAX_HELM_RELEASE_BYTES);
+        let mut decompressed = String::new();
+        decoder.read_to_string(&mut decompressed)?;
 
-    let release_data: Value = serde_json::from_str(&decompressed)?;
-
-    let yaml = serde_yaml::to_string(&release_data)?;
+        let release_data: Value = serde_json::from_str(&decompressed)?;
+        Ok(serde_yaml::to_string(&release_data)?)
+    })
+    .await
+    .map_err(|e| KubeliError::unknown(format!("Helm decode task failed: {e}")))??;
 
     Ok(ResourceYaml {
         yaml,

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -208,6 +208,48 @@ pub async fn shell_start(
     Ok(())
 }
 
+/// Max bytes accumulated before a shell output batch is flushed regardless
+/// of timing.
+const MAX_SHELL_BATCH: usize = 64 * 1024;
+/// How long to keep draining further reads before flushing a batch.
+const SHELL_BATCH_WINDOW: std::time::Duration = std::time::Duration::from_millis(8);
+
+/// Emit the decodable prefix of `pending`; an incomplete trailing UTF-8
+/// sequence stays buffered for the next read unless `take_all` is set
+/// (EOF - nothing more will arrive to complete it).
+fn flush_shell_output(app: &AppHandle, event_name: &str, pending: &mut Vec<u8>, take_all: bool) {
+    let output = take_valid_utf8(pending, take_all);
+    if !output.is_empty() {
+        let _ = app.emit(event_name, ShellEvent::Output(output));
+    }
+}
+
+/// Split the valid UTF-8 prefix out of `pending`. A truncated multi-byte
+/// sequence at the end is kept for the next chunk; genuinely invalid bytes
+/// are lossy-decoded so the stream cannot stall on binary output.
+fn take_valid_utf8(pending: &mut Vec<u8>, take_all: bool) -> String {
+    match std::str::from_utf8(pending) {
+        Ok(s) => {
+            let out = s.to_string();
+            pending.clear();
+            out
+        }
+        Err(e) if e.error_len().is_none() && !take_all => {
+            // Incomplete trailing sequence: emit the valid part, keep the tail
+            let valid = e.valid_up_to();
+            let out = String::from_utf8_lossy(&pending[..valid]).into_owned();
+            pending.drain(..valid);
+            out
+        }
+        Err(_) => {
+            // Invalid bytes mid-stream (or EOF with a truncated tail)
+            let out = String::from_utf8_lossy(pending).into_owned();
+            pending.clear();
+            out
+        }
+    }
+}
+
 /// Run the shell session handling stdin/stdout
 async fn run_shell_session(
     mut attached: AttachedProcess,
@@ -224,6 +266,10 @@ async fn run_shell_session(
     let mut terminal_size_tx = attached.terminal_size();
 
     let mut stdout_buf = vec![0u8; 4096];
+    // Carries bytes across reads: an incomplete trailing UTF-8 sequence from
+    // one chunk is completed by the next instead of being lossy-decoded into
+    // replacement characters mid-glyph.
+    let mut pending: Vec<u8> = Vec::new();
 
     loop {
         if stop_flag.load(Ordering::SeqCst) {
@@ -260,11 +306,34 @@ async fn run_shell_session(
                 match result {
                     Ok(0) => {
                         // EOF
+                        flush_shell_output(&app, event_name, &mut pending, true);
                         break;
                     }
                     Ok(n) => {
-                        let output = String::from_utf8_lossy(&stdout_buf[..n]).to_string();
-                        let _ = app.emit(event_name, ShellEvent::Output(output));
+                        pending.extend_from_slice(&stdout_buf[..n]);
+                        // Batch: keep draining for a few ms so fast producers
+                        // (e.g. `cat` of a large file) emit one IPC event per
+                        // ~batch instead of one per 4 KB read.
+                        let mut eof = false;
+                        while pending.len() < MAX_SHELL_BATCH {
+                            match tokio::time::timeout(
+                                SHELL_BATCH_WINDOW,
+                                stdout.read(&mut stdout_buf),
+                            )
+                            .await
+                            {
+                                Ok(Ok(0)) => {
+                                    eof = true;
+                                    break;
+                                }
+                                Ok(Ok(n)) => pending.extend_from_slice(&stdout_buf[..n]),
+                                Ok(Err(_)) | Err(_) => break,
+                            }
+                        }
+                        flush_shell_output(&app, event_name, &mut pending, eof);
+                        if eof {
+                            break;
+                        }
                     }
                     Err(e) => {
                         let _ = app.emit(event_name, ShellEvent::Error(format!("Read error: {}", e)));
@@ -637,4 +706,38 @@ pub async fn node_shell_cleanup(
         tracing::info!("Closed node shell session {}", session_id);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::take_valid_utf8;
+
+    #[test]
+    fn keeps_incomplete_utf8_tail_for_next_chunk() {
+        // "ä" (0xC3 0xA4) split across two reads
+        let mut pending = vec![b'a', 0xC3];
+        assert_eq!(take_valid_utf8(&mut pending, false), "a");
+        assert_eq!(pending, vec![0xC3]);
+
+        pending.push(0xA4);
+        assert_eq!(take_valid_utf8(&mut pending, false), "ä");
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn lossy_decodes_genuinely_invalid_bytes_without_stalling() {
+        let mut pending = vec![b'a', 0xFF, b'b'];
+        let out = take_valid_utf8(&mut pending, false);
+        assert!(out.starts_with('a') && out.ends_with('b'));
+        assert!(out.contains('\u{FFFD}'));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn final_flush_emits_truncated_tail_as_replacement() {
+        let mut pending = vec![b'a', 0xC3];
+        let out = take_valid_utf8(&mut pending, true);
+        assert_eq!(out, "a\u{FFFD}");
+        assert!(pending.is_empty());
+    }
 }

--- a/src-tauri/src/k8s/client.rs
+++ b/src-tauri/src/k8s/client.rs
@@ -374,21 +374,34 @@ impl KubeClientManager {
         }
     }
 
-    /// List all namespaces
+    /// List all namespaces (metadata only - names are all we need) with a
+    /// hard timeout so a hanging API server cannot stall the caller.
     pub async fn list_namespaces(&self) -> Result<Vec<String>> {
         let client = self.get_client().await?;
         let namespaces: Api<Namespace> = Api::all(client);
 
-        let list = namespaces
-            .list(&ListParams::default())
-            .await
-            .context("Failed to list namespaces")?;
+        // Page through results (500/page) so huge clusters neither truncate
+        // nor produce one giant response.
+        let mut names = Vec::new();
+        let mut continue_token: Option<String> = None;
+        loop {
+            let mut params = ListParams::default().limit(500).timeout(10);
+            if let Some(token) = &continue_token {
+                params = params.continue_token(token);
+            }
+            let list =
+                tokio::time::timeout(Duration::from_secs(15), namespaces.list_metadata(&params))
+                    .await
+                    .context("Timed out listing namespaces")?
+                    .context("Failed to list namespaces")?;
 
-        Ok(list
-            .items
-            .into_iter()
-            .filter_map(|ns| ns.metadata.name)
-            .collect())
+            continue_token = list.metadata.continue_.clone().filter(|t| !t.is_empty());
+            names.extend(list.items.into_iter().filter_map(|ns| ns.metadata.name));
+            if continue_token.is_none() {
+                break;
+            }
+        }
+        Ok(names)
     }
 }
 

--- a/src/components/features/home/components/ClusterGrid.tsx
+++ b/src/components/features/home/components/ClusterGrid.tsx
@@ -103,16 +103,19 @@ export function ClusterGrid() {
   useEffect(() => {
     let cancelled = false;
     async function loadConfigured() {
-      const configured = new Set<string>();
-      for (const cluster of clusters) {
-        try {
+      // One call per cluster, all in parallel - sequential awaits made the
+      // grid wait clusters x RTT before showing namespace badges
+      const results = await Promise.allSettled(
+        clusters.map(async (cluster) => {
           const settings = await getClusterSettings(cluster.context);
-          if (settings && settings.accessible_namespaces.length > 0) {
-            configured.add(cluster.context);
-          }
-        } catch {
-          // Ignore errors
-        }
+          return settings && settings.accessible_namespaces.length > 0
+            ? cluster.context
+            : null;
+        }),
+      );
+      const configured = new Set<string>();
+      for (const r of results) {
+        if (r.status === "fulfilled" && r.value) configured.add(r.value);
       }
       if (!cancelled) nsDialogDispatch({ type: "setConfigured", contexts: configured });
     }

--- a/src/components/features/tray/ForwardTab.tsx
+++ b/src/components/features/tray/ForwardTab.tsx
@@ -44,13 +44,18 @@ export function ForwardTab() {
     return `${selectedNamespaces.length} namespaces`;
   }, [selectedNamespaces]);
 
+  const fetchSeq = useRef(0);
+
   const fetchResources = useCallback(async () => {
+    const seq = ++fetchSeq.current;
     setIsRefreshing(true);
     try {
       const [pods, services] = await Promise.all([
         listPods().catch(() => [] as PodInfo[]),
         listServices().catch(() => [] as ServiceInfo[]),
       ]);
+      // A newer fetch superseded this one - drop the stale result
+      if (seq !== fetchSeq.current) return;
 
       const forwardable: ForwardableItem[] = [];
 
@@ -86,21 +91,15 @@ export function ForwardTab() {
     } catch (err) {
       console.error("Failed to fetch resources:", err);
     } finally {
-      setIsRefreshing(false);
+      if (seq === fetchSeq.current) {
+        setIsRefreshing(false);
+      }
     }
   }, []);
 
   useEffect(() => {
     fetchResources();
   }, [fetchResources]);
-
-  // Refetch when namespace selection changes
-  useEffect(() => {
-    if (hasLoaded.current) {
-      fetchResources();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNamespaces]);
 
   const filtered = useMemo(() => {
     let result = items;

--- a/src/lib/hooks/useDeploymentLogs.ts
+++ b/src/lib/hooks/useDeploymentLogs.ts
@@ -124,14 +124,25 @@ export function useDeploymentLogs(
     if (batch.length === 0 || !mountedRef.current) return;
 
     const maxLines = getMaxLines();
+    const cmp = (a: LogEntry, b: LogEntry) => {
+      if (!a.timestamp && !b.timestamp) return 0;
+      if (!a.timestamp) return -1;
+      if (!b.timestamp) return 1;
+      return a.timestamp.localeCompare(b.timestamp);
+    };
     setLogs((prev) => {
-      const next = [...prev, ...batch];
-      next.sort((a, b) => {
-        if (!a.timestamp && !b.timestamp) return 0;
-        if (!a.timestamp) return -1;
-        if (!b.timestamp) return 1;
-        return a.timestamp.localeCompare(b.timestamp);
-      });
+      // prev is already sorted - only sort the incoming batch, then merge.
+      // Full re-sort per flush is O(n log n) on the whole buffer and made
+      // busy multi-pod streams CPU-bound.
+      batch.sort(cmp);
+      const next: LogEntry[] = [];
+      let i = 0;
+      let j = 0;
+      while (i < prev.length && j < batch.length) {
+        next.push(cmp(prev[i], batch[j]) <= 0 ? prev[i++] : batch[j++]);
+      }
+      while (i < prev.length) next.push(prev[i++]);
+      while (j < batch.length) next.push(batch[j++]);
       if (next.length > maxLines) {
         next.splice(0, next.length - maxLines);
       }
@@ -251,6 +262,10 @@ export function useDeploymentLogs(
             switch (logEvent.type) {
               case "Line":
                 pendingLogsRef.current.push(logEvent.data);
+                scheduleFlush();
+                break;
+              case "Lines":
+                pendingLogsRef.current.push(...logEvent.data);
                 scheduleFlush();
                 break;
               case "Error":

--- a/src/lib/stores/log-store.ts
+++ b/src/lib/stores/log-store.ts
@@ -8,7 +8,7 @@ import {
   stopLogStream,
   getPodContainers,
 } from "../tauri/commands";
-import type { LogEntry, LogOptions, LogEvent } from "../types";
+import type { LogEntry, LogOptions, LogEvent, PodInfo, WatchEvent } from "../types";
 import { type KubeliError, toKubeliError, getErrorMessage } from "../types/errors";
 import { useUIStore } from "./ui-store";
 
@@ -73,7 +73,7 @@ const stampSeq = (entry: LogEntry): LogEntry => ({ ...entry, seq: ++logSeq });
 const listeners = new Map<string, UnlistenFn>();
 const pendingLogs = new Map<string, LogEntry[]>();
 const flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
-const podWatchers = new Map<string, ReturnType<typeof setInterval>>();
+const podWatchers = new Map<string, () => void>();
 
 const podWatchInfo = new Map<string, PodWatchInfo>();
 
@@ -82,47 +82,71 @@ interface PodWatchInfo {
   podName: string;
 }
 
-const POD_CHECK_INTERVAL = 2000;
+/** Mark a log tab as errored because its pod disappeared. */
+function markPodGone(
+  tabId: string,
+  pod: string,
+  set: (fn: (s: LogStoreState) => Partial<LogStoreState>) => void
+) {
+  set((s) => {
+    const t = s.logTabs[tabId];
+    if (!t) return {};
+    return {
+      logTabs: {
+        ...s.logTabs,
+        [tabId]: {
+          ...t,
+          error: toKubeliError(`Pod ${pod} not found (deleted?)`),
+          isStreaming: false,
+        },
+      },
+    };
+  });
+  stopPodWatcher(tabId);
+}
 
-function startPodWatcher(tabId: string, ns: string, pod: string, set: (fn: (s: LogStoreState) => Partial<LogStoreState>) => void, get: () => LogStoreState) {
+// Watch-based pod-existence tracking: a Deleted watch event flags the tab
+// instead of polling the API every 2 s per open log tab.
+async function startPodWatcher(
+  tabId: string,
+  ns: string,
+  pod: string,
+  set: (fn: (s: LogStoreState) => Partial<LogStoreState>) => void
+) {
   stopPodWatcher(tabId);
   podWatchInfo.set(tabId, { namespace: ns, podName: pod });
 
-  const check = async () => {
-    const tab = get().logTabs[tabId];
-    if (!tab || tab.error) return;
-
-    // Skip API call for inactive tabs to reduce unnecessary polling
-    const activeTabId = get().activeTabId;
-    if (activeTabId && tabId !== activeTabId) return;
-
-    try {
-      await getPodContainers(ns, pod);
-    } catch (e) {
-      const msg = getErrorMessage(e);
-      if (msg.includes("NotFound") || msg.includes("not found")) {
-        set((s) => {
-          const t = s.logTabs[tabId];
-          if (!t) return {};
-          return {
-            logTabs: {
-              ...s.logTabs,
-              [tabId]: { ...t, error: toKubeliError(e), isStreaming: false },
-            },
-          };
-        });
-        stopPodWatcher(tabId);
+  const watchId = `log-pod-${tabId}-${Date.now()}`;
+  try {
+    const { watchPods, stopWatch } = await import("../tauri/commands");
+    const unlisten = await listen<WatchEvent<PodInfo>>(
+      `pods-watch-${watchId}`,
+      (event) => {
+        const we = event.payload;
+        if (we.type === "Deleted") {
+          const p = we.data as PodInfo;
+          if (p.name === pod) markPodGone(tabId, pod, set);
+        } else if (we.type === "Restarted") {
+          // Watch resynced - pod may have vanished while we were not looking
+          const all = we.data as PodInfo[];
+          if (!all.some((p) => p.name === pod)) markPodGone(tabId, pod, set);
+        }
       }
-    }
-  };
-
-  podWatchers.set(tabId, setInterval(check, POD_CHECK_INTERVAL));
+    );
+    podWatchers.set(tabId, () => {
+      unlisten();
+      stopWatch(watchId).catch(() => {});
+    });
+    await watchPods(watchId, ns);
+  } catch {
+    // Watch unavailable - the log stream itself will surface errors
+  }
 }
 
 function stopPodWatcher(tabId: string) {
-  const timer = podWatchers.get(tabId);
-  if (timer) {
-    clearInterval(timer);
+  const cleanup = podWatchers.get(tabId);
+  if (cleanup) {
+    cleanup();
     podWatchers.delete(tabId);
   }
   podWatchInfo.delete(tabId);
@@ -217,8 +241,8 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
       }
     }
 
-    // Start polling for pod existence
-    startPodWatcher(tabId, ns, pod, set, get);
+    // Watch pod existence (Deleted event flags the tab)
+    startPodWatcher(tabId, ns, pod, set);
   },
 
   async startStream(tabId, ns, pod, container, tailLines) {
@@ -255,6 +279,18 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
               pendingLogs.set(tabId, pending);
             }
             pending.push(stampSeq(logEvent.data));
+            scheduleFlush(tabId, set);
+            break;
+          }
+          case "Lines": {
+            let pending = pendingLogs.get(tabId);
+            if (!pending) {
+              pending = [];
+              pendingLogs.set(tabId, pending);
+            }
+            for (const entry of logEvent.data) {
+              pending.push(stampSeq(entry));
+            }
             scheduleFlush(tabId, set);
             break;
           }

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -141,10 +141,11 @@ export interface LogOptions {
   previous?: boolean;
 }
 
-export type LogEventType = "Line" | "Error" | "Started" | "Stopped";
+export type LogEventType = "Line" | "Lines" | "Error" | "Started" | "Stopped";
 
 export type LogEvent =
   | { type: "Line"; data: LogEntry }
+  | { type: "Lines"; data: LogEntry[] }
   | { type: "Error"; data: KubeliError }
   | { type: "Started"; data: { stream_id: string } }
   | { type: "Stopped"; data: { stream_id: string } };


### PR DESCRIPTION
## Summary

Backend performance pass (tasks 1.5 + 1.6 + 1.7 + the rusqlite part of 3.6).

### IPC/stream batching
- **Log streaming**: lines are batched (50 ms / 100 lines) into one `Lines` IPC event — a busy pod no longer fires one webview event per line
- **Shell output**: reads drain over an 8 ms window before emitting; UTF-8 carry-over completes multi-byte sequences split across 4 KB chunks (no more replacement chars mid-glyph) — with unit tests
- **Deployment logs**: flush merges the sorted batch into the sorted buffer instead of re-sorting everything each 150 ms
- **Pod existence**: log tabs subscribe to watch `Deleted` events instead of polling the API every 2 s per tab

### Query efficiency
- `list_namespaces`: metadata-only, paginated, hard timeout
- Helm: server-side `owner=helm,name=<release>` filter; decode on the blocking pool, 64 MB decompression cap
- Resource graph: per-namespace queries when filtered; Pod→Deployment via ReplicaSet owner references (authoritative, O(1)) instead of label matching
- Metrics: pre-check probe removed (real 404 classified instead — one round-trip saved per call), kubelet stats queried in parallel with per-node failure skip, quantities parsed as f64 (`1.5Gi` counted as 0 before) — with regression tests
- Kubeconfig sources: 3 s parse cache shared by `list_clusters`/`connect_cluster`, invalidated on source changes
- `mcp_install_ide`/`mcp_uninstall_ide`: async + spawn_blocking
- ClusterGrid settings parallel; ForwardTab no longer refetches on namespace toggle + sequence guard
- AI session store: all rusqlite calls on the blocking pool

### Build
- `codegen-units = 1`, `panic = "abort"` in release profile
- tokio features enumerated instead of `full`
- `cargo tree -d`: remaining duplicates (base64 0.21/0.22, bitflags 1/2, digest 0.10/0.11, …) are all transitive via kube/tauri — nothing actionable directly; binary size delta will show in the next release CI artifacts

## Tests

235 cargo (+6 new), 638 jest, clippy, lint, typecheck green.

## Manual smoke checklist (before merge)

- [ ] Pod-Logs streamen (busy Pod) — flüssig, keine kaputten Umlaute im Shell-Output
- [ ] Deployment-Logs mit mehreren Pods
- [ ] Pod löschen während Log-Tab offen → Tab zeigt Fehler
- [ ] Resource Diagram mit/ohne Namespace-Filter
- [ ] Metrics-Dashboard (mit metrics-server)
- [ ] Helm-Release Details/History
- [ ] Tray: Port-Forward-Tab Namespace-Filter