### PR TITLE
fix: data-loss paths, Helm forget semantics, env-secret redaction

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3157,7 +3157,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -6692,6 +6692,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,7 +88,7 @@ rmcp = { version = "1.7", features = ["server", "transport-io", "macros"] }
 clap = { version = "4.5", features = ["derive"] }
 
 # TOML for Codex config
-toml = "1.0"
+toml_edit = "0.25"
 
 # macOS window management for tray popup
 [target."cfg(target_os = \"macos\")".dependencies]

--- a/src-tauri/src/app/command_registry/mod.rs
+++ b/src-tauri/src/app/command_registry/mod.rs
@@ -67,6 +67,7 @@ pub fn handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Syn
         crate::commands::resources::list_mutating_webhooks,
         crate::commands::resources::list_validating_webhooks,
         crate::commands::resources::get_pod,
+        crate::commands::resources::reveal_env_var,
         crate::commands::resources::delete_pod,
         crate::commands::resources::get_resource_yaml,
         crate::commands::resources::apply_resource_yaml,

--- a/src-tauri/src/commands/cluster_settings.rs
+++ b/src-tauri/src/commands/cluster_settings.rs
@@ -45,6 +45,17 @@ pub async fn get_cluster_settings(
     }
 }
 
+/// Serializes read-modify-write cycles on the settings store: two concurrent
+/// partial updates (namespaces vs. auth flag) would otherwise both read the
+/// same snapshot and the second save would drop the first change.
+static SETTINGS_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock_settings() -> std::sync::MutexGuard<'static, ()> {
+    SETTINGS_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Read the current settings for a context, falling back to defaults so other
 /// fields are preserved across partial updates.
 fn current_settings(
@@ -88,6 +99,7 @@ pub async fn set_cluster_accessible_namespaces(
         .store("cluster-settings.json")
         .map_err(|e| format!("Failed to open cluster settings store: {}", e))?;
 
+    let _guard = lock_settings();
     let mut settings = current_settings(&store, &context);
     settings.accessible_namespaces = namespaces;
     persist_settings(&store, &context, &settings)?;
@@ -112,6 +124,7 @@ pub async fn set_cluster_prefer_kubeconfig_auth(
         .store("cluster-settings.json")
         .map_err(|e| format!("Failed to open cluster settings store: {}", e))?;
 
+    let _guard = lock_settings();
     let mut settings = current_settings(&store, &context);
     settings.prefer_kubeconfig_auth = prefer;
     persist_settings(&store, &context, &settings)?;
@@ -132,6 +145,7 @@ pub async fn clear_cluster_settings(app: AppHandle, context: String) -> Result<(
         .store("cluster-settings.json")
         .map_err(|e| format!("Failed to open cluster settings store: {}", e))?;
 
+    let _guard = lock_settings();
     store.delete(&context);
 
     store

--- a/src-tauri/src/commands/helm.rs
+++ b/src-tauri/src/commands/helm.rs
@@ -580,7 +580,9 @@ pub async fn get_helm_release_manifest(
     Ok(detail.manifest)
 }
 
-/// Uninstall a native Helm release by deleting all its release secrets
+/// Forget a native Helm release by deleting all its release secrets.
+/// Deployed manifest resources are intentionally left running - the UI
+/// presents this as "Forget release", not a full `helm uninstall`.
 #[command]
 pub async fn uninstall_helm_release(
     state: State<'_, AppState>,

--- a/src-tauri/src/commands/kubeconfig.rs
+++ b/src-tauri/src/commands/kubeconfig.rs
@@ -11,6 +11,17 @@ use tauri_plugin_store::StoreExt;
 const STORE_FILENAME: &str = "kubeconfig-sources.json";
 const STORE_KEY: &str = "sources_config";
 
+/// Serializes load-modify-save cycles: two concurrent commands would
+/// otherwise both read the same state and the second save wins, silently
+/// dropping the first change.
+static SOURCES_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock_sources() -> std::sync::MutexGuard<'static, ()> {
+    SOURCES_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Load sources config from Tauri store
 pub(crate) fn load_sources_config(app: &AppHandle) -> KubeconfigSourcesConfig {
     let store = match app.store(STORE_FILENAME) {
@@ -81,6 +92,7 @@ pub async fn set_kubeconfig_sources(
     app: AppHandle,
     config: KubeconfigSourcesConfig,
 ) -> Result<(), String> {
+    let _guard = lock_sources();
     save_sources_config(&app, &config)?;
     allow_sources_in_fs_scope(&app);
     Ok(())
@@ -93,6 +105,7 @@ pub async fn add_kubeconfig_source(
     path: String,
     source_type: KubeconfigSourceType,
 ) -> Result<KubeconfigSourcesConfig, String> {
+    let _guard = lock_sources();
     let mut config = load_sources_config(&app);
 
     // Check for duplicates
@@ -127,6 +140,7 @@ pub async fn remove_kubeconfig_source(
         return Err("Cannot remove the default kubeconfig source".to_string());
     }
 
+    let _guard = lock_sources();
     let mut config = load_sources_config(&app);
     config.sources.retain(|s| s.path != path);
     save_sources_config(&app, &config)?;
@@ -172,6 +186,7 @@ pub async fn set_kubeconfig_merge_mode(
     app: AppHandle,
     enabled: bool,
 ) -> Result<KubeconfigSourcesConfig, String> {
+    let _guard = lock_sources();
     let mut config = load_sources_config(&app);
     config.merge_mode = enabled;
     save_sources_config(&app, &config)?;

--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -772,10 +772,8 @@ async fn resolve_env_vars(
     containers: &mut [ContainerInfo],
     pod: &PodContext,
 ) {
-    // Cache for ConfigMap and Secret data to avoid redundant fetches
+    // Cache for ConfigMap data to avoid redundant fetches
     let mut configmap_cache: HashMap<String, Option<std::collections::BTreeMap<String, String>>> =
-        HashMap::new();
-    let mut secret_cache: HashMap<String, Option<std::collections::BTreeMap<String, String>>> =
         HashMap::new();
 
     for container in containers.iter_mut() {
@@ -799,33 +797,10 @@ async fn resolve_env_vars(
                             }
                         }
                     }
-                    "secret" => {
-                        if let Some((secret_name, secret_key)) = ref_value.split_once(':') {
-                            let cache_key = secret_name.to_string();
-                            let data = if let Some(cached) = secret_cache.get(&cache_key) {
-                                cached.clone()
-                            } else {
-                                let secrets: Api<Secret> =
-                                    Api::namespaced(client.clone(), namespace);
-                                let fetched = secrets.get(secret_name).await.ok().and_then(|s| {
-                                    s.data.map(|d| {
-                                        d.into_iter()
-                                            .map(|(k, v)| {
-                                                let decoded = String::from_utf8(v.0)
-                                                    .unwrap_or_else(|_| "<binary>".to_string());
-                                                (k, decoded)
-                                            })
-                                            .collect()
-                                    })
-                                });
-                                secret_cache.insert(cache_key, fetched.clone());
-                                fetched
-                            };
-                            if let Some(data) = data {
-                                env_var.resolved_value = data.get(secret_key).cloned();
-                            }
-                        }
-                    }
+                    // Secret-backed values are deliberately NOT resolved here:
+                    // they would sit decoded in every pod-detail payload. The
+                    // UI calls `reveal_env_var` when the user explicitly asks.
+                    "secret" => {}
                     "field" => {
                         env_var.resolved_value = resolve_field_ref(ref_value, pod);
                     }
@@ -939,6 +914,27 @@ pub async fn get_pod(
         restart_count: total_restarts,
         ready_containers: format!("{}/{}", ready_count, total_count),
     })
+}
+
+/// Fetch one secret-backed env var value on demand. `get_pod` never resolves
+/// secret values, so they only leave the cluster when the user reveals them.
+#[command]
+pub async fn reveal_env_var(
+    state: State<'_, AppState>,
+    namespace: String,
+    secret_name: String,
+    key: String,
+) -> Result<String, KubeliError> {
+    let client = state.k8s.get_client().await?;
+
+    let secrets: Api<Secret> = Api::namespaced(client, &namespace);
+    let secret = secrets.get(&secret_name).await?;
+    let data = secret.data.unwrap_or_default();
+    let value = data
+        .get(&key)
+        .ok_or_else(|| format!("Key '{}' not found in secret '{}'", key, secret_name))?;
+
+    Ok(String::from_utf8(value.0.clone()).unwrap_or_else(|_| "<binary>".to_string()))
 }
 
 /// Delete a pod
@@ -1452,13 +1448,21 @@ pub async fn apply_resource_yaml(
         ("", api_version)
     };
 
-    // Create ApiResource for dynamic API
-    let ar = ApiResource {
-        group: group.to_string(),
-        version: version.to_string(),
-        kind: kind.to_string(),
-        api_version: api_version.to_string(),
-        plural: get_plural(kind),
+    // Resolve the plural via API discovery - guessing it breaks kinds like
+    // StorageClass ("storageclasss"). Fall back to the heuristic offline.
+    let gvk = kube::core::GroupVersionKind::gvk(group, version, kind);
+    let ar = match kube::discovery::oneshot::pinned_kind(&client, &gvk).await {
+        Ok((ar, _caps)) => ar,
+        Err(e) => {
+            tracing::warn!("Discovery failed for {}/{} {}: {}", group, version, kind, e);
+            ApiResource {
+                group: group.to_string(),
+                version: version.to_string(),
+                kind: kind.to_string(),
+                api_version: api_version.to_string(),
+                plural: get_plural(kind),
+            }
+        }
     };
 
     // Create dynamic API
@@ -1658,7 +1662,28 @@ fn get_plural(kind: &str) -> String {
         "cronjob" => "cronjobs".to_string(),
         "event" => "events".to_string(),
         "lease" => "leases".to_string(),
-        _ => format!("{}s", kind.to_lowercase()),
+        "endpoints" => "endpoints".to_string(),
+        other => fallback_plural(other),
+    }
+}
+
+/// English pluralization heuristic for kinds not in the table above.
+/// Matches how Kubernetes derives plurals for built-ins and most CRDs.
+fn fallback_plural(lower_kind: &str) -> String {
+    if lower_kind.ends_with('s')
+        || lower_kind.ends_with('x')
+        || lower_kind.ends_with("ch")
+        || lower_kind.ends_with("sh")
+    {
+        format!("{}es", lower_kind)
+    } else if let Some(stem) = lower_kind.strip_suffix('y') {
+        if stem.ends_with(|c: char| "aeiou".contains(c)) {
+            format!("{}s", lower_kind)
+        } else {
+            format!("{}ies", stem)
+        }
+    } else {
+        format!("{}s", lower_kind)
     }
 }
 
@@ -4489,5 +4514,67 @@ mod tests {
             summarize_dynamic_status(&resource),
             Some("Active".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_env_vars_never_resolves_secret_values() {
+        // Regression (security): secret values used to be fetched and decoded
+        // into every get_pod payload. They must stay unresolved until the user
+        // explicitly calls reveal_env_var. The client points at an unroutable
+        // address - if this test hangs or errors, the secret arm hit the API.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let config = kube::Config::new("http://127.0.0.1:1".parse().unwrap());
+        let client = kube::Client::try_from(config).expect("client");
+
+        let mut containers = vec![ContainerInfo {
+            name: "app".into(),
+            image: "img".into(),
+            ready: true,
+            restart_count: 0,
+            state: "Running".into(),
+            state_reason: None,
+            last_state: None,
+            last_state_reason: None,
+            last_exit_code: None,
+            last_finished_at: None,
+            env_vars: vec![ContainerEnvVar {
+                name: "DB_PASSWORD".into(),
+                value: None,
+                value_from_kind: Some("secret".into()),
+                value_from: Some("db-secret:password".into()),
+                resolved_value: None,
+            }],
+            ports: vec![],
+        }];
+        let pod = PodContext {
+            name: "pod".into(),
+            namespace: "default".into(),
+            uid: "uid".into(),
+            node_name: None,
+            pod_ip: None,
+            host_ip: None,
+            service_account: None,
+            labels: HashMap::new(),
+            annotations: HashMap::new(),
+        };
+
+        resolve_env_vars(&client, "default", &mut containers, &pod).await;
+
+        assert_eq!(containers[0].env_vars[0].resolved_value, None);
+    }
+
+    #[test]
+    fn test_get_plural_handles_irregular_kinds() {
+        // Regression: the old fallback appended a bare "s", producing
+        // "storageclasss" / "ingressclasss" and failing every apply.
+        assert_eq!(get_plural("StorageClass"), "storageclasses");
+        assert_eq!(get_plural("IngressClass"), "ingressclasses");
+        assert_eq!(get_plural("Ingress"), "ingresses");
+        assert_eq!(get_plural("NetworkPolicy"), "networkpolicies");
+        assert_eq!(get_plural("PriorityClass"), "priorityclasses");
+        assert_eq!(get_plural("Endpoints"), "endpoints");
+        assert_eq!(get_plural("Pod"), "pods");
+        assert_eq!(get_plural("Gateway"), "gateways");
+        assert_eq!(get_plural("MyCrd"), "mycrds");
     }
 }

--- a/src-tauri/src/mcp/ide_config.rs
+++ b/src-tauri/src/mcp/ide_config.rs
@@ -3,7 +3,7 @@
 //! Handles installation and removal of MCP server configuration for various IDEs.
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::ai::cli_detector::get_extended_path;
 
@@ -370,69 +370,93 @@ fn uninstall_claude_code_config(_path: &PathBuf) -> Result<(), String> {
     Ok(())
 }
 
+/// Write via temp file + rename so a crash mid-write can't truncate the config.
+fn write_atomic(path: &Path, content: &str) -> Result<(), String> {
+    let tmp = path.with_extension("kubeli-tmp");
+    std::fs::write(&tmp, content).map_err(|e| format!("Failed to write config: {}", e))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("Failed to write config: {}", e))
+}
+
 // --- Codex (TOML) ---
+// Uses toml_edit so user comments and formatting in config.toml survive edits.
 
 fn install_codex_config(path: &PathBuf, kubeli_path: &str) -> Result<(), String> {
-    let mut content = if path.exists() {
-        std::fs::read_to_string(path).map_err(|e| format!("Failed to read config: {}", e))?
+    let mut doc = if path.exists() {
+        let content =
+            std::fs::read_to_string(path).map_err(|e| format!("Failed to read config: {}", e))?;
+        content.parse::<toml_edit::DocumentMut>().map_err(|e| {
+            format!(
+                "Cannot parse {} as TOML ({}); refusing to modify it",
+                path.display(),
+                e
+            )
+        })?
     } else {
-        String::new()
+        toml_edit::DocumentMut::new()
     };
 
-    // Check if already configured
-    if content.contains("[mcp_servers.kubeli]") {
+    let servers = doc
+        .entry("mcp_servers")
+        .or_insert(toml_edit::table())
+        .as_table_mut()
+        .ok_or_else(|| "mcp_servers in config.toml is not a table".to_string())?;
+    servers.set_implicit(true);
+
+    if servers.contains_key("kubeli") {
         return Ok(()); // Already configured
     }
 
-    // Add Kubeli config
-    let kubeli_config = format!(
-        r#"
-[mcp_servers.kubeli]
-command = "{}"
-args = ["--mcp"]
-startup_timeout_sec = 15
-tool_timeout_sec = 120
-"#,
-        kubeli_path
-    );
+    let mut kubeli = toml_edit::Table::new();
+    kubeli["command"] = toml_edit::value(kubeli_path);
+    let mut args = toml_edit::Array::new();
+    args.push("--mcp");
+    kubeli["args"] = toml_edit::value(args);
+    kubeli["startup_timeout_sec"] = toml_edit::value(15);
+    kubeli["tool_timeout_sec"] = toml_edit::value(120);
+    servers.insert("kubeli", toml_edit::Item::Table(kubeli));
 
-    content.push_str(&kubeli_config);
-
-    std::fs::write(path, content).map_err(|e| format!("Failed to write config: {}", e))?;
-
-    Ok(())
+    write_atomic(path, &doc.to_string())
 }
 
 fn uninstall_codex_config(path: &PathBuf) -> Result<(), String> {
     let content =
         std::fs::read_to_string(path).map_err(|e| format!("Failed to read config: {}", e))?;
 
-    // Parse TOML and remove kubeli section
-    let mut doc: toml::Table =
-        toml::from_str(&content).map_err(|e| format!("Failed to parse TOML: {}", e))?;
+    let mut doc = content
+        .parse::<toml_edit::DocumentMut>()
+        .map_err(|e| format!("Failed to parse TOML: {}", e))?;
 
     if let Some(servers) = doc.get_mut("mcp_servers").and_then(|v| v.as_table_mut()) {
         servers.remove("kubeli");
     }
 
+    write_atomic(path, &doc.to_string())
+}
+
+/// Read an existing JSON config, or start fresh if the file doesn't exist.
+/// A file that exists but doesn't parse is a hard error: silently replacing it
+/// with `{}` would wipe the user's settings (VS Code settings.json may contain
+/// JSONC comments, which we can't safely rewrite).
+fn read_json_config(path: &Path) -> Result<serde_json::Value, String> {
+    if !path.exists() {
+        return Ok(serde_json::json!({}));
+    }
     let content =
-        toml::to_string_pretty(&doc).map_err(|e| format!("Failed to serialize TOML: {}", e))?;
-
-    std::fs::write(path, content).map_err(|e| format!("Failed to write config: {}", e))?;
-
-    Ok(())
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read config: {}", e))?;
+    serde_json::from_str(&content).map_err(|e| {
+        format!(
+            "Cannot parse {} as JSON ({}); refusing to modify it. \
+             If the file uses comments, please add the Kubeli MCP entry manually.",
+            path.display(),
+            e
+        )
+    })
 }
 
 // --- VS Code (JSON) ---
 
-fn install_vscode_config(path: &PathBuf, kubeli_path: &str) -> Result<(), String> {
-    let mut config: serde_json::Value = if path.exists() {
-        let content =
-            std::fs::read_to_string(path).map_err(|e| format!("Failed to read config: {}", e))?;
-        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
-    } else {
-        serde_json::json!({})
-    };
+fn install_vscode_config(path: &Path, kubeli_path: &str) -> Result<(), String> {
+    let mut config = read_json_config(path)?;
 
     // Ensure mcp.servers exists
     if config.get("mcp.servers").is_none() {
@@ -448,9 +472,7 @@ fn install_vscode_config(path: &PathBuf, kubeli_path: &str) -> Result<(), String
     let content = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {}", e))?;
 
-    std::fs::write(path, content).map_err(|e| format!("Failed to write config: {}", e))?;
-
-    Ok(())
+    write_atomic(path, &content)
 }
 
 fn uninstall_vscode_config(path: &PathBuf) -> Result<(), String> {
@@ -469,21 +491,13 @@ fn uninstall_vscode_config(path: &PathBuf) -> Result<(), String> {
     let content = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {}", e))?;
 
-    std::fs::write(path, content).map_err(|e| format!("Failed to write config: {}", e))?;
-
-    Ok(())
+    write_atomic(path, &content)
 }
 
 // --- Cursor (JSON) ---
 
-fn install_cursor_config(path: &PathBuf, kubeli_path: &str) -> Result<(), String> {
-    let mut config: serde_json::Value = if path.exists() {
-        let content =
-            std::fs::read_to_string(path).map_err(|e| format!("Failed to read config: {}", e))?;
-        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
-    } else {
-        serde_json::json!({})
-    };
+fn install_cursor_config(path: &Path, kubeli_path: &str) -> Result<(), String> {
+    let mut config = read_json_config(path)?;
 
     // Ensure mcpServers exists
     if config.get("mcpServers").is_none() {
@@ -499,9 +513,7 @@ fn install_cursor_config(path: &PathBuf, kubeli_path: &str) -> Result<(), String
     let content = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {}", e))?;
 
-    std::fs::write(path, content).map_err(|e| format!("Failed to write config: {}", e))?;
-
-    Ok(())
+    write_atomic(path, &content)
 }
 
 fn uninstall_cursor_config(path: &PathBuf) -> Result<(), String> {
@@ -520,9 +532,7 @@ fn uninstall_cursor_config(path: &PathBuf) -> Result<(), String> {
     let content = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {}", e))?;
 
-    std::fs::write(path, content).map_err(|e| format!("Failed to write config: {}", e))?;
-
-    Ok(())
+    write_atomic(path, &content)
 }
 
 #[cfg(test)]
@@ -651,6 +661,71 @@ mod tests {
         assert!(uninstalled.contains("\"mcpServers\": {}"));
         assert!(!uninstalled.contains("\"kubeli\""));
         assert!(!check_mcp_configured(IdeType::Cursor, &path));
+    }
+
+    #[test]
+    fn test_codex_windows_path_survives_toml_roundtrip() {
+        // A raw backslash path interpolated into a TOML basic string used to
+        // produce invalid escapes (\U, \P) and a broken config on Windows.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let win_path = r"C:\Program Files\Kubeli\Kubeli.exe";
+
+        install_codex_config(&path, win_path).unwrap();
+
+        let doc: toml_edit::DocumentMut = std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert_eq!(
+            doc["mcp_servers"]["kubeli"]["command"].as_str(),
+            Some(win_path)
+        );
+    }
+
+    #[test]
+    fn test_codex_install_preserves_comments() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "# my note\nmodel = \"o3\"\n").unwrap();
+
+        install_codex_config(&path, "/tmp/kubeli").unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("# my note"));
+        assert!(content.contains("model = \"o3\""));
+        assert!(content.contains("[mcp_servers.kubeli]"));
+
+        uninstall_codex_config(&path).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("# my note"));
+        assert!(!content.contains("kubeli"));
+    }
+
+    #[test]
+    fn test_codex_install_refuses_invalid_toml() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "not [ valid toml").unwrap();
+
+        assert!(install_codex_config(&path, "/tmp/kubeli").is_err());
+        // File untouched
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "not [ valid toml");
+    }
+
+    #[test]
+    fn test_json_install_refuses_unparseable_config_instead_of_wiping() {
+        // VS Code settings.json is JSONC: comments are legal for the editor
+        // but unparseable for serde_json. Install used to replace the whole
+        // file with just the kubeli entry - the user's settings were gone.
+        let dir = tempdir().unwrap();
+        let jsonc = "{\n  // my editor settings\n  \"editor.fontSize\": 14\n}";
+
+        let vscode = dir.path().join("settings.json");
+        std::fs::write(&vscode, jsonc).unwrap();
+        assert!(install_vscode_config(&vscode, "/tmp/kubeli").is_err());
+        assert_eq!(std::fs::read_to_string(&vscode).unwrap(), jsonc);
+
+        let cursor = dir.path().join("mcp.json");
+        std::fs::write(&cursor, jsonc).unwrap();
+        assert!(install_cursor_config(&cursor, "/tmp/kubeli").is_err());
+        assert_eq!(std::fs::read_to_string(&cursor).unwrap(), jsonc);
     }
 
     #[test]

--- a/src-tauri/src/oidc/store.rs
+++ b/src-tauri/src/oidc/store.rs
@@ -53,10 +53,18 @@ impl OidcTokenStore {
     }
 
     pub fn save_refresh_token(issuer: &str, client_id: &str, refresh_token: &str) {
+        // A silent failure here means the user re-authenticates in the browser
+        // every session without knowing why - at least leave a trace.
         let service = keyring_service(issuer, client_id);
-        let entry = keyring::Entry::new(&service, "refresh_token");
-        if let Ok(entry) = entry {
-            let _ = entry.set_password(refresh_token);
+        match keyring::Entry::new(&service, "refresh_token") {
+            Ok(entry) => {
+                if let Err(e) = entry.set_password(refresh_token) {
+                    tracing::warn!("Failed to save OIDC refresh token to keyring: {}", e);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to open keyring entry for OIDC refresh token: {}", e);
+            }
         }
     }
 

--- a/src/components/features/dashboard/dialogs/UninstallHelmDialog.tsx
+++ b/src/components/features/dashboard/dialogs/UninstallHelmDialog.tsx
@@ -33,7 +33,9 @@ export function UninstallHelmDialog({ state, onClose }: UninstallHelmDialogProps
     if (!state) return;
     try {
       await uninstallHelmRelease(state.name, state.namespace);
-      toast.success("Release uninstalled", { description: state.name });
+      toast.success("Release forgotten", {
+        description: `${state.name} removed from Helm history. Deployed resources are still running.`,
+      });
       state.onSuccess?.();
     } catch (e) {
       toast.error("Failed to uninstall", { description: String(e) });
@@ -45,15 +47,18 @@ export function UninstallHelmDialog({ state, onClose }: UninstallHelmDialogProps
     <AlertDialog open={state?.open} onOpenChange={(open) => !open && onClose()}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Uninstall Helm Release?</AlertDialogTitle>
+          <AlertDialogTitle>Forget Helm Release?</AlertDialogTitle>
           <AlertDialogDescription>
-            {t("messages.confirmDelete", { name: state?.name || "" })}
+            This deletes the Helm release records (secrets) for{" "}
+            <strong>{state?.name}</strong>
             {state?.namespace && (
               <>
                 {" "}
                 ({t("cluster.namespace")}: <strong>{state.namespace}</strong>)
               </>
             )}
+            , so Helm no longer tracks it. The deployed resources stay in the
+            cluster - delete them individually if you want them gone.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -62,7 +67,7 @@ export function UninstallHelmDialog({ state, onClose }: UninstallHelmDialogProps
             onClick={handleUninstall}
             className="bg-destructive text-white hover:bg-destructive/90"
           >
-            Uninstall
+            Forget release
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/features/dashboard/views/gitops/HelmReleasesView.tsx
+++ b/src/components/features/dashboard/views/gitops/HelmReleasesView.tsx
@@ -127,7 +127,7 @@ export function HelmReleasesView() {
       });
     } else {
       items.push({
-        label: "Uninstall",
+        label: "Forget release",
         icon: <Trash2 className="size-4" />,
         onClick: () => handleUninstallFromContext(release.name, release.namespace, refresh),
         variant: "destructive",

--- a/src/components/features/resources/components/ContainerStatusSection.tsx
+++ b/src/components/features/resources/components/ContainerStatusSection.tsx
@@ -8,11 +8,13 @@ import { Separator } from "@/components/ui/separator";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { revealEnvVar } from "@/lib/tauri/commands";
 import type { ContainerInfo } from "@/lib/types";
 
 interface ContainerStatusSectionProps {
   initContainers?: ContainerInfo[];
   containers: ContainerInfo[];
+  namespace: string;
 }
 
 function formatTimestamp(timestamp: string | null): string {
@@ -91,31 +93,67 @@ function EnvVarSourceBadge({ kind }: { kind: string }) {
   );
 }
 
-function EnvVarRow({ env, t }: { env: ContainerInfo["env_vars"][number]; t: ReturnType<typeof useTranslations> }) {
+function EnvVarRow({
+  env,
+  namespace,
+  t,
+}: {
+  env: ContainerInfo["env_vars"][number];
+  namespace: string;
+  t: ReturnType<typeof useTranslations>;
+}) {
   const [revealed, setRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [secretValue, setSecretValue] = useState<string | null>(null);
 
   const isRef = !!env.value_from_kind;
+  const isSecret = env.value_from_kind === "secret";
   const hasResolvedValue = isRef && env.resolved_value != null;
-  const displayValue = hasResolvedValue ? env.resolved_value! : (env.value_from ?? env.value ?? "");
-  const canReveal = !isRef || hasResolvedValue;
+  const resolvedDisplay = isSecret ? secretValue : hasResolvedValue ? env.resolved_value! : null;
+  const displayValue = resolvedDisplay ?? env.value_from ?? env.value ?? "";
+  const canReveal = !isRef || hasResolvedValue || isSecret;
 
-  const toggleReveal = useCallback(() => {
+  // Secret values are never included in the pod payload; fetch on explicit
+  // reveal/copy only.
+  const loadValue = useCallback(async () => {
+    if (!isSecret) return displayValue;
+    if (secretValue != null) return secretValue;
+    const ref = env.value_from ?? "";
+    const idx = ref.indexOf(":");
+    const value = await revealEnvVar(namespace, ref.slice(0, idx), ref.slice(idx + 1));
+    setSecretValue(value);
+    return value;
+  }, [isSecret, displayValue, secretValue, env.value_from, namespace]);
+
+  const toggleReveal = useCallback(async () => {
     if (revealed) {
       setRevealed(false);
-    } else {
-      setRevealed(true);
-      // Auto-hide after 10 seconds (like secrets)
-      setTimeout(() => setRevealed(false), 10000);
+      return;
     }
-  }, [revealed]);
+    try {
+      await loadValue();
+    } catch (e) {
+      toast.error("Failed to reveal value", { description: String(e) });
+      return;
+    }
+    setRevealed(true);
+    // Auto-hide after 10 seconds (like secrets)
+    setTimeout(() => setRevealed(false), 10000);
+  }, [revealed, loadValue]);
 
   const copyValue = useCallback(async () => {
-    await navigator.clipboard.writeText(displayValue);
+    let value = displayValue;
+    try {
+      value = await loadValue();
+    } catch (e) {
+      toast.error("Failed to copy value", { description: String(e) });
+      return;
+    }
+    await navigator.clipboard.writeText(value);
     setCopied(true);
     toast.success(t("messages.copySuccess"));
     setTimeout(() => setCopied(false), 2000);
-  }, [displayValue, t]);
+  }, [displayValue, loadValue, t]);
 
   return (
     <div className="space-y-1">
@@ -150,7 +188,7 @@ function EnvVarRow({ env, t }: { env: ContainerInfo["env_vars"][number]; t: Retu
           userSelect: revealed ? "text" : "none",
         } : undefined}
       >
-        <span className={cn("break-all", isRef && !hasResolvedValue && "text-blue-400 italic text-[11px]")}>
+        <span className={cn("break-all", isRef && !hasResolvedValue && !isSecret && "text-blue-400 italic text-[11px]")}>
           {canReveal ? (revealed ? displayValue : "••••••••") : displayValue}
         </span>
       </div>
@@ -160,9 +198,11 @@ function EnvVarRow({ env, t }: { env: ContainerInfo["env_vars"][number]; t: Retu
 
 function EnvVarsSection({
   envVars,
+  namespace,
   t,
 }: {
   envVars: ContainerInfo["env_vars"];
+  namespace: string;
   t: ReturnType<typeof useTranslations>;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -196,7 +236,7 @@ function EnvVarsSection({
         {expanded && (
           <div className="px-3 pb-3 space-y-2">
             {envVars.map((env) => (
-              <EnvVarRow key={env.name} env={env} t={t} />
+              <EnvVarRow key={env.name} env={env} namespace={namespace} t={t} />
             ))}
           </div>
         )}
@@ -207,9 +247,11 @@ function EnvVarsSection({
 
 function ContainerCard({
   container,
+  namespace,
   t,
 }: {
   container: ContainerInfo;
+  namespace: string;
   t: ReturnType<typeof useTranslations>;
 }) {
   return (
@@ -291,12 +333,12 @@ function ContainerCard({
         </div>
       )}
 
-      <EnvVarsSection envVars={container.env_vars} t={t} />
+      <EnvVarsSection envVars={container.env_vars} namespace={namespace} t={t} />
     </div>
   );
 }
 
-export function ContainerStatusSection({ initContainers, containers }: ContainerStatusSectionProps) {
+export function ContainerStatusSection({ initContainers, containers, namespace }: ContainerStatusSectionProps) {
   const t = useTranslations();
 
   const hasInitContainers = initContainers && initContainers.length > 0;
@@ -316,7 +358,7 @@ export function ContainerStatusSection({ initContainers, containers }: Container
           </h3>
           <div className="space-y-3">
             {initContainers.map((container) => (
-              <ContainerCard key={container.name} container={container} t={t} />
+              <ContainerCard key={container.name} container={container} namespace={namespace} t={t} />
             ))}
           </div>
         </div>
@@ -330,7 +372,7 @@ export function ContainerStatusSection({ initContainers, containers }: Container
           </h3>
           <div className="space-y-3">
             {containers.map((container) => (
-              <ContainerCard key={container.name} container={container} t={t} />
+              <ContainerCard key={container.name} container={container} namespace={namespace} t={t} />
             ))}
           </div>
         </div>

--- a/src/components/features/resources/components/OverviewTab.tsx
+++ b/src/components/features/resources/components/OverviewTab.tsx
@@ -123,7 +123,11 @@ export function OverviewTab({ resource, resourceType, onNavigateToOwner }: Overv
 
         {/* Container Status Section (for Pods only) */}
         {resourceType === "pod" && (initContainers.length > 0 || containers.length > 0) && (
-          <ContainerStatusSection initContainers={initContainers} containers={containers} />
+          <ContainerStatusSection
+            initContainers={initContainers}
+            containers={containers}
+            namespace={resource.namespace ?? ""}
+          />
         )}
 
         {/* Labels Section */}

--- a/src/lib/tauri/commands/resources.ts
+++ b/src/lib/tauri/commands/resources.ts
@@ -248,6 +248,14 @@ export async function deletePod(name: string, namespace: string): Promise<void> 
   return invoke("delete_pod", { name, namespace });
 }
 
+export async function revealEnvVar(
+  namespace: string,
+  secretName: string,
+  key: string,
+): Promise<string> {
+  return invoke<string>("reveal_env_var", { namespace, secretName, key });
+}
+
 // Resource YAML commands
 export interface ResourceYaml {
   yaml: string;

--- a/src/lib/tauri/mock.ts
+++ b/src/lib/tauri/mock.ts
@@ -256,6 +256,8 @@ export function mockInvoke(command: string, payload?: Record<string, unknown>) {
       return Promise.resolve([]);
     case "check_metrics_server":
       return Promise.resolve(true);
+    case "reveal_env_var":
+      return Promise.resolve("mock-secret-value");
     case "get_pod_metrics":
     case "get_pod_metrics_direct":
       return Promise.resolve(buildMockPodMetrics());


### PR DESCRIPTION
## Summary

Task 3.5 (data-loss paths) plus the remaining secrets items from task 2.2/2.3 of the code review.

### IDE MCP config (src-tauri/src/mcp/ide_config.rs)
- A settings file that exists but fails to parse is now a hard error instead of being silently replaced with `{}`. VS Code `settings.json` with JSONC comments used to be wiped completely on MCP install.
- Codex `config.toml` is built with `toml_edit` instead of string interpolation: raw Windows paths (`C:\Program Files\...`) no longer produce invalid TOML escapes, and user comments/formatting survive install and uninstall.
- All config writes go through temp file + rename, so a crash mid-write can't truncate the file.

### Helm "Uninstall" → "Forget release"
The backend only deletes the Helm release secrets; deployed resources were never removed. The UI now says so: context menu and dialog renamed to "Forget release", with an explicit warning that resources stay in the cluster.

### apply_resource_yaml plural resolution
The plural was guessed with `format!("{}s")`, which breaks kinds like StorageClass ("storageclasss") and made every apply of those kinds fail. Now resolved via API discovery (`pinned_kind`), with an improved English-pluralization fallback for offline/error cases.

### Lost-update protection
`kubeconfig sources` and `cluster settings` commands do load-modify-save on a shared store; two concurrent updates could silently drop one change. Both cycles are now serialized under a mutex.

### Pod env secrets (security)
`get_pod` used to fetch and base64-decode every secret-backed env var into the pod-detail payload. Secret values are no longer resolved server-side; a new `reveal_env_var` command fetches a single value only when the user explicitly reveals or copies it in the UI.

### OIDC keyring
Refresh-token save failures are logged (`warn!`) instead of silently ignored — a silent failure meant re-authenticating every session with no trace why.

## Tests
- ide_config: JSONC refusal (VS Code/Cursor), invalid-TOML refusal, Windows-path TOML round-trip, comment preservation (new)
- resources: `get_plural` irregular kinds (StorageClass/IngressClass/Ingress/NetworkPolicy/Endpoints), secret env vars stay unresolved (regression, new)
- Full suite: 258 Rust, 639 Jest, typecheck, ESLint, clippy `-D warnings` all green

## Manual smoke checklist
- [ ] Pod-Detail → Env-Vars: Secret-Wert erscheint erst nach Klick auf Auge (fetch on reveal), Copy holt Wert
- [ ] Pod-Detail → Env-Vars: ConfigMap-/Field-Refs wie bisher aufgelöst
- [ ] Helm-Release → Kontextmenü "Forget release": Dialog-Warnung, Release verschwindet, Pods laufen weiter
- [ ] Settings → MCP: Install/Uninstall für Cursor/VS Code/Codex funktioniert weiter
- [ ] YAML-Editor: Apply auf Ingress/StorageClass funktioniert