### PR TITLE
fix: connect state machine, teardown, watch/portforward lifecycle

### DIFF
--- a/src-tauri/src/commands/clusters/commands.rs
+++ b/src-tauri/src/commands/clusters/commands.rs
@@ -19,6 +19,29 @@ use super::types::{
     ClusterInfo, ConnectionStatus, HealthCheckResult, NamespaceResult, OidcAuthInfo,
 };
 
+/// Stop every session (watches, log streams, shells, port-forwards) that
+/// belongs to the current connection. Called before switching contexts and
+/// on disconnect - otherwise streams keep running against the old cluster.
+async fn teardown_active_sessions(app: &AppHandle, state: &AppState) {
+    let old_client = state.k8s.get_client().await.ok();
+
+    let watches: State<'_, Arc<crate::commands::watch::WatchManager>> = app.state();
+    watches.stop_all().await;
+
+    let logs: State<'_, Arc<crate::commands::logs::LogStreamManager>> = app.state();
+    logs.stop_all().await;
+
+    let forwards: State<'_, Arc<crate::commands::portforward::PortForwardManager>> = app.state();
+    forwards.stop_all().await;
+
+    let pf_watches: State<'_, Arc<crate::commands::portforward::PortForwardWatchManager>> =
+        app.state();
+    pf_watches.stop_all().await;
+
+    let shells: State<'_, Arc<crate::commands::shell::ShellSessionManager>> = app.state();
+    shells.stop_all(old_client).await;
+}
+
 /// List all available clusters from kubeconfig
 #[command]
 pub async fn list_clusters(
@@ -134,6 +157,21 @@ pub async fn connect_cluster(
     context: String,
 ) -> Result<ConnectionStatus, KubeliError> {
     tracing::info!("Connecting to cluster with context: {}", context);
+
+    // Serialize connect attempts - two racing connects would interleave
+    // init/test and could leave client and context mismatched.
+    let _connect_guard = state.k8s.begin_connect().await;
+
+    // Stop a previous connection's OIDC refresh loop before switching; a
+    // non-OIDC target would otherwise keep the old task alive forever.
+    {
+        let oidc_state: State<'_, Arc<OidcState>> = app.state();
+        oidc_state.cancel_refresh();
+    }
+
+    // Tear down all sessions of the previous connection before the client
+    // is replaced.
+    teardown_active_sessions(&app, &state).await;
 
     // Resolve source_file for this context before building the kubeconfig
     let source_file = load_kubeconfig_from_sources(&app).await.and_then(|cfg| {
@@ -255,78 +293,104 @@ pub async fn connect_cluster(
         }
     }
 
-    match state
-        .k8s
-        .init_with_context(&context, kubeconfig.clone(), source_file.as_deref())
-        .await
-    {
-        Ok(_) => {
-            // Test the connection with latency measurement
-            let start = std::time::Instant::now();
-            match state.k8s.test_connection().await {
-                Ok(true) => {
-                    let latency = start.elapsed().as_millis() as u64;
-                    tracing::info!(
-                        "Successfully connected to cluster: {} (latency: {}ms)",
-                        context,
-                        latency
-                    );
-                    // Keep the OIDC token fresh for the lifetime of the connection
-                    if let (Some(oidc_config), Some(ref user)) = (active_oidc, &user_name) {
-                        let oidc_state: State<'_, Arc<OidcState>> = app.state();
-                        spawn_oidc_refresh_task(
-                            app.clone(),
-                            state.k8s.client_handle(),
-                            state.k8s.context_handle(),
-                            Arc::clone(&oidc_state),
-                            oidc_config,
-                            context.clone(),
-                            kubeconfig,
-                            user.clone(),
-                        );
-                    }
+    // Hard timeout: exec-plugin based configs can hang indefinitely (e.g.
+    // waiting for a device-code login that never happens).
+    let init_result = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        state
+            .k8s
+            .init_with_context(&context, kubeconfig.clone(), source_file.as_deref()),
+    )
+    .await;
 
-                    Ok(ConnectionStatus {
-                        connected: true,
-                        context: Some(context),
-                        error: None,
-                        latency_ms: Some(latency),
-                        oidc_auth_required: None,
-                    })
-                }
-                Ok(false) => {
-                    let latency = start.elapsed().as_millis() as u64;
-                    tracing::warn!("Connection test failed for context: {}", context);
-                    Ok(ConnectionStatus {
-                        connected: false,
-                        context: Some(context),
-                        error: Some("Connection test failed - unable to reach cluster".to_string()),
-                        latency_ms: Some(latency),
-                        oidc_auth_required: None,
-                    })
-                }
-                Err(e) => {
-                    tracing::error!("Connection test error: {}", e);
-                    Ok(ConnectionStatus {
-                        connected: false,
-                        context: Some(context),
-                        error: Some(format!("Connection test failed: {}", e)),
-                        latency_ms: None,
-                        oidc_auth_required: None,
-                    })
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to connect to cluster: {}", e);
-            Ok(ConnectionStatus {
+    match init_result {
+        Err(_) => {
+            tracing::error!("Connection init timed out for context: {}", context);
+            state.k8s.clear_connection().await;
+            return Ok(ConnectionStatus {
                 connected: false,
                 context: Some(context),
-                error: Some(format!("Failed to connect: {}", e)),
+                error: Some("Connection attempt timed out after 30s".to_string()),
                 latency_ms: None,
                 oidc_auth_required: None,
-            })
+            });
         }
+        Ok(init_result) => match init_result {
+            Ok(_) => {
+                // Test the connection with latency measurement
+                let start = std::time::Instant::now();
+                match state.k8s.test_connection().await {
+                    Ok(true) => {
+                        let latency = start.elapsed().as_millis() as u64;
+                        tracing::info!(
+                            "Successfully connected to cluster: {} (latency: {}ms)",
+                            context,
+                            latency
+                        );
+                        // Keep the OIDC token fresh for the lifetime of the connection
+                        if let (Some(oidc_config), Some(ref user)) = (active_oidc, &user_name) {
+                            let oidc_state: State<'_, Arc<OidcState>> = app.state();
+                            spawn_oidc_refresh_task(
+                                app.clone(),
+                                state.k8s.client_handle(),
+                                state.k8s.context_handle(),
+                                Arc::clone(&oidc_state),
+                                oidc_config,
+                                context.clone(),
+                                kubeconfig,
+                                user.clone(),
+                            );
+                        }
+
+                        Ok(ConnectionStatus {
+                            connected: true,
+                            context: Some(context),
+                            error: None,
+                            latency_ms: Some(latency),
+                            oidc_auth_required: None,
+                        })
+                    }
+                    Ok(false) => {
+                        let latency = start.elapsed().as_millis() as u64;
+                        tracing::warn!("Connection test failed for context: {}", context);
+                        state.k8s.clear_connection().await;
+                        Ok(ConnectionStatus {
+                            connected: false,
+                            context: Some(context),
+                            error: Some(
+                                "Connection test failed - unable to reach cluster".to_string(),
+                            ),
+                            latency_ms: Some(latency),
+                            oidc_auth_required: None,
+                        })
+                    }
+                    Err(e) => {
+                        tracing::error!("Connection test error: {}", e);
+                        state.k8s.clear_connection().await;
+                        Ok(ConnectionStatus {
+                            connected: false,
+                            context: Some(context),
+                            error: Some(format!("Connection test failed: {}", e)),
+                            latency_ms: None,
+                            oidc_auth_required: None,
+                        })
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to connect to cluster: {}", e);
+                // A failed init may have overwritten (or half-replaced) the
+                // previous connection - never keep a client that did not pass.
+                state.k8s.clear_connection().await;
+                Ok(ConnectionStatus {
+                    connected: false,
+                    context: Some(context),
+                    error: Some(format!("Failed to connect: {}", e)),
+                    latency_ms: None,
+                    oidc_auth_required: None,
+                })
+            }
+        },
     }
 }
 
@@ -349,8 +413,8 @@ pub async fn disconnect_cluster(
     tracing::info!("Disconnecting from cluster");
     let oidc_state: State<'_, Arc<OidcState>> = app.state();
     oidc_state.cancel_refresh();
-    *state.k8s.client_handle().write().await = None;
-    *state.k8s.context_handle().write().await = None;
+    teardown_active_sessions(&app, &state).await;
+    state.k8s.clear_connection().await;
     Ok(())
 }
 
@@ -466,7 +530,7 @@ async fn sleep_cancellable(seconds: u64, stop_flag: &std::sync::atomic::AtomicBo
     let check_interval = seconds.clamp(1, 5);
     let mut elapsed = 0u64;
     while elapsed < seconds {
-        if stop_flag.load(Ordering::Relaxed) {
+        if stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
             return false;
         }
         let step = std::cmp::min(check_interval, seconds - elapsed);
@@ -555,9 +619,15 @@ fn spawn_oidc_refresh_task(
                     // matches, a newer client either is or will be installed and
                     // we must not clobber it with this stale one.
                     let mut client_guard = k8s_manager.write().await;
-                    if !refresh_target_is_current(&k8s_connected, &context_name).await {
+                    // Check the stop flag under the same lock: a reconnect to
+                    // the SAME context arms a new refresh task - the context
+                    // check alone would not stop this superseded one from
+                    // clobbering the new connection's client.
+                    if stop_flag.load(std::sync::atomic::Ordering::Relaxed)
+                        || !refresh_target_is_current(&k8s_connected, &context_name).await
+                    {
                         tracing::debug!(
-                            "OIDC refresh: context changed during refresh, discarding stale client"
+                            "OIDC refresh: superseded during refresh, discarding stale client"
                         );
                         break;
                     }

--- a/src-tauri/src/commands/clusters/commands.rs
+++ b/src-tauri/src/commands/clusters/commands.rs
@@ -307,13 +307,13 @@ pub async fn connect_cluster(
         Err(_) => {
             tracing::error!("Connection init timed out for context: {}", context);
             state.k8s.clear_connection().await;
-            return Ok(ConnectionStatus {
+            Ok(ConnectionStatus {
                 connected: false,
                 context: Some(context),
                 error: Some("Connection attempt timed out after 30s".to_string()),
                 latency_ms: None,
                 oidc_auth_required: None,
-            });
+            })
         }
         Ok(init_result) => match init_result {
             Ok(_) => {

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -91,6 +91,16 @@ impl LogStreamManager {
         let streams = self.active_streams.read().await;
         streams.contains_key(id)
     }
+
+    /// Stop every active log stream. Called on disconnect/context switch so
+    /// no stream keeps reading from the previous cluster.
+    pub async fn stop_all(&self) {
+        let mut streams = self.active_streams.write().await;
+        for session in streams.values() {
+            session.stop_flag.store(true, Ordering::SeqCst);
+        }
+        streams.clear();
+    }
 }
 
 impl Default for LogStreamManager {
@@ -593,5 +603,21 @@ mod tests {
         let manager = LogStreamManager::default();
         // Just verify it doesn't panic and creates properly
         assert!(std::mem::size_of_val(&manager) > 0);
+    }
+
+    #[tokio::test]
+    async fn stop_all_flags_every_stream_and_clears_the_map() {
+        let manager = LogStreamManager::new();
+        let flag_a = Arc::new(AtomicBool::new(false));
+        let flag_b = Arc::new(AtomicBool::new(false));
+        manager.add_stream("a".into(), flag_a.clone()).await;
+        manager.add_stream("b".into(), flag_b.clone()).await;
+
+        manager.stop_all().await;
+
+        assert!(flag_a.load(Ordering::SeqCst));
+        assert!(flag_b.load(Ordering::SeqCst));
+        assert!(!manager.is_active("a").await);
+        assert!(!manager.is_active("b").await);
     }
 }

--- a/src-tauri/src/commands/portforward.rs
+++ b/src-tauri/src/commands/portforward.rs
@@ -8,16 +8,19 @@ use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{command, AppHandle, Emitter, State};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
+use tokio_util::sync::CancellationToken;
 
 /// Port forward session state
 struct PortForwardSession {
-    stop_flag: Arc<AtomicBool>,
+    cancel: CancellationToken,
+    /// Becomes true once the forward task has exited and dropped its listener,
+    /// i.e. the local port is free again.
+    finished: watch::Receiver<bool>,
     local_port: u16,
     target_port: u16,
     target_type: PortForwardTargetType,
@@ -147,21 +150,45 @@ impl PortForwardManager {
     async fn stop_session(&self, id: &str) -> bool {
         let sessions = self.sessions.read().await;
         if let Some(session) = sessions.get(id) {
-            session.stop_flag.store(true, Ordering::SeqCst);
+            session.cancel.cancel();
             true
         } else {
             false
         }
     }
 
-    async fn remove_session(&self, id: &str) {
+    /// Remove a session. Returns the removed entry so callers can release
+    /// resources tied to it exactly once (see `cleanup_session`).
+    async fn remove_session(&self, id: &str) -> Option<PortForwardSession> {
         let mut sessions = self.sessions.write().await;
-        sessions.remove(id);
+        sessions.remove(id)
     }
 
     async fn is_active(&self, id: &str) -> bool {
         let sessions = self.sessions.read().await;
         sessions.contains_key(id)
+    }
+
+    /// Stop every port-forward session. Called on disconnect/context switch
+    /// so no forward keeps tunneling into the previous cluster.
+    pub async fn stop_all(&self) {
+        let mut sessions = self.sessions.write().await;
+        for session in sessions.values() {
+            session.cancel.cancel();
+        }
+        sessions.clear();
+    }
+
+    /// Wait (bounded) until a session's forward task has exited and dropped
+    /// its listener. No-op when the session is already gone.
+    async fn wait_finished(&self, id: &str, timeout: tokio::time::Duration) {
+        let rx = {
+            let sessions = self.sessions.read().await;
+            sessions.get(id).map(|s| s.finished.clone())
+        };
+        if let Some(mut rx) = rx {
+            let _ = tokio::time::timeout(timeout, rx.wait_for(|done| *done)).await;
+        }
     }
 
     async fn list_sessions(&self) -> Vec<PortForwardInfo> {
@@ -195,13 +222,15 @@ impl PortForwardManager {
         id: &str,
         new_pod_name: String,
         new_pod_uid: String,
-        new_stop_flag: Arc<AtomicBool>,
+        new_cancel: CancellationToken,
+        new_finished: watch::Receiver<bool>,
     ) {
         let mut sessions = self.sessions.write().await;
         if let Some(session) = sessions.get_mut(id) {
             session.pod_name = new_pod_name;
             session.pod_uid = new_pod_uid;
-            session.stop_flag = new_stop_flag;
+            session.cancel = new_cancel;
+            session.finished = new_finished;
         }
     }
 
@@ -251,8 +280,26 @@ impl Default for PortForwardManager {
     }
 }
 
-/// Find an available random port in the high range (30000-60000)
-async fn find_available_port() -> Result<u16, String> {
+/// Remove a session and release its namespace-watcher ref. Idempotent per
+/// forward: only the caller that actually removes the entry releases the ref,
+/// so racing cleanup paths (stop command, forward task exit, pod watcher)
+/// cannot double-release.
+async fn cleanup_session(
+    pf_manager: &Arc<PortForwardManager>,
+    pf_watch_manager: &Arc<PortForwardWatchManager>,
+    forward_id: &str,
+) {
+    if let Some(session) = pf_manager.remove_session(forward_id).await {
+        pf_watch_manager
+            .release_namespace_watcher(&session.namespace)
+            .await;
+    }
+}
+
+/// Bind a listener on a random high port (30000-60000). Returns the bound
+/// listener so the caller keeps ownership of the port; a check-then-bind-later
+/// pattern would let another process grab it in between.
+async fn bind_available_port() -> Result<TcpListener, String> {
     // Generate random ports upfront to avoid Send issues with rng
     let random_ports: Vec<u16> = {
         let mut rng = rand::rng();
@@ -262,16 +309,14 @@ async fn find_available_port() -> Result<u16, String> {
     // Try random ports first
     for port in random_ports {
         if let Ok(listener) = TcpListener::bind(format!("127.0.0.1:{}", port)).await {
-            drop(listener);
-            return Ok(port);
+            return Ok(listener);
         }
     }
 
     // Fallback: try sequential from 30000
     for port in 30000..65535 {
         if let Ok(listener) = TcpListener::bind(format!("127.0.0.1:{}", port)).await {
-            drop(listener);
-            return Ok(port);
+            return Ok(listener);
         }
     }
 
@@ -294,22 +339,24 @@ pub async fn portforward_start(
 
     let client = state.k8s.get_client().await.map_err(|e| e.to_string())?;
 
-    // Determine local port
-    let local_port = match options.local_port {
+    // Bind the listener once and hand it to the forward task; re-binding
+    // inside the task would leave a window where another process takes the
+    // port and the failure only surfaces asynchronously.
+    let listener = match options.local_port {
         Some(port) => {
             if pf_manager.is_port_in_use(port).await {
                 return Err(format!("Port {} is already in use", port));
             }
-            match TcpListener::bind(format!("127.0.0.1:{}", port)).await {
-                Ok(listener) => {
-                    drop(listener);
-                    port
-                }
-                Err(_) => return Err(format!("Port {} is not available", port)),
-            }
+            TcpListener::bind(format!("127.0.0.1:{}", port))
+                .await
+                .map_err(|_| format!("Port {} is not available", port))?
         }
-        None => find_available_port().await?,
+        None => bind_available_port().await?,
     };
+    let local_port = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to read local address: {}", e))?
+        .port();
 
     // Verify target exists and get pod + resolved target port + UID + selector
     let (pod_name, pod_uid, resolved_target_port, service_selector) = match &options.target_type {
@@ -374,11 +421,13 @@ pub async fn portforward_start(
         }
     };
 
-    let stop_flag = Arc::new(AtomicBool::new(false));
+    let cancel = CancellationToken::new();
+    let (finished_tx, finished_rx) = watch::channel(false);
     let status = Arc::new(RwLock::new(PortForwardStatus::Connecting));
 
     let session = PortForwardSession {
-        stop_flag: stop_flag.clone(),
+        cancel: cancel.clone(),
+        finished: finished_rx,
         local_port,
         target_port: resolved_target_port,
         target_type: options.target_type.clone(),
@@ -402,11 +451,14 @@ pub async fn portforward_start(
         pod_uid: Some(pod_uid.clone()),
     };
 
+    // All fallible setup is done; inserting last means a failed start never
+    // leaves a phantom session in the manager.
     pf_manager.add_session(forward_id.clone(), session).await;
 
     let event_name = format!("portforward-{}", forward_id);
     let forward_id_clone = forward_id.clone();
     let pf_manager_clone = Arc::clone(&pf_manager);
+    let pf_watch_manager_clone = Arc::clone(&pf_watch_manager);
     let namespace = options.namespace.clone();
     let target_port = resolved_target_port;
 
@@ -419,15 +471,12 @@ pub async fn portforward_start(
     );
 
     // Start the pod health watcher for this namespace
-    let pf_watch_manager_clone = Arc::clone(&pf_watch_manager);
-    let pf_manager_for_watch = Arc::clone(&pf_manager);
-    let watch_client = state.k8s.get_client().await.map_err(|e| e.to_string())?;
-    pf_watch_manager_clone
+    Arc::clone(&pf_watch_manager)
         .ensure_namespace_watcher(
-            watch_client,
+            client.clone(),
             app.clone(),
             options.namespace.clone(),
-            pf_manager_for_watch,
+            Arc::clone(&pf_manager),
         )
         .await;
 
@@ -438,7 +487,8 @@ pub async fn portforward_start(
             app.clone(),
             &event_name,
             &forward_id_clone,
-            stop_flag,
+            listener,
+            cancel,
             status,
             local_port,
             target_port,
@@ -447,10 +497,19 @@ pub async fn portforward_start(
         )
         .await;
 
+        // Listener is dropped once run_port_forward returns; unblock waiters
+        // (stop command, reconnect) that need the port free.
+        let _ = finished_tx.send(true);
+
         // Only cleanup if not being reconnected by the watcher
         let current_status = status_for_check.read().await.clone();
         if current_status != PortForwardStatus::Reconnecting {
-            pf_manager_clone.remove_session(&forward_id_clone).await;
+            cleanup_session(
+                &pf_manager_clone,
+                &pf_watch_manager_clone,
+                &forward_id_clone,
+            )
+            .await;
             let _ = app.emit(
                 &event_name,
                 PortForwardEvent::Stopped {
@@ -472,35 +531,22 @@ pub async fn portforward_start(
     Ok(info)
 }
 
-/// Run the port forward session
+/// Run the port forward session. Takes ownership of the pre-bound listener
+/// and drops it on return, freeing the local port.
 #[allow(clippy::too_many_arguments)]
 async fn run_port_forward(
     client: kube::Client,
     app: AppHandle,
     event_name: &str,
     forward_id: &str,
-    stop_flag: Arc<AtomicBool>,
+    listener: TcpListener,
+    cancel: CancellationToken,
     status: Arc<RwLock<PortForwardStatus>>,
     local_port: u16,
     target_port: u16,
     namespace: &str,
     pod_name: &str,
 ) {
-    let listener = match TcpListener::bind(format!("127.0.0.1:{}", local_port)).await {
-        Ok(l) => l,
-        Err(e) => {
-            let _ = app.emit(
-                event_name,
-                PortForwardEvent::Error {
-                    forward_id: forward_id.to_string(),
-                    message: format!("Failed to bind to port {}: {}", local_port, e),
-                },
-            );
-            *status.write().await = PortForwardStatus::Error;
-            return;
-        }
-    };
-
     *status.write().await = PortForwardStatus::Connected;
     let _ = app.emit(
         event_name,
@@ -516,20 +562,14 @@ async fn run_port_forward(
     );
 
     let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
-    let pod_name = pod_name.to_string();
-    let forward_id = forward_id.to_string();
 
     loop {
-        if stop_flag.load(Ordering::SeqCst) {
-            tracing::info!("Port forward {} stopped by user", forward_id);
-            break;
-        }
-
         tokio::select! {
-            _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
-                if stop_flag.load(Ordering::SeqCst) {
-                    break;
-                }
+            // Stop must cut the accept loop immediately, not on the next
+            // poll tick.
+            _ = cancel.cancelled() => {
+                tracing::info!("Port forward {} stopped by user", forward_id);
+                break;
             }
             result = listener.accept() => {
                 match result {
@@ -537,9 +577,9 @@ async fn run_port_forward(
                         tracing::debug!("New connection from {} for forward {}", addr, forward_id);
 
                         let pods_clone = pods.clone();
-                        let pod_name_clone = pod_name.clone();
-                        let forward_id_clone = forward_id.clone();
-                        let stop_flag_clone = stop_flag.clone();
+                        let pod_name_clone = pod_name.to_string();
+                        let forward_id_clone = forward_id.to_string();
+                        let cancel_clone = cancel.clone();
                         let app_clone = app.clone();
                         let event_name_clone = event_name.to_string();
 
@@ -550,7 +590,7 @@ async fn run_port_forward(
                                 target_port,
                                 tcp_stream,
                                 addr,
-                                stop_flag_clone,
+                                cancel_clone,
                                 &forward_id_clone,
                                 app_clone,
                                 &event_name_clone,
@@ -587,7 +627,7 @@ async fn handle_connection(
     target_port: u16,
     mut tcp_stream: tokio::net::TcpStream,
     addr: SocketAddr,
-    stop_flag: Arc<AtomicBool>,
+    cancel: CancellationToken,
     forward_id: &str,
     app: AppHandle,
     event_name: &str,
@@ -623,15 +663,9 @@ async fn handle_connection(
     let (mut tcp_read, mut tcp_write) = tcp_stream.split();
     let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream);
 
-    let forward_id_clone = forward_id.to_string();
-    let stop_flag_clone = stop_flag.clone();
-
     let tcp_to_upstream = async {
         let mut buf = vec![0u8; 8192];
         loop {
-            if stop_flag_clone.load(Ordering::SeqCst) {
-                break;
-            }
             match tcp_read.read(&mut buf).await {
                 Ok(0) => break,
                 Ok(n) => {
@@ -647,9 +681,6 @@ async fn handle_connection(
     let upstream_to_tcp = async {
         let mut buf = vec![0u8; 8192];
         loop {
-            if stop_flag.load(Ordering::SeqCst) {
-                break;
-            }
             match upstream_read.read(&mut buf).await {
                 Ok(0) => break,
                 Ok(n) => {
@@ -662,16 +693,15 @@ async fn handle_connection(
         }
     };
 
+    // The cancelled() arm lets stop cut idle connections that are parked in
+    // read() with no data flowing.
     tokio::select! {
+        _ = cancel.cancelled() => {}
         _ = tcp_to_upstream => {}
         _ = upstream_to_tcp => {}
     }
 
-    tracing::debug!(
-        "Connection from {} closed for forward {}",
-        addr,
-        forward_id_clone
-    );
+    tracing::debug!("Connection from {} closed for forward {}", addr, forward_id);
 }
 
 fn resolve_service_target_port(
@@ -761,7 +791,7 @@ async fn find_replacement_pod(
 
 /// Per-namespace pod watcher for port forward health monitoring
 struct NamespaceWatchHandle {
-    stop_flag: Arc<AtomicBool>,
+    cancel: CancellationToken,
     ref_count: usize,
 }
 
@@ -779,7 +809,7 @@ impl PortForwardWatchManager {
 
     /// Ensure a watcher exists for the given namespace. If one already exists, increment ref count.
     async fn ensure_namespace_watcher(
-        &self,
+        self: Arc<Self>,
         client: kube::Client,
         app: AppHandle,
         namespace: String,
@@ -791,11 +821,11 @@ impl PortForwardWatchManager {
             return;
         }
 
-        let stop_flag = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
         watchers.insert(
             namespace.clone(),
             NamespaceWatchHandle {
-                stop_flag: stop_flag.clone(),
+                cancel: cancel.clone(),
                 ref_count: 1,
             },
         );
@@ -803,9 +833,13 @@ impl PortForwardWatchManager {
 
         let ns = namespace.clone();
         let client_clone = client.clone();
+        // The watcher needs the watch manager itself so auto-cleanup paths
+        // can release namespace refs for the forwards they remove.
+        let watch_manager = Arc::clone(&self);
 
         tokio::spawn(async move {
-            watch_pods_for_portforwards(client_clone, app, ns, pf_manager, stop_flag).await;
+            watch_pods_for_portforwards(client_clone, app, ns, pf_manager, watch_manager, cancel)
+                .await;
         });
 
         tracing::info!(
@@ -814,13 +848,22 @@ impl PortForwardWatchManager {
         );
     }
 
+    /// Stop all namespace watchers regardless of ref counts (disconnect).
+    pub async fn stop_all(&self) {
+        let mut watchers = self.watchers.write().await;
+        for handle in watchers.values() {
+            handle.cancel.cancel();
+        }
+        watchers.clear();
+    }
+
     /// Decrement ref count for a namespace watcher. Stop it if ref count reaches 0.
     async fn release_namespace_watcher(&self, namespace: &str) {
         let mut watchers = self.watchers.write().await;
         let should_remove = if let Some(handle) = watchers.get_mut(namespace) {
             handle.ref_count = handle.ref_count.saturating_sub(1);
             if handle.ref_count == 0 {
-                handle.stop_flag.store(true, Ordering::SeqCst);
+                handle.cancel.cancel();
                 true
             } else {
                 false
@@ -851,23 +894,30 @@ async fn watch_pods_for_portforwards(
     app: AppHandle,
     namespace: String,
     pf_manager: Arc<PortForwardManager>,
-    stop_flag: Arc<AtomicBool>,
+    watch_manager: Arc<PortForwardWatchManager>,
+    cancel: CancellationToken,
 ) {
     let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
     let watcher_config = Config::default();
     let mut stream = watcher(pods, watcher_config).boxed();
 
-    while let Some(event) = stream.next().await {
-        if stop_flag.load(Ordering::SeqCst) {
-            break;
-        }
+    loop {
+        // A plain stream.next() would only notice the stop after the next
+        // pod event arrives; select makes release/stop_all take effect now.
+        let event = tokio::select! {
+            _ = cancel.cancelled() => break,
+            maybe_event = stream.next() => match maybe_event {
+                Some(event) => event,
+                None => break,
+            },
+        };
 
         match event {
             Ok(Event::Delete(pod)) => {
-                let pod_uid = pod.metadata.uid.as_deref().unwrap_or_default();
-                let pod_name = pod.metadata.name.as_deref().unwrap_or_default();
+                let pod_uid = pod.metadata.uid.clone().unwrap_or_default();
+                let pod_name = pod.metadata.name.clone().unwrap_or_default();
 
-                let affected = pf_manager.get_forwards_for_pod_uid(pod_uid).await;
+                let affected = pf_manager.get_forwards_for_pod_uid(&pod_uid).await;
                 if affected.is_empty() {
                     continue;
                 }
@@ -881,76 +931,94 @@ async fn watch_pods_for_portforwards(
 
                 for (forward_id, target_type, selector) in affected {
                     let event_name = format!("portforward-{}", forward_id);
+                    let client = client.clone();
+                    let app = app.clone();
+                    let pf_manager = Arc::clone(&pf_manager);
+                    let watch_manager = Arc::clone(&watch_manager);
+                    let namespace = namespace.clone();
+                    let pod_name = pod_name.clone();
+                    let pod_uid = pod_uid.clone();
 
-                    match target_type {
-                        PortForwardTargetType::Service => {
-                            if let Some(sel) = &selector {
-                                handle_service_reconnect(
-                                    &client,
-                                    &app,
-                                    &pf_manager,
-                                    &forward_id,
-                                    &event_name,
-                                    &namespace,
-                                    pod_name,
-                                    sel,
-                                )
-                                .await;
+                    // Reconnects retry for up to 30s; run them off the watch
+                    // loop so other pod events keep flowing meanwhile.
+                    tokio::spawn(async move {
+                        match target_type {
+                            PortForwardTargetType::Service => {
+                                if let Some(sel) = &selector {
+                                    handle_service_reconnect(
+                                        &client,
+                                        &app,
+                                        &pf_manager,
+                                        &watch_manager,
+                                        &forward_id,
+                                        &event_name,
+                                        &namespace,
+                                        &pod_name,
+                                        sel,
+                                    )
+                                    .await;
+                                }
                             }
-                        }
-                        PortForwardTargetType::Pod => {
-                            // For pod-type forwards: check if same-name pod exists (StatefulSet pattern)
-                            let pod_api: Api<Pod> = Api::namespaced(client.clone(), &namespace);
-                            match pod_api.get(pod_name).await {
-                                Ok(new_pod) => {
-                                    let new_uid =
-                                        new_pod.metadata.uid.as_deref().unwrap_or_default();
-                                    if new_uid != pod_uid {
-                                        // Same name, new UID - StatefulSet replacement
-                                        handle_pod_reconnect(
-                                            &client,
-                                            &app,
-                                            &pf_manager,
-                                            &forward_id,
+                            PortForwardTargetType::Pod => {
+                                // For pod-type forwards: check if same-name pod exists (StatefulSet pattern)
+                                let pod_api: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+                                match pod_api.get(&pod_name).await {
+                                    Ok(new_pod) => {
+                                        let new_uid =
+                                            new_pod.metadata.uid.as_deref().unwrap_or_default();
+                                        if new_uid != pod_uid {
+                                            // Same name, new UID - StatefulSet replacement
+                                            handle_pod_reconnect(
+                                                &client,
+                                                &app,
+                                                &pf_manager,
+                                                &watch_manager,
+                                                &forward_id,
+                                                &event_name,
+                                                &namespace,
+                                                &pod_name,
+                                            )
+                                            .await;
+                                        }
+                                    }
+                                    Err(_) => {
+                                        // Pod gone with different name expected (Deployment) - auto-cleanup
+                                        let _ = app.emit(
                                             &event_name,
-                                            &namespace,
-                                            pod_name,
-                                        )
-                                        .await;
+                                            PortForwardEvent::PodDied {
+                                                forward_id: forward_id.clone(),
+                                                pod_name: pod_name.clone(),
+                                            },
+                                        );
+                                        // Stop and remove the forward
+                                        pf_manager.stop_session(&forward_id).await;
+                                        pf_manager
+                                            .wait_finished(
+                                                &forward_id,
+                                                tokio::time::Duration::from_secs(5),
+                                            )
+                                            .await;
+                                        cleanup_session(&pf_manager, &watch_manager, &forward_id)
+                                            .await;
+                                        let _ = app.emit(
+                                            &event_name,
+                                            PortForwardEvent::Stopped {
+                                                forward_id: forward_id.clone(),
+                                            },
+                                        );
                                     }
                                 }
-                                Err(_) => {
-                                    // Pod gone with different name expected (Deployment) - auto-cleanup
-                                    let _ = app.emit(
-                                        &event_name,
-                                        PortForwardEvent::PodDied {
-                                            forward_id: forward_id.clone(),
-                                            pod_name: pod_name.to_string(),
-                                        },
-                                    );
-                                    // Stop and remove the forward
-                                    pf_manager.stop_session(&forward_id).await;
-                                    tokio::time::sleep(tokio::time::Duration::from_millis(100))
-                                        .await;
-                                    pf_manager.remove_session(&forward_id).await;
-                                    let _ = app.emit(
-                                        &event_name,
-                                        PortForwardEvent::Stopped {
-                                            forward_id: forward_id.clone(),
-                                        },
-                                    );
-                                }
                             }
                         }
-                    }
+                    });
                 }
             }
             Ok(Event::Apply(pod)) => {
                 // Check if this pod has a deletion_timestamp (terminating)
                 if pod.metadata.deletion_timestamp.is_some() {
-                    let pod_uid = pod.metadata.uid.as_deref().unwrap_or_default();
-                    let pod_name = pod.metadata.name.as_deref().unwrap_or_default();
-                    let affected = pf_manager.get_forwards_for_pod_uid(pod_uid).await;
+                    let pod_uid = pod.metadata.uid.clone().unwrap_or_default();
+                    let pod_name = pod.metadata.name.clone().unwrap_or_default();
+                    let affected = pf_manager.get_forwards_for_pod_uid(&pod_uid).await;
                     if affected.is_empty() {
                         continue;
                     }
@@ -958,19 +1026,29 @@ async fn watch_pods_for_portforwards(
                     // Pod is terminating - for service-type, start proactive reconnect
                     for (forward_id, target_type, selector) in affected {
                         if target_type == PortForwardTargetType::Service {
-                            if let Some(sel) = &selector {
+                            if let Some(sel) = selector {
                                 let event_name = format!("portforward-{}", forward_id);
-                                handle_service_reconnect(
-                                    &client,
-                                    &app,
-                                    &pf_manager,
-                                    &forward_id,
-                                    &event_name,
-                                    &namespace,
-                                    pod_name,
-                                    sel,
-                                )
-                                .await;
+                                let client = client.clone();
+                                let app = app.clone();
+                                let pf_manager = Arc::clone(&pf_manager);
+                                let watch_manager = Arc::clone(&watch_manager);
+                                let namespace = namespace.clone();
+                                let pod_name = pod_name.clone();
+
+                                tokio::spawn(async move {
+                                    handle_service_reconnect(
+                                        &client,
+                                        &app,
+                                        &pf_manager,
+                                        &watch_manager,
+                                        &forward_id,
+                                        &event_name,
+                                        &namespace,
+                                        &pod_name,
+                                        &sel,
+                                    )
+                                    .await;
+                                });
                             }
                         }
                     }
@@ -996,6 +1074,7 @@ async fn handle_service_reconnect(
     client: &kube::Client,
     app: &AppHandle,
     pf_manager: &Arc<PortForwardManager>,
+    pf_watch_manager: &Arc<PortForwardWatchManager>,
     forward_id: &str,
     event_name: &str,
     namespace: &str,
@@ -1046,6 +1125,7 @@ async fn handle_service_reconnect(
                 client,
                 app,
                 pf_manager,
+                pf_watch_manager,
                 forward_id,
                 event_name,
                 namespace,
@@ -1055,7 +1135,9 @@ async fn handle_service_reconnect(
             .await;
         }
         None => {
-            // No replacement found - auto-cleanup
+            // No replacement found - auto-cleanup. The forward task skips its
+            // own cleanup while status is Reconnecting, so this path must
+            // remove the session and release the watcher ref itself.
             let _ = app.emit(
                 event_name,
                 PortForwardEvent::PodDied {
@@ -1064,8 +1146,10 @@ async fn handle_service_reconnect(
                 },
             );
             pf_manager.stop_session(forward_id).await;
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            pf_manager.remove_session(forward_id).await;
+            pf_manager
+                .wait_finished(forward_id, tokio::time::Duration::from_secs(5))
+                .await;
+            cleanup_session(pf_manager, pf_watch_manager, forward_id).await;
             let _ = app.emit(
                 event_name,
                 PortForwardEvent::Stopped {
@@ -1077,10 +1161,12 @@ async fn handle_service_reconnect(
 }
 
 /// Handle reconnection for pod-type forwards (StatefulSet same-name pattern)
+#[allow(clippy::too_many_arguments)]
 async fn handle_pod_reconnect(
     client: &kube::Client,
     app: &AppHandle,
     pf_manager: &Arc<PortForwardManager>,
+    pf_watch_manager: &Arc<PortForwardWatchManager>,
     forward_id: &str,
     event_name: &str,
     namespace: &str,
@@ -1122,7 +1208,15 @@ async fn handle_pod_reconnect(
             if is_running && is_ready {
                 let new_uid = pod.metadata.uid.as_deref().unwrap_or_default();
                 reconnect_forward(
-                    client, app, pf_manager, forward_id, event_name, namespace, pod_name, new_uid,
+                    client,
+                    app,
+                    pf_manager,
+                    pf_watch_manager,
+                    forward_id,
+                    event_name,
+                    namespace,
+                    pod_name,
+                    new_uid,
                 )
                 .await;
                 ready = true;
@@ -1133,6 +1227,8 @@ async fn handle_pod_reconnect(
     }
 
     if !ready {
+        // Same as the service path: status is Reconnecting, so the forward
+        // task will not clean up - do it here, releasing the watcher ref.
         let _ = app.emit(
             event_name,
             PortForwardEvent::PodDied {
@@ -1141,8 +1237,10 @@ async fn handle_pod_reconnect(
             },
         );
         pf_manager.stop_session(forward_id).await;
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        pf_manager.remove_session(forward_id).await;
+        pf_manager
+            .wait_finished(forward_id, tokio::time::Duration::from_secs(5))
+            .await;
+        cleanup_session(pf_manager, pf_watch_manager, forward_id).await;
         let _ = app.emit(
             event_name,
             PortForwardEvent::Stopped {
@@ -1158,6 +1256,7 @@ async fn reconnect_forward(
     client: &kube::Client,
     app: &AppHandle,
     pf_manager: &Arc<PortForwardManager>,
+    pf_watch_manager: &Arc<PortForwardWatchManager>,
     forward_id: &str,
     event_name: &str,
     namespace: &str,
@@ -1170,18 +1269,23 @@ async fn reconnect_forward(
         None => return,
     };
 
-    // Stop old listener
+    // Stop the old forward and wait until its listener is actually released;
+    // a fixed sleep here would race the rebind below.
     pf_manager.stop_session(forward_id).await;
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    pf_manager
+        .wait_finished(forward_id, tokio::time::Duration::from_secs(5))
+        .await;
 
-    // Create new stop flag for reconnected session
-    let new_stop_flag = Arc::new(AtomicBool::new(false));
+    // Fresh cancel token and completion signal for the reconnected session
+    let new_cancel = CancellationToken::new();
+    let (finished_tx, finished_rx) = watch::channel(false);
     pf_manager
         .update_pod_target(
             forward_id,
             new_pod_name.to_string(),
             new_pod_uid.to_string(),
-            new_stop_flag.clone(),
+            new_cancel.clone(),
+            finished_rx,
         )
         .await;
 
@@ -1194,26 +1298,49 @@ async fn reconnect_forward(
     let status_clone = status.clone();
     let status_for_check = status.clone();
     let pf_manager_clone = Arc::clone(pf_manager);
+    let pf_watch_manager_clone = Arc::clone(pf_watch_manager);
 
     tokio::spawn(async move {
-        run_port_forward(
-            client_clone,
-            app_clone.clone(),
-            &event_name_clone,
-            &forward_id_clone,
-            new_stop_flag,
-            status_clone,
-            local_port,
-            target_port,
-            &namespace_clone,
-            &pod_name_clone,
-        )
-        .await;
+        match TcpListener::bind(format!("127.0.0.1:{}", local_port)).await {
+            Ok(listener) => {
+                run_port_forward(
+                    client_clone,
+                    app_clone.clone(),
+                    &event_name_clone,
+                    &forward_id_clone,
+                    listener,
+                    new_cancel,
+                    status_clone,
+                    local_port,
+                    target_port,
+                    &namespace_clone,
+                    &pod_name_clone,
+                )
+                .await;
+            }
+            Err(e) => {
+                let _ = app_clone.emit(
+                    &event_name_clone,
+                    PortForwardEvent::Error {
+                        forward_id: forward_id_clone.clone(),
+                        message: format!("Failed to bind to port {}: {}", local_port, e),
+                    },
+                );
+                *status_clone.write().await = PortForwardStatus::Error;
+            }
+        }
+
+        let _ = finished_tx.send(true);
 
         // Only cleanup if not being reconnected again
         let current_status = status_for_check.read().await.clone();
         if current_status != PortForwardStatus::Reconnecting {
-            pf_manager_clone.remove_session(&forward_id_clone).await;
+            cleanup_session(
+                &pf_manager_clone,
+                &pf_watch_manager_clone,
+                &forward_id_clone,
+            )
+            .await;
             let _ = app_clone.emit(
                 &event_name_clone,
                 PortForwardEvent::Stopped {
@@ -1249,20 +1376,13 @@ pub async fn portforward_stop(
 ) -> Result<(), String> {
     let event_name = format!("portforward-{}", forward_id);
 
-    // Get namespace before removing
-    let namespace = {
-        let sessions = pf_manager.sessions.read().await;
-        sessions.get(&forward_id).map(|s| s.namespace.clone())
-    };
-
     if pf_manager.stop_session(&forward_id).await {
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        pf_manager.remove_session(&forward_id).await;
-
-        // Release the namespace watcher ref
-        if let Some(ns) = namespace {
-            pf_watch_manager.release_namespace_watcher(&ns).await;
-        }
+        // Wait until the forward task has dropped its listener so the port is
+        // actually free when we report Stopped.
+        pf_manager
+            .wait_finished(&forward_id, tokio::time::Duration::from_secs(5))
+            .await;
+        cleanup_session(&pf_manager, &pf_watch_manager, &forward_id).await;
 
         let _ = app.emit(
             &event_name,
@@ -1391,7 +1511,8 @@ mod tests {
         pod_uid: &str,
     ) -> PortForwardSession {
         PortForwardSession {
-            stop_flag: Arc::new(AtomicBool::new(false)),
+            cancel: CancellationToken::new(),
+            finished: watch::channel(false).1,
             local_port,
             target_port,
             target_type,
@@ -1414,7 +1535,8 @@ mod tests {
         selector: BTreeMap<String, String>,
     ) -> PortForwardSession {
         PortForwardSession {
-            stop_flag: Arc::new(AtomicBool::new(false)),
+            cancel: CancellationToken::new(),
+            finished: watch::channel(false).1,
             local_port,
             target_port,
             target_type: PortForwardTargetType::Service,
@@ -1643,7 +1765,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn manager_stop_sets_flag() {
+    async fn manager_stop_cancels_token() {
         let mgr = PortForwardManager::new();
         let session = make_session(
             8080,
@@ -1654,12 +1776,45 @@ mod tests {
             "web-abc",
             "uid-1",
         );
-        let flag = session.stop_flag.clone();
+        let cancel = session.cancel.clone();
         mgr.add_session("fwd-1".to_string(), session).await;
 
-        assert!(!flag.load(Ordering::SeqCst));
+        assert!(!cancel.is_cancelled());
         assert!(mgr.stop_session("fwd-1").await);
-        assert!(flag.load(Ordering::SeqCst));
+        assert!(cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn manager_stop_all_cancels_and_clears() {
+        let mgr = PortForwardManager::new();
+        let s1 = make_session(
+            8080,
+            80,
+            PortForwardTargetType::Pod,
+            "default",
+            "web",
+            "pod-1",
+            "uid-1",
+        );
+        let s2 = make_session(
+            9090,
+            90,
+            PortForwardTargetType::Service,
+            "kube-system",
+            "dns",
+            "pod-2",
+            "uid-2",
+        );
+        let c1 = s1.cancel.clone();
+        let c2 = s2.cancel.clone();
+        mgr.add_session("fwd-1".to_string(), s1).await;
+        mgr.add_session("fwd-2".to_string(), s2).await;
+
+        mgr.stop_all().await;
+
+        assert!(c1.is_cancelled());
+        assert!(c2.is_cancelled());
+        assert!(mgr.list_sessions().await.is_empty());
     }
 
     #[tokio::test]
@@ -1728,12 +1883,12 @@ mod tests {
         );
         mgr.add_session("fwd-1".to_string(), session).await;
 
-        let new_flag = Arc::new(AtomicBool::new(false));
         mgr.update_pod_target(
             "fwd-1",
             "new-pod".to_string(),
             "new-uid".to_string(),
-            new_flag,
+            CancellationToken::new(),
+            watch::channel(false).1,
         )
         .await;
 
@@ -1855,21 +2010,22 @@ mod tests {
 
     // ── PortForwardWatchManager tests ──
 
+    /// Insert a watch handle directly (ensure_namespace_watcher needs a real client)
+    async fn insert_watch_handle(wm: &PortForwardWatchManager, namespace: &str, ref_count: usize) {
+        let mut watchers = wm.watchers.write().await;
+        watchers.insert(
+            namespace.to_string(),
+            NamespaceWatchHandle {
+                cancel: CancellationToken::new(),
+                ref_count,
+            },
+        );
+    }
+
     #[tokio::test]
     async fn watch_manager_release_decrements_ref_count() {
         let wm = PortForwardWatchManager::new();
-
-        // Manually insert a watch handle (we can't use ensure_namespace_watcher without a real client)
-        {
-            let mut watchers = wm.watchers.write().await;
-            watchers.insert(
-                "default".to_string(),
-                NamespaceWatchHandle {
-                    stop_flag: Arc::new(AtomicBool::new(false)),
-                    ref_count: 3,
-                },
-            );
-        }
+        insert_watch_handle(&wm, "default", 3).await;
 
         wm.release_namespace_watcher("default").await;
         {
@@ -1886,23 +2042,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watch_manager_release_sets_stop_flag_at_zero() {
+    async fn watch_manager_release_cancels_at_zero() {
         let wm = PortForwardWatchManager::new();
-        let stop_flag = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
 
         {
             let mut watchers = wm.watchers.write().await;
             watchers.insert(
                 "kube-system".to_string(),
                 NamespaceWatchHandle {
-                    stop_flag: stop_flag.clone(),
+                    cancel: cancel.clone(),
                     ref_count: 1,
                 },
             );
         }
 
         wm.release_namespace_watcher("kube-system").await;
-        assert!(stop_flag.load(Ordering::SeqCst));
+        assert!(cancel.is_cancelled());
     }
 
     #[tokio::test]
@@ -1910,6 +2066,149 @@ mod tests {
         let wm = PortForwardWatchManager::new();
         // Should not panic
         wm.release_namespace_watcher("nonexistent").await;
+    }
+
+    #[tokio::test]
+    async fn watch_manager_stop_all_cancels_and_clears() {
+        let wm = PortForwardWatchManager::new();
+        let cancel = CancellationToken::new();
+        {
+            let mut watchers = wm.watchers.write().await;
+            watchers.insert(
+                "default".to_string(),
+                NamespaceWatchHandle {
+                    cancel: cancel.clone(),
+                    ref_count: 2,
+                },
+            );
+        }
+
+        wm.stop_all().await;
+
+        assert!(cancel.is_cancelled());
+        assert!(wm.watchers.read().await.is_empty());
+    }
+
+    // ── cleanup_session tests ──
+
+    #[tokio::test]
+    async fn cleanup_session_removes_session_and_releases_watcher() {
+        let pf = Arc::new(PortForwardManager::new());
+        let wm = Arc::new(PortForwardWatchManager::new());
+        insert_watch_handle(&wm, "default", 1).await;
+        let session = make_session(
+            8080,
+            80,
+            PortForwardTargetType::Pod,
+            "default",
+            "web",
+            "web-abc",
+            "uid-1",
+        );
+        pf.add_session("fwd-1".to_string(), session).await;
+
+        cleanup_session(&pf, &wm, "fwd-1").await;
+
+        assert!(!pf.is_active("fwd-1").await);
+        // Last ref released -> watcher removed
+        assert!(!wm.watchers.read().await.contains_key("default"));
+    }
+
+    /// Racing cleanup paths (stop command, forward task exit, pod watcher) may
+    /// all call cleanup_session for the same forward; only one may release.
+    #[tokio::test]
+    async fn cleanup_session_is_idempotent_no_double_release() {
+        let pf = Arc::new(PortForwardManager::new());
+        let wm = Arc::new(PortForwardWatchManager::new());
+        // Two forwards share the namespace watcher
+        insert_watch_handle(&wm, "default", 2).await;
+        let s1 = make_session(
+            8080,
+            80,
+            PortForwardTargetType::Pod,
+            "default",
+            "web",
+            "pod-1",
+            "uid-1",
+        );
+        let s2 = make_session(
+            9090,
+            90,
+            PortForwardTargetType::Pod,
+            "default",
+            "api",
+            "pod-2",
+            "uid-2",
+        );
+        pf.add_session("fwd-1".to_string(), s1).await;
+        pf.add_session("fwd-2".to_string(), s2).await;
+
+        cleanup_session(&pf, &wm, "fwd-1").await;
+        // Second call for the same forward must be a no-op
+        cleanup_session(&pf, &wm, "fwd-1").await;
+
+        let watchers = wm.watchers.read().await;
+        assert_eq!(watchers.get("default").unwrap().ref_count, 1);
+        drop(watchers);
+        assert!(pf.is_active("fwd-2").await);
+    }
+
+    #[tokio::test]
+    async fn cleanup_session_unknown_forward_leaves_watcher_untouched() {
+        let pf = Arc::new(PortForwardManager::new());
+        let wm = Arc::new(PortForwardWatchManager::new());
+        insert_watch_handle(&wm, "default", 1).await;
+
+        cleanup_session(&pf, &wm, "nope").await;
+
+        assert_eq!(
+            wm.watchers.read().await.get("default").unwrap().ref_count,
+            1
+        );
+    }
+
+    // ── wait_finished tests ──
+
+    #[tokio::test]
+    async fn wait_finished_returns_when_task_signals() {
+        let mgr = PortForwardManager::new();
+        let (tx, rx) = watch::channel(false);
+        let mut session = make_session(
+            8080,
+            80,
+            PortForwardTargetType::Pod,
+            "default",
+            "web",
+            "web-abc",
+            "uid-1",
+        );
+        session.finished = rx;
+        mgr.add_session("fwd-1".to_string(), session).await;
+
+        let signal = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            let _ = tx.send(true);
+        });
+
+        // Must return once signalled, well before the 5s bound
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(1),
+            mgr.wait_finished("fwd-1", tokio::time::Duration::from_secs(5)),
+        )
+        .await
+        .expect("wait_finished should return after the task signals");
+        signal.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_finished_missing_session_returns_immediately() {
+        let mgr = PortForwardManager::new();
+        tokio::time::timeout(
+            tokio::time::Duration::from_millis(100),
+            mgr.wait_finished("nope", tokio::time::Duration::from_secs(5)),
+        )
+        .await
+        .expect("wait_finished on a missing session must not block");
     }
 
     // ── Serialization tests ──

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -97,6 +97,35 @@ impl ShellSessionManager {
         let sessions = self.sessions.read().await;
         sessions.get(id).and_then(|s| s.debug_pod.clone())
     }
+
+    /// Stop every shell session. Node-shell debug pods are deleted best
+    /// effort with the given client (the old cluster's client must still be
+    /// available when this is called on disconnect/context switch).
+    pub async fn stop_all(&self, client: Option<kube::Client>) {
+        let debug_pods: Vec<DebugPodInfo> = {
+            let mut sessions = self.sessions.write().await;
+            let pods = sessions
+                .values()
+                .filter_map(|s| {
+                    s.stop_flag.store(true, Ordering::SeqCst);
+                    s.debug_pod.clone()
+                })
+                .collect();
+            sessions.clear();
+            pods
+        };
+
+        if let Some(client) = client {
+            if !debug_pods.is_empty() {
+                tokio::spawn(async move {
+                    for info in debug_pods {
+                        let pods: Api<Pod> = Api::namespaced(client.clone(), &info.namespace);
+                        let _ = pods.delete(&info.pod_name, &DeleteParams::default()).await;
+                    }
+                });
+            }
+        }
+    }
 }
 
 impl Default for ShellSessionManager {

--- a/src-tauri/src/commands/watch.rs
+++ b/src-tauri/src/commands/watch.rs
@@ -7,10 +7,10 @@ use kube::api::Api;
 use kube::runtime::watcher::{watcher, Config, Event};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{command, AppHandle, Emitter, State};
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 /// Watch event types
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,9 +23,11 @@ pub enum WatchEvent<T> {
     Error(KubeliError),
 }
 
-/// Active watch session
+/// Active watch session. The token is wrapped in an Arc so a watch task can
+/// prove its identity when removing itself (Arc::ptr_eq) - a task must never
+/// remove a session that replaced it under the same id.
 struct WatchSession {
-    stop_flag: Arc<AtomicBool>,
+    token: Arc<CancellationToken>,
 }
 
 /// Watch manager to track active watches
@@ -40,15 +42,27 @@ impl WatchManager {
         }
     }
 
-    async fn add_session(&self, id: String, stop_flag: Arc<AtomicBool>) {
+    /// Register a session. If a session with the same id already exists it
+    /// is cancelled first - otherwise the old task would keep running with
+    /// no one able to stop it.
+    async fn add_session(&self, id: String) -> Arc<CancellationToken> {
+        let token = Arc::new(CancellationToken::new());
         let mut sessions = self.sessions.write().await;
-        sessions.insert(id, WatchSession { stop_flag });
+        if let Some(old) = sessions.insert(
+            id,
+            WatchSession {
+                token: Arc::clone(&token),
+            },
+        ) {
+            old.token.cancel();
+        }
+        token
     }
 
     async fn stop_session(&self, id: &str) -> bool {
         let sessions = self.sessions.read().await;
         if let Some(session) = sessions.get(id) {
-            session.stop_flag.store(true, Ordering::SeqCst);
+            session.token.cancel();
             true
         } else {
             false
@@ -58,6 +72,27 @@ impl WatchManager {
     async fn remove_session(&self, id: &str) {
         let mut sessions = self.sessions.write().await;
         sessions.remove(id);
+    }
+
+    /// Remove the session only if it still belongs to the calling task
+    /// (identity via Arc::ptr_eq). Used by watch tasks on exit.
+    async fn remove_session_if_owned(&self, id: &str, token: &Arc<CancellationToken>) {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get(id) {
+            if Arc::ptr_eq(&session.token, token) {
+                sessions.remove(id);
+            }
+        }
+    }
+
+    /// Stop every active watch. Called on disconnect/context switch so no
+    /// watch keeps streaming from the previous cluster.
+    pub async fn stop_all(&self) {
+        let mut sessions = self.sessions.write().await;
+        for session in sessions.values() {
+            session.token.cancel();
+        }
+        sessions.clear();
     }
 }
 
@@ -126,6 +161,78 @@ fn pod_to_info(pod: Pod) -> PodInfo {
     }
 }
 
+/// Map a raw watcher event to the frontend event, buffering the initial
+/// listing: Init/InitApply/InitDone become ONE Restarted(Vec) instead of a
+/// flood of Added events (which duplicated existing rows on every watch
+/// resync). Returns None when nothing should be emitted yet.
+fn map_watch_event<K, T>(
+    event: Result<Event<K>, kube::runtime::watcher::Error>,
+    init_buffer: &mut Option<Vec<T>>,
+    to_info: impl Fn(K) -> T,
+) -> Option<WatchEvent<T>> {
+    match event {
+        Ok(Event::Init) => {
+            *init_buffer = Some(Vec::new());
+            None
+        }
+        Ok(Event::InitApply(obj)) => {
+            let info = to_info(obj);
+            match init_buffer {
+                Some(buf) => {
+                    buf.push(info);
+                    None
+                }
+                // Defensive: InitApply without Init
+                None => Some(WatchEvent::Added(info)),
+            }
+        }
+        Ok(Event::InitDone) => init_buffer.take().map(WatchEvent::Restarted),
+        Ok(Event::Apply(obj)) => Some(WatchEvent::Modified(to_info(obj))),
+        Ok(Event::Delete(obj)) => Some(WatchEvent::Deleted(to_info(obj))),
+        Err(e) => Some(WatchEvent::Error(KubeliError::from(e))),
+    }
+}
+
+/// Drive a watch stream until it ends or the session is cancelled. Uses
+/// select! so cancellation takes effect immediately - the old stop-flag was
+/// only polled after the next event, so quiet watches lingered forever.
+async fn run_watch_loop<K, T>(
+    app: AppHandle,
+    manager: Arc<WatchManager>,
+    watch_id: String,
+    event_prefix: &str,
+    stream: impl futures::Stream<Item = Result<Event<K>, kube::runtime::watcher::Error>>,
+    to_info: impl Fn(K) -> T,
+    token: Arc<CancellationToken>,
+) where
+    T: Serialize + Clone,
+{
+    tokio::pin!(stream);
+    let mut init_buffer: Option<Vec<T>> = None;
+    let event_name = format!("{event_prefix}-{watch_id}");
+
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => {
+                tracing::info!("Watch {} cancelled", watch_id);
+                break;
+            }
+            event = stream.next() => {
+                let Some(event) = event else { break };
+                if let Some(watch_event) = map_watch_event(event, &mut init_buffer, &to_info) {
+                    if let Err(e) = app.emit(&event_name, &watch_event) {
+                        tracing::error!("Failed to emit watch event: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    manager.remove_session_if_owned(&watch_id, &token).await;
+    tracing::info!("Watch {} ended", watch_id);
+}
+
 /// Start watching pods in a namespace
 #[command]
 pub async fn watch_pods(
@@ -137,11 +244,7 @@ pub async fn watch_pods(
 ) -> Result<(), KubeliError> {
     let client = state.k8s.get_client().await.map_err(KubeliError::from)?;
     let manager = Arc::clone(watch_manager.inner());
-
-    let stop_flag = Arc::new(AtomicBool::new(false));
-    manager
-        .add_session(watch_id.clone(), stop_flag.clone())
-        .await;
+    let token = manager.add_session(watch_id.clone()).await;
 
     let pods: Api<Pod> = if let Some(ns) = &namespace {
         Api::namespaced(client, ns)
@@ -149,52 +252,19 @@ pub async fn watch_pods(
         Api::all(client)
     };
 
-    let watcher_config = Config::default();
     let watch_id_clone = watch_id.clone();
-
-    // Spawn the watch task
     tokio::spawn(async move {
-        let mut stream = watcher(pods, watcher_config).boxed();
-
-        while let Some(event) = stream.next().await {
-            if stop_flag.load(Ordering::SeqCst) {
-                tracing::info!("Watch {} stopped by user", watch_id_clone);
-                break;
-            }
-
-            let watch_event = match event {
-                Ok(Event::Apply(pod)) => {
-                    let info = pod_to_info(pod);
-                    WatchEvent::Modified(info)
-                }
-                Ok(Event::Delete(pod)) => {
-                    let info = pod_to_info(pod);
-                    WatchEvent::Deleted(info)
-                }
-                Ok(Event::Init) => {
-                    // Initial list event - skip
-                    continue;
-                }
-                Ok(Event::InitApply(pod)) => {
-                    let info = pod_to_info(pod);
-                    WatchEvent::Added(info)
-                }
-                Ok(Event::InitDone) => {
-                    // Initial list done - skip
-                    continue;
-                }
-                Err(e) => WatchEvent::Error(KubeliError::from(e)),
-            };
-
-            let event_name = format!("pods-watch-{}", watch_id_clone);
-            if let Err(e) = app.emit(&event_name, &watch_event) {
-                tracing::error!("Failed to emit watch event: {}", e);
-                break;
-            }
-        }
-
-        manager.remove_session(&watch_id_clone).await;
-        tracing::info!("Watch {} ended", watch_id_clone);
+        let stream = watcher(pods, Config::default()).boxed();
+        run_watch_loop(
+            app,
+            manager,
+            watch_id_clone,
+            "pods-watch",
+            stream,
+            pod_to_info,
+            token,
+        )
+        .await;
     });
 
     tracing::info!("Started pods watch: {}", watch_id);
@@ -230,53 +300,23 @@ pub async fn watch_namespaces(
 ) -> Result<(), KubeliError> {
     let client = state.k8s.get_client().await.map_err(KubeliError::from)?;
     let manager = Arc::clone(watch_manager.inner());
-
-    let stop_flag = Arc::new(AtomicBool::new(false));
-    manager
-        .add_session(watch_id.clone(), stop_flag.clone())
-        .await;
+    let token = manager.add_session(watch_id.clone()).await;
 
     let namespaces: Api<Namespace> = Api::all(client);
 
-    let watcher_config = Config::default();
     let watch_id_clone = watch_id.clone();
-
     tokio::spawn(async move {
-        let mut stream = watcher(namespaces, watcher_config).boxed();
-
-        while let Some(event) = stream.next().await {
-            if stop_flag.load(Ordering::SeqCst) {
-                tracing::info!("Watch {} stopped by user", watch_id_clone);
-                break;
-            }
-
-            let watch_event = match event {
-                Ok(Event::Apply(ns)) => {
-                    let info = namespace_to_info(ns);
-                    WatchEvent::Modified(info)
-                }
-                Ok(Event::Delete(ns)) => {
-                    let info = namespace_to_info(ns);
-                    WatchEvent::Deleted(info)
-                }
-                Ok(Event::Init) => continue,
-                Ok(Event::InitApply(ns)) => {
-                    let info = namespace_to_info(ns);
-                    WatchEvent::Added(info)
-                }
-                Ok(Event::InitDone) => continue,
-                Err(e) => WatchEvent::Error(KubeliError::from(e)),
-            };
-
-            let event_name = format!("namespaces-watch-{}", watch_id_clone);
-            if let Err(e) = app.emit(&event_name, &watch_event) {
-                tracing::error!("Failed to emit namespace watch event: {}", e);
-                break;
-            }
-        }
-
-        manager.remove_session(&watch_id_clone).await;
-        tracing::info!("Namespace watch {} ended", watch_id_clone);
+        let stream = watcher(namespaces, Config::default()).boxed();
+        run_watch_loop(
+            app,
+            manager,
+            watch_id_clone,
+            "namespaces-watch",
+            stream,
+            namespace_to_info,
+            token,
+        )
+        .await;
     });
 
     tracing::info!("Started namespaces watch: {}", watch_id);
@@ -296,4 +336,88 @@ pub async fn stop_watch(
         tracing::debug!("Watch {} already stopped or not found", watch_id);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply(n: u32) -> Result<Event<u32>, kube::runtime::watcher::Error> {
+        Ok(Event::Apply(n))
+    }
+
+    #[test]
+    fn init_listing_becomes_one_restarted_event() {
+        let mut buf: Option<Vec<u32>> = None;
+        let id = |v: u32| v;
+
+        assert!(map_watch_event(Ok(Event::Init), &mut buf, id).is_none());
+        assert!(map_watch_event(Ok(Event::InitApply(1)), &mut buf, id).is_none());
+        assert!(map_watch_event(Ok(Event::InitApply(2)), &mut buf, id).is_none());
+
+        match map_watch_event(Ok(Event::InitDone), &mut buf, id) {
+            Some(WatchEvent::Restarted(items)) => assert_eq!(items, vec![1, 2]),
+            other => panic!("expected Restarted, got {:?}", other.map(|_| ())),
+        }
+        // Buffer is consumed - a second InitDone emits nothing
+        assert!(map_watch_event(Ok(Event::InitDone), &mut buf, id).is_none());
+    }
+
+    #[test]
+    fn init_apply_without_init_falls_back_to_added() {
+        let mut buf: Option<Vec<u32>> = None;
+        match map_watch_event(Ok(Event::InitApply(7)), &mut buf, |v| v) {
+            Some(WatchEvent::Added(7)) => {}
+            other => panic!("expected Added(7), got {:?}", other.map(|_| ())),
+        }
+    }
+
+    #[test]
+    fn live_events_map_directly() {
+        let mut buf: Option<Vec<u32>> = None;
+        assert!(matches!(
+            map_watch_event(apply(5), &mut buf, |v| v),
+            Some(WatchEvent::Modified(5))
+        ));
+        assert!(matches!(
+            map_watch_event(Ok(Event::Delete(5)), &mut buf, |v| v),
+            Some(WatchEvent::Deleted(5))
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_session_cancels_a_session_it_replaces() {
+        let manager = WatchManager::new();
+        let old_token = manager.add_session("w1".into()).await;
+        assert!(!old_token.is_cancelled());
+
+        let new_token = manager.add_session("w1".into()).await;
+        assert!(
+            old_token.is_cancelled(),
+            "replaced session must be cancelled"
+        );
+        assert!(!new_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn task_cannot_remove_a_session_that_replaced_it() {
+        let manager = WatchManager::new();
+        let old_token = manager.add_session("w1".into()).await;
+        let new_token = manager.add_session("w1".into()).await;
+
+        // Old task exits and tries to clean up - must NOT remove the new session
+        manager.remove_session_if_owned("w1", &old_token).await;
+        assert!(manager.stop_session("w1").await, "new session must survive");
+        assert!(new_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn stop_all_cancels_every_session() {
+        let manager = WatchManager::new();
+        let t1 = manager.add_session("a".into()).await;
+        let t2 = manager.add_session("b".into()).await;
+        manager.stop_all().await;
+        assert!(t1.is_cancelled() && t2.is_cancelled());
+        assert!(!manager.stop_session("a").await);
+    }
 }

--- a/src-tauri/src/k8s/client.rs
+++ b/src-tauri/src/k8s/client.rs
@@ -38,6 +38,9 @@ pub struct KubeClientManager {
     current_context: Arc<RwLock<Option<String>>>,
     kubeconfig: Arc<RwLock<Option<ParsedKubeConfig>>>,
     connection_log: Arc<RwLock<Option<String>>>,
+    /// Serializes connect attempts: two racing connect_cluster calls would
+    /// otherwise interleave init/test and leave client+context mismatched.
+    connect_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 #[allow(dead_code)] // Some methods may be used in future features (e.g., Resource Detail Views, Settings)
@@ -125,7 +128,22 @@ impl KubeClientManager {
             current_context: Arc::new(RwLock::new(None)),
             kubeconfig: Arc::new(RwLock::new(None)),
             connection_log: Arc::new(RwLock::new(None)),
+            connect_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
+    }
+
+    /// Take the connect lock for the duration of a connect attempt. Owned
+    /// guard so the caller can hold it across the whole command.
+    pub async fn begin_connect(&self) -> tokio::sync::OwnedMutexGuard<()> {
+        Arc::clone(&self.connect_lock).lock_owned().await
+    }
+
+    /// Drop the active connection. Called when a connect attempt fails so
+    /// the stored client/context never point at a cluster that did not pass
+    /// the connection test (the UI treats a failed connect as disconnected).
+    pub async fn clear_connection(&self) {
+        *self.client.write().await = None;
+        *self.current_context.write().await = None;
     }
 
     /// Initialize the client from the default kubeconfig.
@@ -476,5 +494,85 @@ mod tests {
             config.write_timeout.is_none(),
             "write_timeout must be unset so idle exec sessions are not torn down (issue #292)"
         );
+    }
+
+    fn test_kubeconfig(server: &str) -> Kubeconfig {
+        let yaml = format!(
+            r#"
+apiVersion: v1
+kind: Config
+current-context: test-ctx
+contexts:
+  - name: test-ctx
+    context:
+      cluster: test-cluster
+      user: test-user
+clusters:
+  - name: test-cluster
+    cluster:
+      server: {server}
+users:
+  - name: test-user
+    user:
+      token: dummy-token
+"#
+        );
+        serde_yaml::from_str(&yaml).expect("valid test kubeconfig")
+    }
+
+    #[tokio::test]
+    async fn init_with_unknown_context_fails_and_leaves_state_untouched() {
+        let manager = KubeClientManager::new();
+        let result = manager
+            .init_with_context(
+                "does-not-exist",
+                test_kubeconfig("https://127.0.0.1:1"),
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(!manager.is_connected().await);
+        assert!(manager.get_current_context().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_connection_test_can_be_cleared() {
+        // Client creation needs a rustls provider (installed at app startup)
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let manager = KubeClientManager::new();
+        // init succeeds (no I/O yet) even though nothing listens on port 1
+        manager
+            .init_with_context("test-ctx", test_kubeconfig("https://127.0.0.1:1"), None)
+            .await
+            .expect("client creation is offline");
+        assert!(manager.is_connected().await);
+
+        // the connection test must fail fast against a closed port
+        let ok = manager.test_connection().await.unwrap_or(false);
+        assert!(!ok, "closed port must not pass the connection test");
+
+        // connect_cluster clears on failure - state no longer claims a
+        // connection that never passed its test
+        manager.clear_connection().await;
+        assert!(!manager.is_connected().await);
+        assert!(manager.get_current_context().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_lock_serializes_concurrent_attempts() {
+        let manager = Arc::new(KubeClientManager::new());
+        let guard = manager.begin_connect().await;
+        let m2 = Arc::clone(&manager);
+        let second = tokio::spawn(async move {
+            let _g = m2.begin_connect().await;
+        });
+        // second attempt must be blocked while the first guard is held
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!second.is_finished());
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("second connect proceeds after the first releases the lock")
+            .unwrap();
     }
 }

--- a/src/components/features/portforward/PortForwardPanel.tsx
+++ b/src/components/features/portforward/PortForwardPanel.tsx
@@ -58,11 +58,7 @@ export function PortForwardPanel({ onClose }: PortForwardPanelProps) {
     startForward,
     stopForward,
     stopAllForwards,
-  } = usePortForward({
-    onError: (forwardId, message) => {
-      console.error(`Port forward ${forwardId} error:`, message);
-    },
-  });
+  } = usePortForward();
 
   const history = usePortForwardStore((s) => s.history);
   const removeHistoryItem = usePortForwardStore((s) => s.removeHistoryItem);

--- a/src/lib/hooks/usePortForward.ts
+++ b/src/lib/hooks/usePortForward.ts
@@ -3,16 +3,7 @@
 import { useEffect } from "react";
 import { usePortForwardStore } from "@/lib/stores/portforward-store";
 
-export interface UsePortForwardOptions {
-  onStarted?: (forwardId: string, localPort: number) => void;
-  onConnected?: (forwardId: string) => void;
-  onDisconnected?: (forwardId: string) => void;
-  onError?: (forwardId: string, message: string) => void;
-  onStopped?: (forwardId: string) => void;
-}
-
- 
-export function usePortForward(_options?: UsePortForwardOptions) {
+export function usePortForward() {
   const forwards = usePortForwardStore((s) => s.forwards);
   const isLoading = usePortForwardStore((s) => s.isLoading);
   const error = usePortForwardStore((s) => s.error);

--- a/src/lib/stores/__tests__/portforward-store.test.ts
+++ b/src/lib/stores/__tests__/portforward-store.test.ts
@@ -119,6 +119,40 @@ describe("PortForwardStore", () => {
     jest.clearAllMocks();
   });
 
+  describe("startForward error cleanup", () => {
+    it("removes only the failed attempt's placeholder, not sibling forwards", async () => {
+      // Existing healthy forward to a *prefix-colliding* target port (80 vs 8080)
+      const sibling: PortForwardInfo = {
+        ...mockForward,
+        forward_id: "pod-demo-web-8080-111",
+        target_port: 8080,
+      };
+      // Existing healthy forward to the SAME target (different attempt)
+      const sameTarget: PortForwardInfo = {
+        ...mockForward,
+        forward_id: "pod-demo-web-80-222",
+        target_port: 80,
+      };
+      usePortForwardStore.setState({ forwards: [sibling, sameTarget] });
+
+      mockPortforwardStart.mockRejectedValue(new Error("port busy"));
+
+      await act(async () => {
+        await usePortForwardStore
+          .getState()
+          .startForward("demo", "web", "pod", 80);
+      });
+
+      const ids = usePortForwardStore.getState().forwards.map((f) => f.forward_id);
+      // The failed placeholder is gone...
+      expect(ids).toHaveLength(2);
+      // ...but both pre-existing forwards survive (old prefix-match killed them)
+      expect(ids).toContain("pod-demo-web-8080-111");
+      expect(ids).toContain("pod-demo-web-80-222");
+      expect(usePortForwardStore.getState().error).toBe("port busy");
+    });
+  });
+
   describe("updateForwardStatus", () => {
     it("should update forward status by id", () => {
       usePortForwardStore.setState({ forwards: [{ ...mockForward }] });

--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -607,6 +607,16 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
               set(updates);
               break;
             }
+            case "Restarted": {
+              // Watch (re)synced: backend now sends the initial/resync
+              // listing as one batch instead of per-item Added events
+              const names = (watchEvent.data as { name: string }[]).map((n) => n.name);
+              const merged = Array.from(new Set([...namespaces, ...names])).sort();
+              if (merged.length !== namespaces.length) {
+                set({ namespaces: merged });
+              }
+              break;
+            }
             case "Error": {
               debug("Namespace watch error:", watchEvent.data);
               break;

--- a/src/lib/stores/portforward-store.ts
+++ b/src/lib/stores/portforward-store.ts
@@ -528,9 +528,10 @@ export const usePortForwardStore = create<PortForwardState>()(
   ) => {
     set({ isLoading: true, error: null });
 
+    const forwardId =
+      forwardIdOverride ?? `${targetType}-${namespace}-${name}-${targetPort}-${Date.now()}`;
+
     try {
-      const forwardId =
-        forwardIdOverride ?? `${targetType}-${namespace}-${name}-${targetPort}-${Date.now()}`;
 
       // Add placeholder forward BEFORE calling Rust to avoid race condition
       // The "Connected" event might arrive before portforwardStart returns
@@ -592,14 +593,13 @@ export const usePortForwardStore = create<PortForwardState>()(
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : "Failed to start port forward";
-      // Remove the placeholder on error
-      const forwardId = `${targetType}-${namespace}-${name}-${targetPort}`;
+      // Remove exactly this attempt's placeholder. The old prefix match
+      // (id without the timestamp suffix) also killed sibling forwards of
+      // the same target and prefix-collided (...-80 matched ...-8080).
       set((state) => ({
         isLoading: false,
         error: errorMessage,
-        forwards: state.forwards.filter(
-          (f) => !f.forward_id.startsWith(forwardId)
-        ),
+        forwards: state.forwards.filter((f) => f.forward_id !== forwardId),
       }));
       return null;
     }


### PR DESCRIPTION
## Summary

Phase-3 robustness pass (tasks 3.1–3.4) — one theme: connection lifecycle.

### Connect state machine (3.1)
- Connect attempts serialized behind a mutex; racing connects could interleave init/test and leave client+context mismatched
- 30 s hard timeout around init — exec-plugin configs (kubelogin device flow) can hang forever
- Any failed connect (init error, failed test, timeout) now clears client+context: the stored client never points at a cluster that didn't pass its connection test
- Previous OIDC refresh loop cancelled at connect start; superseded refresh tasks re-check their stop flag under the client write lock (reconnect to the *same* context could be clobbered by a stale client)
- First tests for the state machine's failure paths (was zero coverage)

### Session teardown (3.2)
`stop_all()` on all five managers (watches, log streams, shells incl. best-effort debug-pod deletion, port-forwards, PF namespace watchers), called on disconnect **and** before context switch. Streams no longer keep running against the old cluster.

### Watch lifecycle (3.3)
- CancellationToken + `select!` — stop is immediate; the old stop-flag was only polled after the next event, so quiet watches lingered forever
- `add_session` cancels a session it replaces; tasks self-remove only while they still own the entry (`Arc::ptr_eq`)
- Initial/resync listing arrives as one `Restarted(Vec)` event instead of an Added-flood (rows duplicated on every resync)

### Port-forward lifecycle (3.4)
- Namespace-watcher refcounts released in every auto-cleanup path via centralized `cleanup_session()` — no leak, no double release
- Listener bound once, moved into the task (TOCTOU gone); no phantom sessions after failed setup
- Reconnect handlers spawned instead of blocking the pod-event loop; idle connections cut immediately on stop; fixed sleeps replaced by a completion signal
- Frontend: failed start removes exactly its own placeholder (prefix match killed sibling forwards, `...-80` matched `...-8080`) + regression test; dead options API removed

## Tests

252 cargo (+17), 639 jest (+1), clippy, lint, typecheck green.

## Manual smoke checklist (before merge)

- [ ] Cluster verbinden → trennen → anderes Cluster verbinden (keine Geister-Streams/Watches)
- [ ] Context-Switch bei offenen Log-Tabs/Watches → alles sauber neu
- [ ] Connect auf nicht erreichbares Cluster → Fehler, danach normales Cluster verbinden funktioniert
- [ ] Port-Forward starten/stoppen, Pod dahinter löschen → Reconnect/Aufräumen
- [ ] Fehlgeschlagener Forward (Port belegt) → andere Forwards bleiben
- [ ] OIDC-Cluster: Verbindung hält > Token-Lifetime (Refresh)