### PR TITLE
fix: frontend races and leaks, structural error handling, MCP/shell hardening

### DIFF
--- a/src-tauri/src/ai/session_store.rs
+++ b/src-tauri/src/ai/session_store.rs
@@ -42,6 +42,27 @@ pub struct SessionStore {
     conn: Arc<Mutex<Connection>>,
 }
 
+/// Parse a timestamp stored as TEXT. Rows are written with `to_rfc3339`, but
+/// tolerate other common formats for rows written by hand or older builds.
+///
+/// Ordering of query results is done in SQL on the raw TEXT column, so the
+/// fallback value here only affects the displayed timestamp — it never changes
+/// the order in which sessions or messages are returned.
+fn parse_timestamp(raw: &str) -> DateTime<Utc> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
+        return dt.with_timezone(&Utc);
+    }
+    // SQLite's datetime() default format (no timezone, assume UTC)
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f") {
+        return naive.and_utc();
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc2822(raw) {
+        return dt.with_timezone(&Utc);
+    }
+    tracing::warn!("Unparseable timestamp in session store: {raw:?}; falling back to Unix epoch");
+    DateTime::<Utc>::UNIX_EPOCH
+}
+
 impl SessionStore {
     /// Create a new session store with database at the given path
     pub fn new(db_path: PathBuf) -> SqliteResult<Self> {
@@ -193,12 +214,8 @@ impl SessionStore {
                 Ok(SessionRecord {
                     session_id: row.get(0)?,
                     cluster_context: row.get(1)?,
-                    created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?)
-                        .unwrap_or_default()
-                        .with_timezone(&Utc),
-                    last_active_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?)
-                        .unwrap_or_default()
-                        .with_timezone(&Utc),
+                    created_at: parse_timestamp(&row.get::<_, String>(2)?),
+                    last_active_at: parse_timestamp(&row.get::<_, String>(3)?),
                     permission_mode: row.get(4)?,
                     title: row.get(5)?,
                 })
@@ -234,12 +251,8 @@ impl SessionStore {
                 Ok(SessionSummary {
                     session_id: row.get(0)?,
                     cluster_context: row.get(1)?,
-                    created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(2)?)
-                        .unwrap_or_default()
-                        .with_timezone(&Utc),
-                    last_active_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(3)?)
-                        .unwrap_or_default()
-                        .with_timezone(&Utc),
+                    created_at: parse_timestamp(&row.get::<_, String>(2)?),
+                    last_active_at: parse_timestamp(&row.get::<_, String>(3)?),
                     title: row.get(4)?,
                     message_count: row.get(5)?,
                 })
@@ -349,9 +362,7 @@ impl SessionStore {
                     role: row.get(2)?,
                     content: row.get(3)?,
                     tool_calls: row.get(4)?,
-                    timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(5)?)
-                        .unwrap_or_default()
-                        .with_timezone(&Utc),
+                    timestamp: parse_timestamp(&row.get::<_, String>(5)?),
                 })
             })?;
 
@@ -387,9 +398,7 @@ impl SessionStore {
                     role: row.get(2)?,
                     content: row.get(3)?,
                     tool_calls: row.get(4)?,
-                    timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(5)?)
-                        .unwrap_or_default()
-                        .with_timezone(&Utc),
+                    timestamp: parse_timestamp(&row.get::<_, String>(5)?),
                 })
             })?;
 
@@ -460,4 +469,34 @@ pub fn create_session_store(db_path: PathBuf) -> Result<SharedSessionStore, Stri
     SessionStore::new(db_path)
         .map(Arc::new)
         .map_err(|e| format!("Failed to create session store: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_rfc3339_timestamps() {
+        let parsed = parse_timestamp("2026-01-02T03:04:05.678+02:00");
+        assert_eq!(parsed.to_rfc3339(), "2026-01-02T01:04:05.678+00:00");
+    }
+
+    #[test]
+    fn parses_sqlite_datetime_format() {
+        let parsed = parse_timestamp("2026-01-02 03:04:05");
+        assert_eq!(
+            parsed,
+            DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z").unwrap()
+        );
+    }
+
+    #[test]
+    fn unparseable_timestamp_falls_back_to_epoch_without_panicking() {
+        // Regression: unparseable timestamps used to silently become epoch via
+        // unwrap_or_default(). The fallback value is still epoch (there is no
+        // correct value to invent), but it is now logged, and result ordering
+        // is unaffected because queries sort on the raw TEXT column in SQL.
+        let parsed = parse_timestamp("not a timestamp");
+        assert_eq!(parsed, DateTime::<Utc>::UNIX_EPOCH);
+    }
 }

--- a/src-tauri/src/app/state.rs
+++ b/src-tauri/src/app/state.rs
@@ -26,11 +26,32 @@ pub fn register(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::Wr
 }
 
 pub fn initialize_ai_session_store(app: &mut tauri::App) {
-    let app_data_dir = app
-        .path()
-        .app_data_dir()
-        .expect("Failed to get app data directory");
-    let db_path = app_data_dir.join("ai_sessions.db");
-    let session_store = create_session_store(db_path).expect("Failed to create session store");
+    // Never crash the app over the AI session store: fall back to an
+    // in-memory database (sessions just won't persist across restarts).
+    let db_path = match app.path().app_data_dir() {
+        Ok(dir) => dir.join("ai_sessions.db"),
+        Err(e) => {
+            tracing::error!(
+                "Failed to get app data directory: {e}; using in-memory AI session store"
+            );
+            std::path::PathBuf::from(":memory:")
+        }
+    };
+    let session_store = match create_session_store(db_path.clone()) {
+        Ok(store) => store,
+        Err(e) => {
+            tracing::error!(
+                "Failed to create AI session store at {:?}: {e}; using in-memory store",
+                db_path
+            );
+            match create_session_store(std::path::PathBuf::from(":memory:")) {
+                Ok(store) => store,
+                Err(e) => {
+                    tracing::error!("Failed to create in-memory AI session store: {e}");
+                    return;
+                }
+            }
+        }
+    };
     app.manage(session_store);
 }

--- a/src-tauri/src/app/tray/mod.rs
+++ b/src-tauri/src/app/tray/mod.rs
@@ -119,7 +119,12 @@ pub fn handle_menu_event(_app: &tauri::AppHandle, event: tauri::menu::MenuEvent)
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn handle_menu_event(_app: &tauri::AppHandle, _event: tauri::menu::MenuEvent) {}
+pub fn handle_menu_event(app: &tauri::AppHandle, event: tauri::menu::MenuEvent) {
+    // Quit must actually exit here; hiding instead of closing is macOS-only.
+    if event.id() == "quit" {
+        app.exit(0);
+    }
+}
 
 #[cfg(target_os = "macos")]
 pub fn handle_window_event<R: tauri::Runtime>(

--- a/src-tauri/src/commands/argocd.rs
+++ b/src-tauri/src/commands/argocd.rs
@@ -100,7 +100,13 @@ pub async fn list_argocd_applications(
         api.list(&lp).await.map(|list| list.items)
     };
 
-    let items = result.unwrap_or_default();
+    let items = match result {
+        Ok(items) => items,
+        // 404 means the ArgoCD Application CRD is not installed - show an
+        // empty list. Everything else (401/403/network) is a real error.
+        Err(kube::Error::Api(resp)) if resp.code == 404 => return Ok(Vec::new()),
+        Err(e) => return Err(format!("Failed to list ArgoCD applications: {}", e)),
+    };
 
     Ok(items
         .into_iter()

--- a/src-tauri/src/commands/clusters/commands.rs
+++ b/src-tauri/src/commands/clusters/commands.rs
@@ -327,6 +327,10 @@ pub async fn connect_cluster(
                             context,
                             latency
                         );
+                        // Remove debug pods orphaned by a previous run/crash
+                        if let Ok(client) = state.k8s.get_client().await {
+                            crate::commands::shell::sweep_orphaned_debug_pods(client);
+                        }
                         // Keep the OIDC token fresh for the lifetime of the connection
                         if let (Some(oidc_config), Some(ref user)) = (active_oidc, &user_name) {
                             let oidc_state: State<'_, Arc<OidcState>> = app.state();
@@ -453,9 +457,15 @@ pub async fn get_namespaces(
             source: "auto".to_string(),
         }),
         Err(e) => {
-            let err_str = format!("{}", e);
-            // Check if this is a 403 Forbidden (RBAC restriction)
-            if err_str.contains("403") || err_str.to_lowercase().contains("forbidden") {
+            // Structural check for 403 Forbidden (RBAC restriction) instead of
+            // message sniffing: walk the anyhow chain for the kube API error.
+            let forbidden = e.chain().any(|cause| {
+                matches!(
+                    cause.downcast_ref::<kube::Error>(),
+                    Some(kube::Error::Api(resp)) if resp.code == 403
+                )
+            });
+            if forbidden {
                 tracing::info!(
                     "Namespace listing forbidden for context '{}', RBAC restricted",
                     context

--- a/src-tauri/src/commands/debug.rs
+++ b/src-tauri/src/commands/debug.rs
@@ -40,6 +40,18 @@ pub struct EnvironmentInfo {
     pub path_contains_aws: bool,
 }
 
+/// Mask the middle of a server URL for privacy. Operates on chars, not
+/// bytes: byte slicing panicked on multi-byte UTF-8 boundaries.
+fn mask_server_url(server: &str) -> String {
+    let chars: Vec<char> = server.chars().collect();
+    if chars.len() <= 30 {
+        return server.to_string();
+    }
+    let head: String = chars[..20].iter().collect();
+    let tail: String = chars[chars.len() - 10..].iter().collect();
+    format!("{}...{}", head, tail)
+}
+
 /// Resolve the effective kubeconfig paths from configured sources
 fn resolve_kubeconfig_paths(app: &AppHandle) -> Vec<String> {
     let sources_config = super::kubeconfig::load_sources_config(app);
@@ -157,11 +169,7 @@ pub async fn export_debug_info(
                 .unwrap_or_else(|| "Unknown".to_string());
 
             // Mask sensitive parts of the server URL for privacy
-            let server_masked = if server.len() > 30 {
-                format!("{}...{}", &server[..20], &server[server.len() - 10..])
-            } else {
-                server.clone()
-            };
+            let server_masked = mask_server_url(&server);
 
             contexts.push(ContextDebugInfo {
                 name: ctx.name.clone(),
@@ -301,4 +309,36 @@ pub async fn generate_debug_log(
     log.push_str("\n=== End of Debug Log ===\n");
 
     Ok(log)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mask_server_url;
+
+    #[test]
+    fn masks_long_ascii_server_urls() {
+        let server = "https://my-cluster.example.com:6443/api/v1";
+        let masked = mask_server_url(server);
+        assert_eq!(masked, "https://my-cluster.e...443/api/v1");
+    }
+
+    #[test]
+    fn keeps_short_urls_unmasked() {
+        assert_eq!(mask_server_url("https://short:6443"), "https://short:6443");
+    }
+
+    #[test]
+    fn does_not_panic_on_multibyte_utf8() {
+        // 40 multi-byte chars: the old byte-offset slicing panicked here
+        let server = "ü".repeat(40);
+        let masked = mask_server_url(&server);
+        assert!(masked.contains("..."));
+        assert_eq!(masked.chars().count(), 20 + 3 + 10);
+    }
+
+    #[test]
+    fn does_not_panic_on_short_strings() {
+        assert_eq!(mask_server_url(""), "");
+        assert_eq!(mask_server_url("abc"), "abc");
+    }
 }

--- a/src-tauri/src/commands/flux.rs
+++ b/src-tauri/src/commands/flux.rs
@@ -64,7 +64,13 @@ pub async fn list_flux_kustomizations(
         api.list(&lp).await.map(|list| list.items)
     };
 
-    let items = result.unwrap_or_default();
+    let items = match result {
+        Ok(items) => items,
+        // 404 means the Flux Kustomization CRD is not installed - show an
+        // empty list. Everything else (401/403/network) is a real error.
+        Err(kube::Error::Api(resp)) if resp.code == 404 => return Ok(Vec::new()),
+        Err(e) => return Err(format!("Failed to list Flux Kustomizations: {}", e)),
+    };
 
     Ok(items
         .into_iter()

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -517,7 +517,7 @@ pub async fn node_shell_start(
     // Create debug pod name
     let debug_pod_name = format!(
         "kubeli-node-shell-{}",
-        &session_id
+        session_id
             .chars()
             .filter(|c| c.is_alphanumeric() || *c == '-')
             .collect::<String>()

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -1,7 +1,9 @@
 use crate::k8s::AppState;
 use futures::SinkExt;
 use k8s_openapi::api::core::v1::Pod;
-use kube::api::{Api, AttachParams, AttachedProcess, DeleteParams, PostParams, TerminalSize};
+use kube::api::{
+    Api, AttachParams, AttachedProcess, DeleteParams, ListParams, PostParams, TerminalSize,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -287,8 +289,14 @@ async fn run_shell_session(
     stop_flag: Arc<AtomicBool>,
     input_rx: &mut mpsc::Receiver<ShellInput>,
 ) {
-    let mut stdin = attached.stdin().expect("stdin available after attach");
-    let mut stdout = attached.stdout().expect("stdout available after attach");
+    let (Some(mut stdin), Some(mut stdout)) = (attached.stdin(), attached.stdout()) else {
+        tracing::error!("Shell attach did not provide stdin/stdout streams");
+        let _ = app.emit(
+            event_name,
+            ShellEvent::Error("Failed to open shell I/O streams".to_string()),
+        );
+        return;
+    };
     // terminal_size() takes the sender out of AttachedProcess (kube 4.0), so it
     // must be called exactly once and reused — calling it per resize returns
     // None after the first call and silently drops every later resize.
@@ -449,6 +457,34 @@ pub struct NodeShellOptions {
 
 const DEFAULT_NODE_SHELL_IMAGE: &str = "docker.io/alpine:3.21";
 const NODE_SHELL_NAMESPACE: &str = "kube-system";
+/// Label selector matching the node-shell debug pods created by Kubeli.
+const DEBUG_POD_SELECTOR: &str = "app.kubernetes.io/managed-by=kubeli,kubeli/purpose=node-shell";
+
+/// Delete leftover node-shell debug pods from earlier runs (e.g. after an
+/// app crash). Best effort, runs in the background. Called after a successful
+/// connect, when no node-shell session can be active yet.
+pub fn sweep_orphaned_debug_pods(client: kube::Client) {
+    tokio::spawn(async move {
+        let pods: Api<Pod> = Api::namespaced(client, NODE_SHELL_NAMESPACE);
+        let lp = ListParams::default().labels(DEBUG_POD_SELECTOR);
+        let list = match pods.list(&lp).await {
+            Ok(list) => list,
+            Err(e) => {
+                tracing::debug!("Debug pod sweep skipped: {}", e);
+                return;
+            }
+        };
+        for pod in list {
+            let Some(name) = pod.metadata.name else {
+                continue;
+            };
+            match pods.delete(&name, &DeleteParams::default()).await {
+                Ok(_) => tracing::info!("Swept orphaned debug pod {}", name),
+                Err(e) => tracing::warn!("Failed to sweep debug pod {}: {}", name, e),
+            }
+        }
+    });
+}
 
 /// Start an interactive shell session on a node via a debug pod
 #[command]
@@ -517,6 +553,8 @@ pub async fn node_shell_start(
             "hostNetwork": true,
             "restartPolicy": "Never",
             "terminationGracePeriodSeconds": 0,
+            // Orphaned debug pods (app crash, lost session) self-terminate
+            "activeDeadlineSeconds": 3600,
             "priorityClassName": "system-node-critical",
             "tolerations": [{
                 "operator": "Exists"

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -171,8 +171,19 @@ impl From<kube::Error> for KubeliError {
                     resource: None,
                 }
             }
+            kube::Error::Auth(_) => {
+                // Structural match: any client auth failure (token refresh,
+                // exec plugin, malformed credentials) is Unauthorized.
+                let mut kubeli = KubeliError::new(
+                    ErrorKind::Unauthorized,
+                    "Authentication failed — your credentials may have expired",
+                );
+                kubeli.detail = Some(format!("{}", err));
+                kubeli
+            }
             _ => {
-                // Network, timeout, and other errors
+                // Last-resort fallback for non-structured errors (transport,
+                // TLS, protocol): classify by message sniffing.
                 let err_str = format!("{}", err);
                 let lower = err_str.to_lowercase();
 
@@ -218,10 +229,15 @@ impl From<kube::Error> for KubeliError {
 impl From<anyhow::Error> for KubeliError {
     fn from(err: anyhow::Error) -> Self {
         // Try to downcast to kube::Error first
-        // Try to downcast to kube::Error first
         match err.downcast::<kube::Error>() {
             Ok(kube_err) => kube_err.into(),
-            Err(err) => KubeliError::unknown(format!("{}", err)),
+            Err(err) => {
+                // `{:#}` renders the whole context chain ("top: mid: root");
+                // plain `{}` would drop everything below the outermost context.
+                let mut kubeli = KubeliError::unknown(format!("{:#}", err));
+                kubeli.detail = Some(err.root_cause().to_string());
+                kubeli
+            }
         }
     }
 }
@@ -353,5 +369,60 @@ mod tests {
 
         assert!(matches!(kubeli.kind, ErrorKind::Unknown));
         assert_eq!(kubeli.message, "something failed");
+    }
+
+    #[test]
+    fn anyhow_errors_keep_context_chain_and_root_cause() {
+        let err = anyhow::anyhow!("root cause")
+            .context("middle layer")
+            .context("top layer");
+        let kubeli: KubeliError = err.into();
+
+        // Regression: `{}` only rendered the outermost context, losing the
+        // cause chain. `{:#}` keeps it, and detail carries the root cause.
+        assert_eq!(kubeli.message, "top layer: middle layer: root cause");
+        assert_eq!(kubeli.detail.as_deref(), Some("root cause"));
+    }
+
+    fn api_error(code: u16) -> kube::Error {
+        // kube::core::ErrorResponse is a deprecated alias for Status
+        kube::Error::Api(Box::new(
+            kube::core::Status::failure("boom", "TestReason").with_code(code),
+        ))
+    }
+
+    #[test]
+    fn kube_api_errors_classify_by_status_code() {
+        let unauthorized: KubeliError = api_error(401).into();
+        assert!(matches!(unauthorized.kind, ErrorKind::Unauthorized));
+        assert_eq!(unauthorized.code, Some(401));
+
+        let forbidden: KubeliError = api_error(403).into();
+        assert!(matches!(forbidden.kind, ErrorKind::Forbidden));
+
+        let not_found: KubeliError = api_error(404).into();
+        assert!(matches!(not_found.kind, ErrorKind::NotFound));
+
+        let conflict: KubeliError = api_error(409).into();
+        assert!(matches!(conflict.kind, ErrorKind::Conflict));
+
+        let rate_limited: KubeliError = api_error(429).into();
+        assert!(matches!(rate_limited.kind, ErrorKind::RateLimited));
+
+        let server_error: KubeliError = api_error(503).into();
+        assert!(matches!(server_error.kind, ErrorKind::ServerError));
+        assert!(server_error.retryable);
+    }
+
+    #[test]
+    fn kube_auth_errors_classify_structurally_as_unauthorized() {
+        // No "401"/"unauthorized" in the message — structural match must win,
+        // not string sniffing.
+        let err = kube::Error::Auth(kube::client::AuthError::UnrefreshableTokenResponse);
+        let kubeli: KubeliError = err.into();
+
+        assert!(matches!(kubeli.kind, ErrorKind::Unauthorized));
+        assert!(!kubeli.retryable);
+        assert!(kubeli.detail.is_some());
     }
 }

--- a/src-tauri/src/mcp/ide_config.rs
+++ b/src-tauri/src/mcp/ide_config.rs
@@ -91,25 +91,12 @@ pub struct IdeStatus {
     pub mcp_configured: bool,
 }
 
-/// Check if running in debug/development mode
-fn is_dev_mode() -> bool {
-    // Check if current executable is in a debug/target directory
-    if let Ok(exe_path) = std::env::current_exe() {
-        let path_str = exe_path.to_string_lossy();
-        return path_str.contains("/target/debug/")
-            || path_str.contains("\\target\\debug\\")
-            || path_str.contains("/target/release/")
-            || path_str.contains("\\target\\release\\");
-    }
-    false
-}
-
 /// Get Kubeli executable path
-/// Automatically detects dev vs production mode
+/// Prefers the actual running binary (covers dev mode and non-standard
+/// install locations), falling back to the platform's default install path.
 fn get_kubeli_path() -> String {
-    // First check if we're in dev mode
-    if is_dev_mode() {
-        if let Ok(exe_path) = std::env::current_exe() {
+    if let Ok(exe_path) = std::env::current_exe() {
+        if exe_path.exists() {
             return exe_path.to_string_lossy().to_string();
         }
     }
@@ -120,16 +107,11 @@ fn get_kubeli_path() -> String {
     }
     #[cfg(target_os = "linux")]
     {
-        // Try to find the AppImage or installed binary
-        std::env::current_exe()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "/usr/bin/kubeli".to_string())
+        "/usr/bin/kubeli".to_string()
     }
     #[cfg(target_os = "windows")]
     {
-        std::env::current_exe()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "C:\\Program Files\\Kubeli\\Kubeli.exe".to_string())
+        "C:\\Program Files\\Kubeli\\Kubeli.exe".to_string()
     }
 }
 

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -2,13 +2,16 @@
 //!
 //! Implements a Model Context Protocol server for IDE integration.
 
+use kube::config::{KubeConfigOptions, Kubeconfig};
 use rmcp::transport::stdio;
 use rmcp::ServiceExt;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use super::tools::KubeliMcpServer;
-use crate::k8s::KubeClientManager;
+use crate::k8s::client::apply_shared_client_timeouts;
+use crate::k8s::{KubeClientManager, KubeConfig, KubeconfigSourceType, KubeconfigSourcesConfig};
 
 /// MCP Server state
 pub struct McpServerState {
@@ -23,20 +26,113 @@ impl McpServerState {
     }
 
     pub async fn connect_to_cluster(&self) -> Result<(), String> {
-        let manager = KubeClientManager::new();
-        manager
-            .init()
-            .await
-            .map_err(|e| format!("Failed to initialize kube client: {}", e))?;
+        // Prefer the kubeconfig sources configured in the app so the MCP
+        // server sees the same clusters; fall back to the default kubeconfig.
+        let client = match client_from_configured_sources().await {
+            Some(client) => client,
+            None => {
+                let manager = KubeClientManager::new();
+                manager
+                    .init()
+                    .await
+                    .map_err(|e| format!("Failed to initialize kube client: {}", e))?;
 
-        let client = manager
-            .get_client()
-            .await
-            .map_err(|e| format!("Failed to get kube client: {}", e))?;
+                manager
+                    .get_client()
+                    .await
+                    .map_err(|e| format!("Failed to get kube client: {}", e))?
+            }
+        };
 
         let mut guard = self.kube_client.write().await;
         *guard = Some(client);
         Ok(())
+    }
+}
+
+/// Path of the kubeconfig sources store written by the desktop app.
+/// The MCP server runs as a separate process (`--mcp`) without the Tauri
+/// store plugin, so it reads the store file directly.
+fn sources_store_path() -> Option<PathBuf> {
+    // tauri-plugin-store writes to the app data dir (identifier "com.kubeli",
+    // see tauri.conf.json).
+    Some(
+        dirs::data_dir()?
+            .join("com.kubeli")
+            .join("kubeconfig-sources.json"),
+    )
+}
+
+/// Parse the tauri-plugin-store JSON (`{"sources_config": {...}}`).
+fn parse_sources_store(content: &str) -> Option<KubeconfigSourcesConfig> {
+    let json: serde_json::Value = serde_json::from_str(content).ok()?;
+    serde_json::from_value(json.get("sources_config")?.clone()).ok()
+}
+
+/// Build a client from the app's configured kubeconfig sources, mirroring
+/// the merge logic of `build_kubeconfig_for_connect`. Returns None when no
+/// sources are configured or none of them can be used.
+async fn client_from_configured_sources() -> Option<kube::Client> {
+    let path = sources_store_path()?;
+    let content = tokio::fs::read_to_string(&path).await.ok()?;
+    let config = parse_sources_store(&content)?;
+    if config.sources.is_empty() {
+        return None;
+    }
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    for source in &config.sources {
+        let path = PathBuf::from(&source.path);
+        match source.source_type {
+            KubeconfigSourceType::File => {
+                if path.exists() {
+                    files.push(path);
+                }
+            }
+            KubeconfigSourceType::Folder => {
+                if let Ok(entries) = KubeConfig::scan_folder(&path).await {
+                    files.extend(entries);
+                }
+            }
+        }
+    }
+
+    let mut merged: Option<Kubeconfig> = None;
+    for file in &files {
+        let cfg = match Kubeconfig::read_from(file) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Skipping kubeconfig {:?}: {}", file, e);
+                continue;
+            }
+        };
+        merged = Some(match merged {
+            Some(existing) => match existing.merge(cfg) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!("Failed to merge kubeconfig {:?}: {}", file, e);
+                    return None;
+                }
+            },
+            None => cfg,
+        });
+    }
+
+    let mut config =
+        match kube::Config::from_custom_kubeconfig(merged?, &KubeConfigOptions::default()).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Failed to build config from configured sources: {}", e);
+                return None;
+            }
+        };
+    apply_shared_client_timeouts(&mut config);
+    match kube::Client::try_from(config) {
+        Ok(client) => Some(client),
+        Err(e) => {
+            tracing::warn!("Failed to create client from configured sources: {}", e);
+            None
+        }
     }
 }
 
@@ -68,4 +164,33 @@ pub async fn run_mcp_server() -> Result<(), Box<dyn std::error::Error>> {
     service.waiting().await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_sources_store;
+
+    #[test]
+    fn parses_sources_config_from_store_file() {
+        let content = r#"{
+            "sources_config": {
+                "merge_mode": false,
+                "sources": [
+                    {"path": "/home/user/.kube/config", "source_type": "file"},
+                    {"path": "/home/user/.kube/extra", "source_type": "folder"}
+                ]
+            }
+        }"#;
+        let config = parse_sources_store(content).expect("should parse");
+        assert_eq!(config.sources.len(), 2);
+        assert!(!config.merge_mode);
+        assert_eq!(config.sources[0].path, "/home/user/.kube/config");
+    }
+
+    #[test]
+    fn returns_none_for_missing_key_or_invalid_json() {
+        assert!(parse_sources_store("{}").is_none());
+        assert!(parse_sources_store("not json").is_none());
+        assert!(parse_sources_store(r#"{"sources_config": 42}"#).is_none());
+    }
 }

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -19,6 +19,9 @@ use std::sync::Arc;
 
 use super::server::McpServerState;
 
+/// Cap on how many events are fetched from the API server per request.
+const EVENT_FETCH_LIMIT: usize = 500;
+
 /// Response types
 #[derive(Debug, Serialize)]
 struct PodSummary {
@@ -112,6 +115,8 @@ struct EventListSummary {
     showing: usize,
     event_type_filter: String,
     time_window: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncated: Option<String>,
 }
 
 /// Kubeli MCP Server with Kubernetes tools
@@ -209,6 +214,40 @@ impl KubeliMcpServer {
                 }
             }
         }
+    }
+
+    /// Explicit marker when a list hit its server-side fetch limit, so the
+    /// model knows the response is incomplete instead of silently truncated.
+    fn fetch_limit_note(fetched: usize, limit: usize) -> Option<String> {
+        (fetched >= limit).then(|| {
+            format!(
+                "[truncated: showing first {} results; more may exist]",
+                limit
+            )
+        })
+    }
+
+    /// Truncation note for the events response: covers both the client-side
+    /// cap (50 shown) and the server-side fetch limit.
+    fn event_truncation_note(
+        showing: usize,
+        total_matched: usize,
+        fetched: usize,
+    ) -> Option<String> {
+        let mut notes = Vec::new();
+        if showing < total_matched {
+            notes.push(format!(
+                "[truncated: showing {} of {} matched events]",
+                showing, total_matched
+            ));
+        }
+        if fetched >= EVENT_FETCH_LIMIT {
+            notes.push(format!(
+                "[fetch capped at {} events; more may exist on the server]",
+                EVENT_FETCH_LIMIT
+            ));
+        }
+        (!notes.is_empty()).then(|| notes.join(" "))
     }
 
     /// Check if a pod is healthy (Running/Succeeded, all containers ready, restarts < 10)
@@ -461,11 +500,21 @@ impl KubeliMcpServer {
 
         let total = pods.len();
         let problem_count = problem_pods.len();
-        let showing = if problem_count > 0 {
+        let mut showing = if problem_count > 0 {
             format!("{} problem pods in detail", problem_count)
         } else {
             "all pods healthy".to_string()
         };
+        if let Some(note) = Self::fetch_limit_note(total, 500) {
+            showing.push(' ');
+            showing.push_str(&note);
+        }
+        if healthy_names.len() > 50 {
+            showing.push_str(&format!(
+                " [truncated: {} healthy pods, names omitted]",
+                healthy_names.len()
+            ));
+        }
 
         let response = PodListResponse {
             summary: PodListSummary {
@@ -538,11 +587,21 @@ impl KubeliMcpServer {
         let total = deployments.len();
         let degraded_count = degraded_list.len();
         let healthy_count = healthy_names.len();
-        let showing = if degraded_count > 0 {
+        let mut showing = if degraded_count > 0 {
             format!("{} degraded deployments in detail", degraded_count)
         } else {
             "all deployments healthy".to_string()
         };
+        if let Some(note) = Self::fetch_limit_note(total, 200) {
+            showing.push(' ');
+            showing.push_str(&note);
+        }
+        if healthy_names.len() > 50 {
+            showing.push_str(&format!(
+                " [truncated: {} healthy deployments, names omitted]",
+                healthy_names.len()
+            ));
+        }
 
         let response = DeploymentListResponse {
             summary: DeploymentListSummary {
@@ -622,7 +681,12 @@ impl KubeliMcpServer {
             })
             .collect();
 
-        serde_json::to_string_pretty(&summaries).map_err(|e| format!("Serialization error: {}", e))
+        let json = serde_json::to_string_pretty(&summaries)
+            .map_err(|e| format!("Serialization error: {}", e))?;
+        Ok(match Self::fetch_limit_note(summaries.len(), 200) {
+            Some(note) => format!("{}\n{}", note, json),
+            None => json,
+        })
     }
 
     async fn get_logs(
@@ -738,10 +802,13 @@ impl KubeliMcpServer {
         let cutoff = k8s_openapi::jiff::Timestamp::now().as_second() - (minutes * 60);
 
         // Use field selector for type filtering at API level (efficient server-side)
+        // and cap the fetch so huge clusters cannot return unbounded event lists.
         let lp = if type_filter.eq_ignore_ascii_case("all") {
-            ListParams::default()
+            ListParams::default().limit(EVENT_FETCH_LIMIT as u32)
         } else {
-            ListParams::default().fields(&format!("type={}", type_filter))
+            ListParams::default()
+                .limit(EVENT_FETCH_LIMIT as u32)
+                .fields(&format!("type={}", type_filter))
         };
 
         let events: Vec<Event> = if let Some(ns) = &namespace {
@@ -799,6 +866,7 @@ impl KubeliMcpServer {
         // Sort by last_seen descending (most recent first)
         summaries.sort_by(|a, b| b.last_seen.cmp(&a.last_seen));
 
+        let fetched = events.len();
         let total_matched = summaries.len();
         summaries.truncate(50);
         let showing = summaries.len();
@@ -815,6 +883,7 @@ impl KubeliMcpServer {
                 showing,
                 event_type_filter: type_label,
                 time_window: format!("last {} minutes", minutes),
+                truncated: Self::event_truncation_note(showing, total_matched, fetched),
             },
             events: summaries,
         };
@@ -1257,6 +1326,7 @@ mod tests {
                 showing: 25,
                 event_type_filter: "Warning".to_string(),
                 time_window: "last 60 minutes".to_string(),
+                truncated: None,
             },
             events: vec![EventSummary {
                 namespace: "default".to_string(),
@@ -1403,6 +1473,53 @@ mod tests {
 
         let metadata = value.get("metadata").unwrap().as_object().unwrap();
         assert!(!metadata.contains_key("managedFields"));
+    }
+
+    #[test]
+    fn test_fetch_limit_note() {
+        // Below the limit: no note
+        assert_eq!(KubeliMcpServer::fetch_limit_note(42, 500), None);
+        assert_eq!(KubeliMcpServer::fetch_limit_note(0, 200), None);
+        // At the limit: explicit truncation marker
+        let note = KubeliMcpServer::fetch_limit_note(500, 500).unwrap();
+        assert!(note.contains("[truncated"));
+        assert!(note.contains("500"));
+    }
+
+    #[test]
+    fn test_event_truncation_note() {
+        // Nothing truncated
+        assert_eq!(KubeliMcpServer::event_truncation_note(10, 10, 10), None);
+
+        // Client-side cap only
+        let note = KubeliMcpServer::event_truncation_note(50, 120, 120).unwrap();
+        assert!(note.contains("showing 50 of 120 matched events"));
+        assert!(!note.contains("fetch capped"));
+
+        // Fetch limit hit as well
+        let note = KubeliMcpServer::event_truncation_note(50, 480, 500).unwrap();
+        assert!(note.contains("showing 50 of 480"));
+        assert!(note.contains("fetch capped at 500"));
+    }
+
+    #[test]
+    fn test_event_list_summary_omits_truncated_when_none() {
+        let summary = EventListSummary {
+            total_matched: 5,
+            showing: 5,
+            event_type_filter: "Warning".to_string(),
+            time_window: "last 60 minutes".to_string(),
+            truncated: None,
+        };
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(!json.contains("truncated"));
+
+        let summary = EventListSummary {
+            truncated: Some("[truncated: showing 50 of 80 matched events]".to_string()),
+            ..summary
+        };
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(json.contains("\"truncated\":\"[truncated: showing 50 of 80 matched events]\""));
     }
 
     #[test]

--- a/src-tauri/src/oidc/commands.rs
+++ b/src-tauri/src/oidc/commands.rs
@@ -41,10 +41,12 @@ impl OidcState {
 
     /// Signal any running refresh task to stop (used on disconnect).
     pub fn cancel_refresh(&self) {
-        if let Ok(mut guard) = self.refresh_stop.lock() {
-            guard.store(true, Ordering::Relaxed);
-            *guard = Arc::new(AtomicBool::new(false));
-        }
+        let mut guard = self
+            .refresh_stop
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.store(true, Ordering::Relaxed);
+        *guard = Arc::new(AtomicBool::new(false));
     }
 
     /// Remember the full exec config (TLS/CA settings included) detected from the
@@ -100,9 +102,18 @@ impl OidcState {
             return Ok(token);
         }
 
-        let refresh_token =
-            OidcTokenStore::load_refresh_token(&config.issuer_url, &config.client_id)
-                .ok_or_else(|| RefreshError::Terminal("No stored refresh token".to_string()))?;
+        // Keyring access is blocking OS IPC; keep it off the async runtime
+        // (same pattern as SessionStore::with_conn).
+        let refresh_token = {
+            let issuer = config.issuer_url.clone();
+            let client_id = config.client_id.clone();
+            tauri::async_runtime::spawn_blocking(move || {
+                OidcTokenStore::load_refresh_token(&issuer, &client_id)
+            })
+            .await
+            .map_err(|e| RefreshError::Transient(format!("Keyring task failed: {e}")))?
+            .ok_or_else(|| RefreshError::Terminal("No stored refresh token".to_string()))?
+        };
 
         match self
             .flow_manager
@@ -111,11 +122,13 @@ impl OidcState {
         {
             Ok(tokens) => {
                 if let Some(ref new_rt) = tokens.refresh_token {
-                    OidcTokenStore::save_refresh_token(
-                        &config.issuer_url,
-                        &config.client_id,
-                        new_rt,
-                    );
+                    let issuer = config.issuer_url.clone();
+                    let client_id = config.client_id.clone();
+                    let new_rt = new_rt.clone();
+                    let _ = tauri::async_runtime::spawn_blocking(move || {
+                        OidcTokenStore::save_refresh_token(&issuer, &client_id, &new_rt);
+                    })
+                    .await;
                 }
                 let id_token = tokens.id_token.clone();
                 self.token_store
@@ -125,11 +138,16 @@ impl OidcState {
             Err(RefreshError::Terminal(message)) => {
                 self.token_store
                     .clear(&config.issuer_url, &config.client_id);
-                OidcTokenStore::delete_refresh_token_if_matches(
-                    &config.issuer_url,
-                    &config.client_id,
-                    &refresh_token,
-                );
+                let issuer = config.issuer_url.clone();
+                let client_id = config.client_id.clone();
+                let _ = tauri::async_runtime::spawn_blocking(move || {
+                    OidcTokenStore::delete_refresh_token_if_matches(
+                        &issuer,
+                        &client_id,
+                        &refresh_token,
+                    );
+                })
+                .await;
                 Err(RefreshError::Terminal(message))
             }
             Err(transient) => Err(transient),
@@ -215,23 +233,17 @@ pub async fn oidc_handle_callback(
     code: String,
     state: String,
 ) -> Result<OidcAuthResult, String> {
-    let (issuer_url, client_id) = {
-        let guard = oidc_state
-            .flow_manager
-            .pending
-            .lock()
-            .map_err(|_| "Failed to lock pending auth state".to_string())?;
-        let pending = guard
-            .as_ref()
-            .ok_or_else(|| "No pending OIDC authentication flow".to_string())?;
-        (
-            pending.config.issuer_url.clone(),
-            pending.config.client_id.clone(),
-        )
-    };
-
-    let tokens = oidc_state.flow_manager.exchange_code(&code, &state).await?;
-    persist_tokens(&app, &oidc_state, &issuer_url, &client_id, &tokens);
+    // exchange_code consumes the pending flow and hands back the config it was
+    // started with, so we don't have to read it out of the pending state first.
+    let (tokens, config) = oidc_state.flow_manager.exchange_code(&code, &state).await?;
+    persist_tokens(
+        &app,
+        &oidc_state,
+        &config.issuer_url,
+        &config.client_id,
+        &tokens,
+    )
+    .await;
 
     Ok(OidcAuthResult {
         status: "authenticated".to_string(),
@@ -263,7 +275,7 @@ pub fn oidc_get_token_status(
     }
 }
 
-fn persist_tokens(
+async fn persist_tokens(
     _app: &tauri::AppHandle,
     oidc_state: &OidcState,
     issuer: &str,
@@ -275,6 +287,39 @@ fn persist_tokens(
         .store_tokens(issuer, client_id, tokens.clone());
 
     if let Some(ref refresh_token) = tokens.refresh_token {
-        OidcTokenStore::save_refresh_token(issuer, client_id, refresh_token);
+        // Keyring access is blocking OS IPC; keep it off the async runtime.
+        let issuer = issuer.to_string();
+        let client_id = client_id.to_string();
+        let refresh_token = refresh_token.clone();
+        let _ = tauri::async_runtime::spawn_blocking(move || {
+            OidcTokenStore::save_refresh_token(&issuer, &client_id, &refresh_token);
+        })
+        .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_refresh_recovers_from_poisoned_mutex() {
+        let state = OidcState::default();
+        let flag = state.arm_refresh();
+
+        // Poison refresh_stop by panicking while holding the lock.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = state.refresh_stop.lock().unwrap();
+            panic!("poison the refresh_stop mutex");
+        }));
+        assert!(
+            state.refresh_stop.lock().is_err(),
+            "mutex should be poisoned"
+        );
+
+        // Regression: cancel_refresh used `if let Ok(...)`, silently doing
+        // nothing on poison — the running refresh task was never signalled.
+        state.cancel_refresh();
+        assert!(flag.load(Ordering::Relaxed), "stop flag must be signalled");
     }
 }

--- a/src-tauri/src/oidc/flow.rs
+++ b/src-tauri/src/oidc/flow.rs
@@ -4,12 +4,14 @@ use base64::engine::general_purpose::{STANDARD, URL_SAFE, URL_SAFE_NO_PAD};
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use openidconnect::core::{
-    CoreAuthenticationFlow, CoreClient, CoreIdToken, CoreProviderMetadata, CoreTokenResponse,
+    CoreAuthenticationFlow, CoreClient, CoreErrorResponseType, CoreIdToken, CoreProviderMetadata,
+    CoreTokenResponse,
 };
 use openidconnect::reqwest;
 use openidconnect::{
     AuthorizationCode, ClientId, CsrfToken, IssuerUrl, Nonce, OAuth2TokenResponse,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope,
+    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, RequestTokenError, Scope,
+    StandardErrorResponse,
 };
 
 use super::config::OidcExecConfig;
@@ -90,7 +92,14 @@ impl OidcFlowManager {
         Ok(auth_url.to_string())
     }
 
-    pub async fn exchange_code(&self, code: &str, state: &str) -> Result<OidcTokens, String> {
+    /// Exchange the authorization code for tokens. Returns the tokens together
+    /// with the config the flow was started with (consumed from the pending
+    /// state), so callers don't have to re-derive it.
+    pub async fn exchange_code(
+        &self,
+        code: &str,
+        state: &str,
+    ) -> Result<(OidcTokens, OidcExecConfig), String> {
         let pending_auth = {
             let mut pending_guard = self
                 .pending
@@ -148,11 +157,14 @@ impl OidcFlowManager {
             .refresh_token()
             .map(|token: &RefreshToken| token.secret().to_string());
 
-        Ok(OidcTokens {
-            id_token,
-            refresh_token,
-            expires_at,
-        })
+        Ok((
+            OidcTokens {
+                id_token,
+                refresh_token,
+                expires_at,
+            },
+            pending_auth.config,
+        ))
     }
 
     pub async fn refresh_token(
@@ -275,20 +287,26 @@ async fn discover_provider(config: &OidcExecConfig) -> Result<CoreProviderMetada
 /// `invalid_grant` OAuth2 error code means the refresh token is dead and must be
 /// discarded; transport errors, parse errors, and other server error codes are
 /// transient and must NOT cause us to drop a still-valid refresh token. We match
-/// the structured `ServerResponse` variant and inspect only the error response
-/// (which carries the code) rather than substring-matching the whole formatted
-/// error chain.
-fn classify_refresh_error<RE, T>(error: openidconnect::RequestTokenError<RE, T>) -> RefreshError
+/// the parsed `error` field of the structured `ServerResponse` variant; a
+/// substring check on the raw body remains only as a fallback for IdPs whose
+/// error response did not deserialize as a conforming OAuth2 error.
+fn classify_refresh_error<RE>(
+    error: RequestTokenError<RE, StandardErrorResponse<CoreErrorResponseType>>,
+) -> RefreshError
 where
     RE: std::error::Error + 'static,
-    T: openidconnect::ErrorResponse + std::fmt::Display,
 {
+    let is_invalid_grant = match &error {
+        RequestTokenError::ServerResponse(resp) => {
+            *resp.error() == CoreErrorResponseType::InvalidGrant
+        }
+        // Fallback: the body was not a parseable OAuth2 error response.
+        RequestTokenError::Parse(_, body) => {
+            String::from_utf8_lossy(body).contains("invalid_grant")
+        }
+        _ => false,
+    };
     let message = format!("Failed to refresh OIDC token: {}", error);
-    let is_invalid_grant = matches!(
-        &error,
-        openidconnect::RequestTokenError::ServerResponse(resp)
-            if resp.to_string().contains("invalid_grant")
-    );
     if is_invalid_grant {
         RefreshError::Terminal(message)
     } else {
@@ -369,5 +387,47 @@ mod tests {
     fn refresh_error_display_shows_message() {
         assert_eq!(RefreshError::Terminal("boom".into()).to_string(), "boom");
         assert_eq!(RefreshError::Transient("blip".into()).to_string(), "blip");
+    }
+
+    type TestTokenError =
+        RequestTokenError<std::convert::Infallible, StandardErrorResponse<CoreErrorResponseType>>;
+
+    fn server_response(error: CoreErrorResponseType) -> TestTokenError {
+        RequestTokenError::ServerResponse(StandardErrorResponse::new(error, None, None))
+    }
+
+    #[test]
+    fn classifies_invalid_grant_server_response_as_terminal() {
+        let result = classify_refresh_error(server_response(CoreErrorResponseType::InvalidGrant));
+        assert!(matches!(result, RefreshError::Terminal(_)));
+    }
+
+    #[test]
+    fn classifies_other_server_errors_as_transient() {
+        // Regression: classification used to substring-match the formatted
+        // error, so an unrelated error mentioning "invalid_grant" in its
+        // description would kill a still-valid refresh token.
+        let result = classify_refresh_error(server_response(CoreErrorResponseType::InvalidClient));
+        assert!(matches!(result, RefreshError::Transient(_)));
+
+        let misleading: TestTokenError =
+            RequestTokenError::ServerResponse(StandardErrorResponse::new(
+                CoreErrorResponseType::InvalidRequest,
+                Some("this is not an invalid_grant error".to_string()),
+                None,
+            ));
+        assert!(matches!(
+            classify_refresh_error(misleading),
+            RefreshError::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_non_server_errors_as_transient() {
+        let other: TestTokenError = RequestTokenError::Other("invalid_grant mention".to_string());
+        assert!(matches!(
+            classify_refresh_error(other),
+            RefreshError::Transient(_)
+        ));
     }
 }

--- a/src/components/features/ai/hooks/__tests__/usePendingAnalysis.test.ts
+++ b/src/components/features/ai/hooks/__tests__/usePendingAnalysis.test.ts
@@ -198,5 +198,40 @@ describe("usePendingAnalysis", () => {
     await waitFor(() => {
       expect(mockSetError).toHaveBeenCalledWith("Send failed");
     });
+
+    // Regression: the prompt must survive a failed send so it can retry.
+    expect(mockClearPendingAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pending analysis when startSession fails", async () => {
+    mockStartSession.mockRejectedValue(new Error("start failed"));
+
+    setAIStoreState({
+      isSessionActive: false,
+      startSession: mockStartSession,
+      sendMessage: mockSendMessage,
+      setError: mockSetError,
+      pendingAnalysis: {
+        clusterContext: "test-cluster",
+        message: "Analyze this pod",
+        namespace: "default",
+      },
+      clearPendingAnalysis: mockClearPendingAnalysis,
+    });
+
+    setClusterStoreState({
+      currentCluster: { context: "test-cluster" },
+    });
+
+    renderHook(() => usePendingAnalysis());
+
+    jest.advanceTimersByTime(200);
+
+    await waitFor(() => {
+      expect(mockStartSession).toHaveBeenCalled();
+    });
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockClearPendingAnalysis).not.toHaveBeenCalled();
   });
 });

--- a/src/components/features/ai/hooks/usePendingAnalysis.ts
+++ b/src/components/features/ai/hooks/usePendingAnalysis.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAIStore } from "@/lib/stores/ai-store";
 import { useClusterStore } from "@/lib/stores/cluster-store";
 
@@ -18,26 +18,37 @@ export function usePendingAnalysis() {
 
   const currentCluster = useClusterStore((s) => s.currentCluster);
 
+  // Guards against a second send when the effect re-runs mid-flight
+  // (e.g. isSessionActive flips after startSession).
+  const sendingRef = useRef(false);
+
   useEffect(() => {
     if (!pendingAnalysis || !currentCluster) return;
     if (pendingAnalysis.clusterContext !== currentCluster.context) return;
 
     const sendPendingAnalysis = async () => {
-      const message = pendingAnalysis.message;
-      clearPendingAnalysis();
-
-      if (!isSessionActive) {
-        try {
-          await startSession(currentCluster.context, pendingAnalysis.namespace);
-        } catch {
-          return;
-        }
-      }
+      if (sendingRef.current) return;
+      sendingRef.current = true;
 
       try {
-        await sendMessage(message);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to send message");
+        if (!isSessionActive) {
+          try {
+            await startSession(currentCluster.context, pendingAnalysis.namespace);
+          } catch {
+            return;
+          }
+        }
+
+        try {
+          await sendMessage(pendingAnalysis.message);
+          // Clear only after a successful send - a failure keeps the
+          // prompt in the store so it isn't lost.
+          clearPendingAnalysis();
+        } catch (e) {
+          setError(e instanceof Error ? e.message : "Failed to send message");
+        }
+      } finally {
+        sendingRef.current = false;
       }
     };
 

--- a/src/components/features/dashboard/views/workloads/PodsView.tsx
+++ b/src/components/features/dashboard/views/workloads/PodsView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import {
   FileText,
@@ -73,7 +73,7 @@ export function PodsView() {
   const openOrActivateTab = useTabsStore((s) => s.openOrActivateTab);
   const pendingLogsHandled = useRef<{ namespace: string; podName: string } | null>(null);
 
-  const openLogsTab = (podName: string, namespace: string) => {
+  const openLogsTab = useCallback((podName: string, namespace: string) => {
     const result = openOrActivateTab(
       "pod-logs",
       `Logs: ${podName} (${namespace})`,
@@ -83,7 +83,7 @@ export function PodsView() {
         tab.metadata?.namespace === namespace,
     );
     if (result === null) toast.warning(t("tabs.limitToast"));
-  };
+  }, [openOrActivateTab, t]);
   const [sortKey, setSortKey] = useState<string | null>("created_at");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const currentCluster = useClusterStore((s) => s.currentCluster);
@@ -146,23 +146,35 @@ export function PodsView() {
     },
   ], [refresh, isWatching]);
 
-  const handleOpenShell = (pod: PodInfo) => {
+  const handleOpenShell = useCallback((pod: PodInfo) => {
     addTab(pod.namespace, pod.name);
-  };
+  }, [addTab]);
+
+  // Precompute pod -> service matches once per data change instead of
+  // scanning all services per row on every render
+  const podServiceMap = useMemo(() => {
+    const map = new Map<string, ServiceInfo>();
+    for (const pod of data) {
+      const service = services.find((svc) => {
+        if (svc.namespace !== pod.namespace) return false;
+        if (!svc.selector || Object.keys(svc.selector).length === 0) return false;
+        return Object.entries(svc.selector).every(
+          ([key, value]) => pod.labels[key] === value
+        );
+      });
+      if (service) map.set(pod.uid, service);
+    }
+    return map;
+  }, [data, services]);
 
   // Find matching service for a pod based on label selectors
-  const findServiceForPod = (pod: PodInfo): ServiceInfo | undefined => {
-    return services.find((svc) => {
-      if (svc.namespace !== pod.namespace) return false;
-      if (!svc.selector || Object.keys(svc.selector).length === 0) return false;
-      return Object.entries(svc.selector).every(
-        ([key, value]) => pod.labels[key] === value
-      );
-    });
-  };
+  const findServiceForPod = useCallback(
+    (pod: PodInfo): ServiceInfo | undefined => podServiceMap.get(pod.uid),
+    [podServiceMap]
+  );
 
   // Check if pod's service is being forwarded (any port)
-  const getForwardForPod = (pod: PodInfo) => {
+  const getForwardForPod = useCallback((pod: PodInfo) => {
     const service = findServiceForPod(pod);
     if (!service) return undefined;
     return forwards.find(
@@ -171,10 +183,10 @@ export function PodsView() {
         f.namespace === service.namespace &&
         f.target_type === "service"
     );
-  };
+  }, [findServiceForPod, forwards]);
 
   // Get all forwards for a pod's service (for multi-port popover)
-  const getForwardsForPod = (pod: PodInfo) => {
+  const getForwardsForPod = useCallback((pod: PodInfo) => {
     const service = findServiceForPod(pod);
     if (!service) return [];
     return forwards.filter(
@@ -183,22 +195,22 @@ export function PodsView() {
         f.namespace === service.namespace &&
         f.target_type === "service"
     );
-  };
+  }, [findServiceForPod, forwards]);
 
-  const handlePortForward = (pod: PodInfo, port?: ServicePortInfo) => {
+  const handlePortForward = useCallback((pod: PodInfo, port?: ServicePortInfo) => {
     const service = findServiceForPod(pod);
     if (service && service.ports.length > 0) {
       const p = port ?? service.ports[0];
       requestForward(service.namespace, service.name, "service", p.port, p.name ?? undefined);
     }
-  };
+  }, [findServiceForPod, requestForward]);
 
-  const handleDisconnect = (pod: PodInfo) => {
+  const handleDisconnect = useCallback((pod: PodInfo) => {
     const forward = getForwardForPod(pod);
     if (forward) {
       stopForward(forward.forward_id);
     }
-  };
+  }, [getForwardForPod, stopForward]);
 
   // Get row class for highlighting forwarded pods
   const getRowClassName = (pod: PodInfo): string => {
@@ -212,10 +224,12 @@ export function PodsView() {
     return "";
   };
 
-  // Always show metrics columns — skeleton shimmer while loading, no layout shift
-  const baseColumns = getPodColumnsWithMetrics(metricsMap, metricsLoading && metricsMap.size === 0);
+  // Memoized so table rows keep referential equality between renders
+  const columnsWithActions = useMemo(() => {
+    // Always show metrics columns — skeleton shimmer while loading, no layout shift
+    const baseColumns = getPodColumnsWithMetrics(metricsMap, metricsLoading && metricsMap.size === 0);
 
-  const columnsWithActions = [
+    return [
     ...translateColumns(baseColumns, t),
     {
       key: "actions",
@@ -310,7 +324,21 @@ export function PodsView() {
         );
       },
     },
-  ];
+    ];
+  }, [
+    metricsMap,
+    metricsLoading,
+    t,
+    findServiceForPod,
+    getForwardForPod,
+    getForwardsForPod,
+    handleOpenShell,
+    handlePortForward,
+    handleDisconnect,
+    stopForward,
+    openLogsTab,
+    closeResourceDetail,
+  ]);
 
   const getPodContextMenu = (pod: PodInfo): ContextMenuItemDef[] => {
     const isTerminating = !!pod.deletion_timestamp;

--- a/src/components/features/portforward/PortForwardPanel.tsx
+++ b/src/components/features/portforward/PortForwardPanel.tsx
@@ -250,8 +250,13 @@ function PortForwardItem({ forward, onStop }: PortForwardItemProps) {
 
   const statusLabel = getStatusLabel(forward.status);
 
-  const openInBrowser = () => {
-    window.open(`http://localhost:${forward.local_port}`, "_blank");
+  const openInBrowser = async () => {
+    try {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(`http://localhost:${forward.local_port}`);
+    } catch (err) {
+      console.error("Failed to open browser:", err);
+    }
   };
 
   return (

--- a/src/components/features/resources/ResourceList.tsx
+++ b/src/components/features/resources/ResourceList.tsx
@@ -101,10 +101,15 @@ export function ResourceList<T>({
 
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
-      result = result.filter((item) =>
-        Object.values(item as Record<string, unknown>).some((value) =>
-          String(value).toLowerCase().includes(query)
-        )
+      const searchColumns = columns.filter((col) => col.getSearchText);
+      result = result.filter(
+        (item) =>
+          Object.values(item as Record<string, unknown>).some((value) =>
+            String(value).toLowerCase().includes(query)
+          ) ||
+          searchColumns.some((col) =>
+            col.getSearchText!(item).toLowerCase().includes(query)
+          )
       );
     }
 
@@ -146,7 +151,7 @@ export function ResourceList<T>({
     }
 
     return result;
-  }, [data, searchQuery, sortKey, sortDirection, activeFilter, filterOptions, customSortComparator]);
+  }, [data, columns, searchQuery, sortKey, sortDirection, activeFilter, filterOptions, customSortComparator]);
 
   const handleSort = (key: string) => {
     const newDirection =

--- a/src/components/features/resources/__tests__/ResourceList.test.tsx
+++ b/src/components/features/resources/__tests__/ResourceList.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { ResourceList } from "../ResourceList";
+import type { Column } from "../types";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+let mockSearchQuery = "";
+jest.mock("@/lib/stores/tabs-store", () => ({
+  useTabsStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      activeTabId: "tab-1",
+      searchQueries: { "tab-1": mockSearchQuery },
+      activeFilters: {},
+      setTabSearch: jest.fn(),
+      setTabFilter: jest.fn(),
+    }),
+}));
+
+jest.mock("../components/ResourceListHeader", () => ({
+  ResourceListHeader: () => null,
+}));
+
+jest.mock("../components/ResourceTable", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  return {
+    ResourceTable: ({
+      data,
+      getRowKey,
+    }: {
+      data: unknown[];
+      getRowKey: (item: unknown) => string;
+    }) =>
+      React.createElement(
+        "div",
+        null,
+        data.map((item) =>
+          React.createElement(
+            "div",
+            { key: getRowKey(item), "data-testid": "row" },
+            getRowKey(item)
+          )
+        )
+      ),
+  };
+});
+
+interface TestItem {
+  uid: string;
+  name: string;
+  labels: Record<string, string>;
+}
+
+const items: TestItem[] = [
+  { uid: "uid-a", name: "pod-a", labels: { app: "web" } },
+  { uid: "uid-b", name: "pod-b", labels: { app: "api" } },
+];
+
+const columnsWithAccessor: Column<TestItem>[] = [
+  { key: "name", label: "NAME" },
+  {
+    key: "labels",
+    label: "LABELS",
+    getSearchText: (item) =>
+      Object.entries(item.labels)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", "),
+  },
+];
+
+const columnsWithoutAccessor: Column<TestItem>[] = [
+  { key: "name", label: "NAME" },
+  { key: "labels", label: "LABELS" },
+];
+
+function renderList(columns: Column<TestItem>[]) {
+  return render(
+    <ResourceList
+      title="Pods"
+      data={items}
+      columns={columns}
+      isLoading={false}
+      error={null}
+      onRefresh={jest.fn()}
+      getRowKey={(item) => item.uid}
+    />
+  );
+}
+
+describe("ResourceList search", () => {
+  afterEach(() => {
+    mockSearchQuery = "";
+  });
+
+  it("matches object cell content via getSearchText", () => {
+    // Regression: object values stringify to "[object Object]", so label
+    // content was unsearchable without a column-level accessor.
+    mockSearchQuery = "app=web";
+    renderList(columnsWithAccessor);
+
+    const rows = screen.getAllByTestId("row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent("uid-a");
+  });
+
+  it("falls back to matching primitive item fields", () => {
+    mockSearchQuery = "pod-b";
+    renderList(columnsWithAccessor);
+
+    const rows = screen.getAllByTestId("row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent("uid-b");
+  });
+
+  it("does not match object content without getSearchText", () => {
+    mockSearchQuery = "app=web";
+    renderList(columnsWithoutAccessor);
+
+    expect(screen.queryAllByTestId("row")).toHaveLength(0);
+  });
+
+  it("shows all rows when the query is empty", () => {
+    renderList(columnsWithAccessor);
+
+    expect(screen.getAllByTestId("row")).toHaveLength(2);
+  });
+});

--- a/src/components/features/resources/columns/cluster.tsx
+++ b/src/components/features/resources/columns/cluster.tsx
@@ -219,6 +219,10 @@ export const runtimeClassColumns: Column<RuntimeClassInfo>[] = [
     key: "scheduling_node_selector",
     label: "NODE SELECTOR",
     sortable: false,
+    getSearchText: (rc) =>
+      Object.entries(rc.scheduling_node_selector ?? {})
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", "),
     render: (rc) => {
       if (!rc.scheduling_node_selector) return "-";
       const count = Object.keys(rc.scheduling_node_selector).length;

--- a/src/components/features/resources/columns/config.tsx
+++ b/src/components/features/resources/columns/config.tsx
@@ -175,6 +175,10 @@ export const namespaceColumns: Column<NamespaceInfo>[] = [
     key: "labels",
     label: "LABELS",
     sortable: false,
+    getSearchText: (ns) =>
+      Object.entries(ns.labels)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", "),
     render: (ns) => {
       const labelCount = Object.keys(ns.labels).length;
       return labelCount > 0 ? `${labelCount} labels` : "-";
@@ -211,6 +215,10 @@ export function getNamespaceColumns(t: TranslateFunc): Column<NamespaceInfo>[] {
       key: "labels",
       label: t("columns.labels"),
       sortable: false,
+      getSearchText: (ns) =>
+        Object.entries(ns.labels)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(", "),
       render: (ns) => {
         const labelCount = Object.keys(ns.labels).length;
         return labelCount > 0 ? `${labelCount} labels` : "-";

--- a/src/components/features/resources/columns/networking.tsx
+++ b/src/components/features/resources/columns/networking.tsx
@@ -251,6 +251,10 @@ export const networkPolicyColumns: Column<NetworkPolicyInfo>[] = [
     key: "pod_selector",
     label: "POD SELECTOR",
     sortable: false,
+    getSearchText: (np) =>
+      Object.entries(np.pod_selector)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", "),
     render: (np) => {
       const entries = Object.entries(np.pod_selector);
       if (entries.length === 0) return <span className="text-muted-foreground">(all pods)</span>;

--- a/src/components/features/resources/columns/scaling.tsx
+++ b/src/components/features/resources/columns/scaling.tsx
@@ -118,6 +118,10 @@ export const resourceQuotaColumns: Column<ResourceQuotaInfo>[] = [
     key: "resources",
     label: "RESOURCES",
     sortable: false,
+    getSearchText: (rq) =>
+      Object.entries(rq.hard)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(", "),
     render: (rq) => Object.keys(rq.hard).length,
   },
   {

--- a/src/components/features/resources/types/column-types.ts
+++ b/src/components/features/resources/types/column-types.ts
@@ -4,6 +4,11 @@ export interface Column<T> {
   sortable?: boolean;
   render?: (item: T) => React.ReactNode;
   width?: string;
+  /**
+   * Text used by the search filter for this column. Needed for columns whose
+   * underlying value is an object (which would stringify to "[object Object]").
+   */
+  getSearchText?: (item: T) => string;
 }
 
 export interface FilterOption<T> {

--- a/src/components/features/settings/components/KubeconfigTab.tsx
+++ b/src/components/features/settings/components/KubeconfigTab.tsx
@@ -313,6 +313,12 @@ function MergeModeSection({
   const [popoverOpen, setPopoverOpen] = useState(false);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
 
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    };
+  }, []);
+
   const handleMouseEnter = () => {
     if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
     hoverTimeoutRef.current = setTimeout(() => setPopoverOpen(true), 300);

--- a/src/components/features/settings/components/McpTab.tsx
+++ b/src/components/features/settings/components/McpTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import {
   RefreshCw,
@@ -29,12 +29,20 @@ export function McpTab({ mcp }: McpTabProps) {
   const t = useTranslations("settings");
   const [examplesOpen, setExamplesOpen] = useState(false);
   const [copiedPrompt, setCopiedPrompt] = useState<string | null>(null);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    };
+  }, []);
 
   const handleCopyPrompt = useCallback(async (prompt: string, key: string) => {
     try {
       await navigator.clipboard.writeText(prompt);
       setCopiedPrompt(key);
-      setTimeout(() => setCopiedPrompt(null), 2000);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopiedPrompt(null), 2000);
     } catch (err) {
       console.error("Failed to copy:", err);
     }

--- a/src/components/features/settings/hooks/useAiCli.ts
+++ b/src/components/features/settings/hooks/useAiCli.ts
@@ -46,10 +46,9 @@ export function useAiCli(isOpen: boolean) {
         opencode: opencodeInfo.status === "authenticated",
         droid: droidInfo.status === "authenticated",
       };
-      const currentProvider: AiCliProvider = settings.aiCliProvider || "claude";
-
-      // If the persisted provider is unavailable but another one is, switch to
-      // the first available — preference order: claude, opencode, codex, droid.
+      // Auto-select only when the user has not picked a provider yet —
+      // never override an explicit choice on re-detection.
+      // Preference order: claude, opencode, codex, droid.
       const fallbackOrder: AiCliProvider[] = [
         "claude",
         "opencode",
@@ -58,9 +57,7 @@ export function useAiCli(isOpen: boolean) {
       ];
       const firstAvailable = fallbackOrder.find((p) => availability[p]);
 
-      if (!availability[currentProvider] && firstAvailable) {
-        updateSettings({ aiCliProvider: firstAvailable });
-      } else if (!settings.aiCliProvider && firstAvailable) {
+      if (!settings.aiCliProvider && firstAvailable) {
         updateSettings({ aiCliProvider: firstAvailable });
       }
     } catch (err) {

--- a/src/components/features/terminal/PodTerminal.tsx
+++ b/src/components/features/terminal/PodTerminal.tsx
@@ -68,23 +68,28 @@ export function PodTerminal({
     }
   }, [autoConnect, selectedContainer, isConnected, isConnecting, connect]);
 
-  const handleData = useCallback(
-    (data: string) => {
-      if (isConnected) {
-        sendInput(data);
-      }
-    },
-    [isConnected, sendInput]
-  );
+  // Keep latest connection state/handlers in refs so handleData/handleResize
+  // stay referentially stable and never force the xterm instance to recreate.
+  const isConnectedRef = useRef(isConnected);
+  const sendInputRef = useRef(sendInput);
+  const resizeRef = useRef(resize);
+  useEffect(() => {
+    isConnectedRef.current = isConnected;
+    sendInputRef.current = sendInput;
+    resizeRef.current = resize;
+  });
 
-  const handleResize = useCallback(
-    (cols: number, rows: number) => {
-      if (isConnected) {
-        resize(cols, rows);
-      }
-    },
-    [isConnected, resize]
-  );
+  const handleData = useCallback((data: string) => {
+    if (isConnectedRef.current) {
+      sendInputRef.current(data);
+    }
+  }, []);
+
+  const handleResize = useCallback((cols: number, rows: number) => {
+    if (isConnectedRef.current) {
+      resizeRef.current(cols, rows);
+    }
+  }, []);
 
   const handleTerminalReady = useCallback((terminal: XTermType) => {
     terminalRef.current = terminal;

--- a/src/components/features/terminal/Terminal.tsx
+++ b/src/components/features/terminal/Terminal.tsx
@@ -28,6 +28,17 @@ export function Terminal({
   const fitAddonRef = useRef<FitAddonType | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
 
+  // Keep latest callbacks in refs so a new callback identity does not
+  // tear down and recreate the xterm instance.
+  const onDataRef = useRef(onData);
+  const onResizeRef = useRef(onResize);
+  const onReadyRef = useRef(onReady);
+  useEffect(() => {
+    onDataRef.current = onData;
+    onResizeRef.current = onResize;
+    onReadyRef.current = onReady;
+  });
+
   // Write data to terminal
   const write = useCallback((data: string) => {
     terminalRef.current?.write(data);
@@ -124,16 +135,16 @@ export function Terminal({
 
       // Handle data input
       terminal.onData((data) => {
-        onData?.(data);
+        onDataRef.current?.(data);
       });
 
       // Handle resize
       terminal.onResize(({ cols, rows }) => {
-        onResize?.(cols, rows);
+        onResizeRef.current?.(cols, rows);
       });
 
       // Notify ready
-      onReady?.(terminal);
+      onReadyRef.current?.(terminal);
       setIsLoaded(true);
 
       // Handle container resize with debounce to ensure layout is settled
@@ -160,7 +171,7 @@ export function Terminal({
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [fontSize, fontFamily, onData, onResize, onReady]);
+  }, [fontSize, fontFamily]);
 
   // Expose methods via ref
   useEffect(() => {

--- a/src/components/features/tray/ActiveTab.tsx
+++ b/src/components/features/tray/ActiveTab.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink, Square, Loader2 } from "lucide-react";
 import { usePortForwardStore } from "@/lib/stores/portforward-store";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export function ActiveTab() {
   const forwards = usePortForwardStore((s) => s.forwards);
@@ -9,6 +9,13 @@ export function ActiveTab() {
   const [stoppingId, setStoppingId] = useState<string | null>(null);
   const [stoppingAll, setStoppingAll] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+    };
+  }, []);
 
   const handleStop = async (forwardId: string) => {
     setStoppingId(forwardId);
@@ -41,7 +48,8 @@ export function ActiveTab() {
     try {
       await navigator.clipboard.writeText(`localhost:${localPort}`);
       setCopiedId(forwardId);
-      setTimeout(() => setCopiedId(null), 1500);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopiedId(null), 1500);
     } catch {
       // Clipboard API may not be available
     }

--- a/src/components/features/tray/TrayApp.tsx
+++ b/src/components/features/tray/TrayApp.tsx
@@ -38,13 +38,17 @@ export function TrayApp() {
     if (initialized.current) return;
     initialized.current = true;
 
+    let cancelled = false;
     const init = async () => {
       await fetchClusters();
       await syncConnectionState();
       await initialize();
-      setIsReady(true);
+      if (!cancelled) setIsReady(true);
     };
     init();
+    return () => {
+      cancelled = true;
+    };
   }, [fetchClusters, syncConnectionState, initialize]);
 
   // Sync Zustand store from shared localStorage (DOM classes already
@@ -76,8 +80,10 @@ export function TrayApp() {
 
   // Re-sync every time the tray popup is shown (event from Rust backend)
   useEffect(() => {
+    let cancelled = false;
     let unlisten: (() => void) | null = null;
     import("@tauri-apps/api/event").then(({ listen }) => {
+      if (cancelled) return;
       listen("tray-popup-shown", () => {
         syncThemeFromStorage();
         syncConnectionState();
@@ -85,18 +91,26 @@ export function TrayApp() {
         // does not propagate live across Tauri windows.
         void usePortForwardStore.persist?.rehydrate();
       }).then((fn) => {
+        // Listener may resolve after unmount — detach immediately
+        if (cancelled) {
+          fn();
+          return;
+        }
         unlisten = fn;
       });
     });
     return () => {
+      cancelled = true;
       unlisten?.();
     };
   }, [syncConnectionState, syncThemeFromStorage]);
 
   // Also sync theme live when the event fires (while popup is open)
   useEffect(() => {
+    let cancelled = false;
     let unlisten: (() => void) | null = null;
     import("@tauri-apps/api/event").then(({ listen }) => {
+      if (cancelled) return;
       listen<{ theme: string; resolvedTheme: "light" | "dark" | "classic-dark" }>(
         "theme-changed",
         (event) => {
@@ -116,10 +130,16 @@ export function TrayApp() {
           }));
         }
       ).then((fn) => {
+        // Listener may resolve after unmount — detach immediately
+        if (cancelled) {
+          fn();
+          return;
+        }
         unlisten = fn;
       });
     });
     return () => {
+      cancelled = true;
       unlisten?.();
     };
   }, []);
@@ -133,12 +153,14 @@ export function TrayApp() {
 
   // Auto-dismiss when window loses focus (click outside on macOS desktop)
   useEffect(() => {
+    let hideTimer: ReturnType<typeof setTimeout> | null = null;
     const handleBlur = async () => {
       try {
         const { getCurrentWindow } = await import("@tauri-apps/api/window");
         const win = getCurrentWindow();
         // Small delay to avoid race with tray icon toggle
-        setTimeout(async () => {
+        if (hideTimer) clearTimeout(hideTimer);
+        hideTimer = setTimeout(async () => {
           if (!document.hasFocus()) {
             await win.hide();
           }
@@ -148,7 +170,10 @@ export function TrayApp() {
       }
     };
     window.addEventListener("blur", handleBlur);
-    return () => window.removeEventListener("blur", handleBlur);
+    return () => {
+      window.removeEventListener("blur", handleBlur);
+      if (hideTimer) clearTimeout(hideTimer);
+    };
   }, []);
 
   if (!isReady) {

--- a/src/components/features/tray/TrayPopup.tsx
+++ b/src/components/features/tray/TrayPopup.tsx
@@ -5,6 +5,7 @@ import { ActiveTab } from "./ActiveTab";
 import { PortForwardDialogs } from "../portforward/PortForwardDialogs";
 import { usePortForwardStore } from "@/lib/stores/portforward-store";
 import { useClusterStore } from "@/lib/stores/cluster-store";
+import { showMainWindow, quitApp as quitAppCommand } from "@/lib/tauri/commands/app";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import packageJson from "../../../../package.json";
 
@@ -30,9 +31,8 @@ export function TrayPopup() {
 
   const openMainWindow = async () => {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       const { emit } = await import("@tauri-apps/api/event");
-      await invoke("show_main_window_command");
+      await showMainWindow();
       // Navigate main window to Pods view
       await emit("navigate", { view: "pods" });
     } catch (err) {
@@ -42,8 +42,7 @@ export function TrayPopup() {
 
   const quitApp = async () => {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("quit_app");
+      await quitAppCommand();
     } catch (err) {
       console.error("Failed to quit:", err);
     }

--- a/src/components/features/tray/__tests__/TrayApp.test.tsx
+++ b/src/components/features/tray/__tests__/TrayApp.test.tsx
@@ -1,0 +1,92 @@
+import { render, act } from "@testing-library/react";
+import { TrayApp } from "../TrayApp";
+import { listen } from "@tauri-apps/api/event";
+
+jest.mock("../TrayPopup", () => ({
+  TrayPopup: () => null,
+}));
+
+const mockListenResolvers: Array<(fn: () => void) => void> = [];
+jest.mock("@tauri-apps/api/event", () => ({
+  listen: jest.fn(
+    () =>
+      new Promise((resolve) => {
+        mockListenResolvers.push(resolve as (fn: () => void) => void);
+      })
+  ),
+}));
+
+jest.mock("@/lib/tauri/commands/cluster", () => ({
+  getConnectionStatus: jest.fn().mockResolvedValue({ connected: false }),
+}));
+
+jest.mock("@/lib/stores/cluster-store", () => {
+  const state = {
+    clusters: [],
+    // Keep initialization pending so TrayApp stays on the loading screen
+    fetchClusters: jest.fn(() => new Promise(() => {})),
+    fetchNamespaces: jest.fn().mockResolvedValue(undefined),
+  };
+  const useClusterStore = (selector?: (s: Record<string, unknown>) => unknown) =>
+    selector ? selector(state) : state;
+  useClusterStore.getState = () => state;
+  useClusterStore.setState = jest.fn();
+  return { useClusterStore };
+});
+
+jest.mock("@/lib/stores/portforward-store", () => {
+  const state = {
+    initialize: jest.fn().mockResolvedValue(undefined),
+  };
+  const usePortForwardStore = (selector?: (s: Record<string, unknown>) => unknown) =>
+    selector ? selector(state) : state;
+  usePortForwardStore.getState = () => state;
+  usePortForwardStore.persist = { rehydrate: jest.fn() };
+  return { usePortForwardStore };
+});
+
+jest.mock("@/lib/stores/ui-store", () => {
+  const state = { settings: {} };
+  const useUIStore = (selector?: (s: Record<string, unknown>) => unknown) =>
+    selector ? selector(state) : state;
+  useUIStore.getState = () => state;
+  useUIStore.setState = jest.fn();
+  return { useUIStore };
+});
+
+describe("TrayApp event listener lifecycle", () => {
+  beforeEach(() => {
+    mockListenResolvers.length = 0;
+    (listen as jest.Mock).mockClear();
+  });
+
+  it("registers tray listeners on mount", async () => {
+    render(<TrayApp />);
+    // Flush the dynamic import of @tauri-apps/api/event
+    await act(async () => {});
+
+    const events = (listen as jest.Mock).mock.calls.map((call) => call[0]);
+    expect(events).toContain("tray-popup-shown");
+    expect(events).toContain("theme-changed");
+  });
+
+  it("detaches listeners that resolve after unmount", async () => {
+    const { unmount } = render(<TrayApp />);
+    await act(async () => {});
+    expect(mockListenResolvers).toHaveLength(2);
+
+    unmount();
+
+    // Regression: listen() promises resolving after unmount used to leak
+    // their listeners because the stored unlisten was never called.
+    const unlistenA = jest.fn();
+    const unlistenB = jest.fn();
+    await act(async () => {
+      mockListenResolvers[0](unlistenA);
+      mockListenResolvers[1](unlistenB);
+    });
+
+    expect(unlistenA).toHaveBeenCalledTimes(1);
+    expect(unlistenB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/hooks/__tests__/useDeploymentLogs.test.ts
+++ b/src/lib/hooks/__tests__/useDeploymentLogs.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, act } from "@testing-library/react";
+import { listen } from "@tauri-apps/api/event";
+import { useDeploymentLogs } from "../useDeploymentLogs";
+
+const mockListPods = jest.fn();
+const mockListDeployments = jest.fn();
+const mockWatchPods = jest.fn();
+const mockStopWatch = jest.fn();
+
+jest.mock("../../tauri/commands", () => ({
+  listPods: (...args: unknown[]) => mockListPods(...args),
+  listDeployments: (...args: unknown[]) => mockListDeployments(...args),
+  streamPodLogs: jest.fn(),
+  stopLogStream: jest.fn().mockResolvedValue(undefined),
+  watchPods: (...args: unknown[]) => mockWatchPods(...args),
+  stopWatch: (...args: unknown[]) => mockStopWatch(...args),
+}));
+
+const mockListen = listen as jest.Mock;
+
+describe("useDeploymentLogs unmount during watch setup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListDeployments.mockResolvedValue([]);
+    mockListPods.mockResolvedValue([]);
+    mockWatchPods.mockResolvedValue(undefined);
+    mockStopWatch.mockResolvedValue(undefined);
+    mockListen.mockResolvedValue(jest.fn());
+  });
+
+  // Regression: listen() resolved after the effect cleanup already ran, so
+  // the listener was registered on an unmounted hook and never removed.
+  it("removes the watch listener when unmounted while listen() is pending", async () => {
+    let resolveListen!: (unlisten: () => void) => void;
+    mockListen.mockImplementation(
+      () => new Promise((resolve) => { resolveListen = resolve; })
+    );
+
+    const { unmount } = renderHook(() => useDeploymentLogs("demo-web", "default"));
+    await act(async () => {});
+
+    unmount();
+
+    const unlisten = jest.fn();
+    await act(async () => {
+      resolveListen(unlisten);
+    });
+
+    expect(unlisten).toHaveBeenCalledTimes(1);
+    // The watch must not start once cleanup has run
+    expect(mockWatchPods).not.toHaveBeenCalled();
+  });
+
+  // Regression: cleanup's stopWatch ran while watchPods() was still pending,
+  // so the watch started afterwards and leaked.
+  it("stops the watch when unmounted while watchPods() is pending", async () => {
+    let resolveWatch!: () => void;
+    mockWatchPods.mockImplementation(
+      () => new Promise<void>((resolve) => { resolveWatch = resolve; })
+    );
+
+    const { unmount } = renderHook(() => useDeploymentLogs("demo-web", "default"));
+    await act(async () => {});
+    expect(mockWatchPods).toHaveBeenCalledTimes(1);
+
+    unmount();
+    // Drop the cleanup's own (too early, no-op) stopWatch call
+    mockStopWatch.mockClear();
+
+    await act(async () => {
+      resolveWatch();
+    });
+
+    expect(mockStopWatch).toHaveBeenCalledTimes(1);
+    expect(mockStopWatch).toHaveBeenCalledWith(
+      expect.stringContaining("deploy-pods-default-demo-web")
+    );
+  });
+});

--- a/src/lib/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/lib/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from "@testing-library/react";
+import { useKeyboardShortcuts } from "../useKeyboardShortcuts";
+
+describe("useKeyboardShortcuts", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  const pressKey = (key: string) => {
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key }));
+    });
+  };
+
+  it("fires the handler for a two-key sequence", () => {
+    const handler = jest.fn();
+    renderHook(() =>
+      useKeyboardShortcuts([{ key: "g p", handler, description: "goto pods" }])
+    );
+
+    pressKey("g");
+    pressKey("p");
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the pending key after 1 second", () => {
+    const handler = jest.fn();
+    const { result } = renderHook(() =>
+      useKeyboardShortcuts([{ key: "g p", handler, description: "goto pods" }])
+    );
+
+    pressKey("g");
+    expect(result.current.pendingKey).toBe("g");
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.pendingKey).toBeNull();
+  });
+
+  it("cancels the pending sequence timer on unmount", () => {
+    const handler = jest.fn();
+    const { unmount } = renderHook(() =>
+      useKeyboardShortcuts([{ key: "g p", handler, description: "goto pods" }])
+    );
+
+    pressKey("g");
+    expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+
+    // Regression: the 1s sequence timer used to keep running after unmount
+    // and call setState on an unmounted component.
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/lib/hooks/__tests__/useKubeconfigWatcher.test.ts
+++ b/src/lib/hooks/__tests__/useKubeconfigWatcher.test.ts
@@ -58,6 +58,33 @@ describe("useKubeconfigWatcher", () => {
     expect(unwatchOk).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: unmounting while watch setup was awaiting left the resolved
+  // watchers running forever because unwatchRef was never populated.
+  it("releases watchers when unmounted while setup is still in flight", async () => {
+    mockGetKubeconfigSources.mockResolvedValue({
+      sources: [{ path: "/home/user/.kube", source_type: "folder" }],
+      merge_mode: false,
+    });
+
+    let resolveWatch!: (unwatch: () => void) => void;
+    mockWatch.mockImplementation(
+      () => new Promise((resolve) => { resolveWatch = resolve; })
+    );
+
+    const { unmount } = renderHook(() => useKubeconfigWatcher());
+    await flush();
+    expect(mockWatch).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    const unwatch = jest.fn();
+    await act(async () => {
+      resolveWatch(unwatch);
+    });
+
+    expect(unwatch).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to watching ~/.kube when no sources are configured", async () => {
     mockGetKubeconfigSources.mockResolvedValue({ sources: [], merge_mode: false });
     mockWatch.mockResolvedValue(jest.fn());

--- a/src/lib/hooks/__tests__/useMetricsHistory.test.ts
+++ b/src/lib/hooks/__tests__/useMetricsHistory.test.ts
@@ -5,8 +5,16 @@ jest.mock("@/lib/tauri/commands", () => ({
   getPodMetrics: jest.fn(),
 }));
 
+const mockClusterState = {
+  isConnected: true,
+  currentCluster: { context: "ctx-a" } as { context: string } | null,
+};
+
 jest.mock("@/lib/stores/cluster-store", () => ({
-  useClusterStore: jest.fn(() => ({ isConnected: true })),
+  useClusterStore: Object.assign(
+    jest.fn(() => ({ isConnected: true })),
+    { getState: () => mockClusterState }
+  ),
 }));
 
 import {
@@ -30,6 +38,7 @@ function makePodMetrics(name: string, cpu: number, mem: number): PodMetrics {
 
 describe("useMetricsHistory module", () => {
   beforeEach(() => {
+    mockClusterState.currentCluster = { context: "ctx-a" };
     clearMetricsHistory();
     jest.useRealTimers();
   });
@@ -104,6 +113,26 @@ describe("useMetricsHistory module", () => {
 
       expect(getHistorySnapshot("kubeli-demo/web")).toEqual([]);
       expect(getHistorySnapshot("kubeli-demo/api")).toEqual([]);
+    });
+  });
+
+  describe("cluster context switch", () => {
+    // Regression: history persisted across cluster switches, so sparklines
+    // briefly showed the previous cluster's data.
+    it("drops history from the previous cluster", () => {
+      seedHistoryFromBulkMetrics([makePodMetrics("web", 100_000_000, 200_000_000)]);
+      expect(getHistorySnapshot("kubeli-demo/web")).toHaveLength(2);
+
+      mockClusterState.currentCluster = { context: "ctx-b" };
+
+      expect(getHistorySnapshot("kubeli-demo/web")).toEqual([]);
+    });
+
+    it("keeps history while the context stays the same", () => {
+      seedHistoryFromBulkMetrics([makePodMetrics("web", 100_000_000, 200_000_000)]);
+
+      expect(getHistorySnapshot("kubeli-demo/web")).toHaveLength(2);
+      expect(getHistorySnapshot("kubeli-demo/web")).toHaveLength(2);
     });
   });
 

--- a/src/lib/hooks/k8s/__tests__/useK8sResource.test.ts
+++ b/src/lib/hooks/k8s/__tests__/useK8sResource.test.ts
@@ -183,6 +183,57 @@ describe("useK8sResource", () => {
     });
   });
 
+  describe("stale refresh handling", () => {
+    // Regression: overlapping refresh() calls could resolve out of order and
+    // the older response overwrote the newer data.
+    it("ignores a stale refresh that resolves after a newer one", async () => {
+      const stale: TestResource[] = [{ uid: "1", name: "stale-pod", namespace: "default" }];
+      const fresh: TestResource[] = [{ uid: "2", name: "fresh-pod", namespace: "default" }];
+
+      let resolveFirst!: (value: TestResource[]) => void;
+      let resolveSecond!: (value: TestResource[]) => void;
+      mockListFn
+        .mockImplementationOnce(
+          () => new Promise<TestResource[]>((resolve) => { resolveFirst = resolve; })
+        )
+        .mockImplementationOnce(
+          () => new Promise<TestResource[]>((resolve) => { resolveSecond = resolve; })
+        );
+
+      const { result } = renderHook(() => useK8sResource(watchConfig));
+
+      // Initial fetch (the slow request) is now in flight
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(mockListFn).toHaveBeenCalledTimes(1);
+
+      // A second, newer refresh starts while the first is still pending
+      let refreshPromise!: Promise<void>;
+      act(() => {
+        refreshPromise = result.current.refresh();
+      });
+      expect(mockListFn).toHaveBeenCalledTimes(2);
+
+      // The newer request resolves first
+      await act(async () => {
+        resolveSecond(fresh);
+        await refreshPromise;
+        await flushPromises();
+      });
+      expect(result.current.data).toEqual(fresh);
+      expect(result.current.isLoading).toBe(false);
+
+      // The stale request resolves last - it must not overwrite newer data
+      await act(async () => {
+        resolveFirst(stale);
+        await flushPromises();
+      });
+      expect(result.current.data).toEqual(fresh);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
   describe("initial namespace filtering", () => {
     it("should pass namespace in listOptions for namespaced resources", async () => {
       renderHook(() => useK8sResource(watchConfig));

--- a/src/lib/hooks/k8s/resources/extensions.ts
+++ b/src/lib/hooks/k8s/resources/extensions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   listCRDs,
   listCustomResources,
@@ -79,9 +79,13 @@ export function useCustomResources(
   );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<KubeliError | null>(null);
+  // Generation counter: a stale (older, slower) refresh must not overwrite
+  // the state written by a newer one
+  const refreshSeq = useRef(0);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
+    const seq = ++refreshSeq.current;
     setIsLoading(true);
     setError(null);
     try {
@@ -136,12 +140,17 @@ export function useCustomResources(
         }
       }
 
+      // A newer refresh superseded this one - drop the stale result
+      if (seq !== refreshSeq.current) return;
       setData(result);
       setCache(cacheKey, result);
     } catch (error) {
+      if (seq !== refreshSeq.current) return;
       setError(toKubeliError(error));
     } finally {
-      setIsLoading(false);
+      if (seq === refreshSeq.current) {
+        setIsLoading(false);
+      }
     }
   }, [
     cacheKey,

--- a/src/lib/hooks/k8s/useClusterScoped.ts
+++ b/src/lib/hooks/k8s/useClusterScoped.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useClusterStore } from "../../stores/cluster-store";
 import { useResourceCacheStore } from "../../stores/resource-cache-store";
 import { type KubeliError, toKubeliError } from "../../types/errors";
@@ -23,19 +23,28 @@ export function useClusterScopedResource<T>(
   const [data, setData] = useState<T[]>(() => getCache<T>(cacheKey));
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<KubeliError | null>(null);
+  // Generation counter: a stale (older, slower) refresh must not overwrite
+  // the state written by a newer one
+  const refreshSeq = useRef(0);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
+    const seq = ++refreshSeq.current;
     setIsLoading(true);
     setError(null);
     try {
       const result = await listFn();
+      // A newer refresh superseded this one - drop the stale result
+      if (seq !== refreshSeq.current) return;
       setData(result);
       setCache(cacheKey, result);
     } catch (e) {
+      if (seq !== refreshSeq.current) return;
       setError(toKubeliError(e));
     } finally {
-      setIsLoading(false);
+      if (seq === refreshSeq.current) {
+        setIsLoading(false);
+      }
     }
   }, [isConnected, listFn, cacheKey, setCache]);
 

--- a/src/lib/hooks/k8s/useK8sResource.ts
+++ b/src/lib/hooks/k8s/useK8sResource.ts
@@ -44,11 +44,15 @@ export function useK8sResource<T>(
   const watchStartingRef = useRef(false);
   // Track whether auto-refresh is paused due to non-retryable error
   const autoRefreshPausedRef = useRef(false);
+  // Generation counter: a stale (older, slower) refresh must not overwrite
+  // the state written by a newer one
+  const refreshSeq = useRef(0);
 
   // ── Fetching ──────────────────────────────────────────────────────
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
+    const seq = ++refreshSeq.current;
     setIsLoading(true);
     setError(null);
     autoRefreshPausedRef.current = false;
@@ -102,9 +106,13 @@ export function useK8sResource<T>(
         result = config.postProcess(result);
       }
 
+      // A newer refresh superseded this one - drop the stale result
+      if (seq !== refreshSeq.current) return;
+
       setData(result);
       setCache(cacheKey, result);
     } catch (e) {
+      if (seq !== refreshSeq.current) return;
       const kubeliError = toKubeliError(e);
       setError(kubeliError);
 
@@ -113,7 +121,9 @@ export function useK8sResource<T>(
         autoRefreshPausedRef.current = true;
       }
     } finally {
-      setIsLoading(false);
+      if (seq === refreshSeq.current) {
+        setIsLoading(false);
+      }
     }
   }, [isConnected, namespace, isMultiNs, isConfiguredAllNs, configuredNamespaces, selectedNamespaces, config, cacheKey, setCache]);
 

--- a/src/lib/hooks/k8s/useOptionalNamespace.ts
+++ b/src/lib/hooks/k8s/useOptionalNamespace.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useClusterStore } from "../../stores/cluster-store";
 import { useResourceCacheStore } from "../../stores/resource-cache-store";
 import { type KubeliError, toKubeliError, getErrorMessage } from "../../types/errors";
@@ -30,9 +30,13 @@ export function useOptionalNamespaceResource<T>(
   const [data, setData] = useState<T[]>(() => getCache<T>(cacheKey));
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<KubeliError | null>(null);
+  // Generation counter: a stale (older, slower) refresh must not overwrite
+  // the state written by a newer one
+  const refreshSeq = useRef(0);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
+    const seq = ++refreshSeq.current;
     setIsLoading(true);
     setError(null);
     try {
@@ -77,12 +81,17 @@ export function useOptionalNamespaceResource<T>(
       } else {
         result = await listFn(namespace || undefined);
       }
+      // A newer refresh superseded this one - drop the stale result
+      if (seq !== refreshSeq.current) return;
       setData(result);
       setCache(cacheKey, result);
     } catch (e) {
+      if (seq !== refreshSeq.current) return;
       setError(toKubeliError(e));
     } finally {
-      setIsLoading(false);
+      if (seq === refreshSeq.current) {
+        setIsLoading(false);
+      }
     }
   }, [isConnected, namespace, isMultiNs, isConfiguredAllNs, configuredNamespaces, selectedNamespaces, listFn, displayName, cacheKey, setCache]);
 

--- a/src/lib/hooks/useDeploymentLogs.ts
+++ b/src/lib/hooks/useDeploymentLogs.ts
@@ -251,6 +251,7 @@ export function useDeploymentLogs(
         let startedCount = 0;
 
         for (const pod of currentPods) {
+          if (!mountedRef.current) break;
           const streamId = `deploy-logs-${namespace}-${deploymentName}-${pod.name}-${Date.now()}`;
           streamIds.push(streamId);
 
@@ -308,6 +309,12 @@ export function useDeploymentLogs(
 
         activeStreamIds.current = streamIds;
         activeListeners.current = listeners;
+
+        // Unmounted while streams were starting - the effect cleanup already
+        // ran with empty refs, so tear everything down here
+        if (!mountedRef.current) {
+          await stopAllStreams();
+        }
       } catch (e) {
         if (mountedRef.current) {
           setError(toKubeliError(e));
@@ -340,11 +347,12 @@ export function useDeploymentLogs(
 
     const watchId = `deploy-pods-${namespace}-${deploymentName}-${Date.now()}`;
     let watchUnlisten: UnlistenFn | null = null;
+    let cancelled = false;
 
     const setupWatch = async () => {
       try {
         // Listen for pod watch events
-        watchUnlisten = await listen<WatchEvent<PodInfo>>(
+        const unlisten = await listen<WatchEvent<PodInfo>>(
           `pods-watch-${watchId}`,
           (event) => {
             if (!mountedRef.current) return;
@@ -395,8 +403,21 @@ export function useDeploymentLogs(
           }
         );
 
+        // Cleanup ran while listen() was pending - drop the listener now
+        if (cancelled) {
+          unlisten();
+          return;
+        }
+        watchUnlisten = unlisten;
+
         // Start the watch
         await watchPods(watchId, namespace);
+
+        // Cleanup ran while watchPods() was pending - its stopWatch was a
+        // no-op back then, so stop the watch here
+        if (cancelled) {
+          stopWatch(watchId).catch(() => {});
+        }
       } catch {
         // Watch failed - no fallback needed, initial fetch already loaded pods
       }
@@ -405,6 +426,7 @@ export function useDeploymentLogs(
     setupWatch();
 
     return () => {
+      cancelled = true;
       mountedRef.current = false;
       // Stop pod watch
       watchUnlisten?.();

--- a/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/lib/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 
 type ShortcutHandler = () => void;
 
@@ -28,6 +28,7 @@ export function useKeyboardShortcuts(
 ) {
   const { enabled = true } = options;
   const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -56,7 +57,8 @@ export function useKeyboardShortcuts(
           if (event.key.toLowerCase() === keys[0] && !pendingKey) {
             setPendingKey(keys[0]);
             // Clear pending after 1 second
-            setTimeout(() => setPendingKey(null), 1000);
+            if (pendingTimerRef.current) clearTimeout(pendingTimerRef.current);
+            pendingTimerRef.current = setTimeout(() => setPendingKey(null), 1000);
             return;
           }
         }
@@ -94,6 +96,13 @@ export function useKeyboardShortcuts(
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
+
+  // Cancel a pending sequence timer on unmount
+  useEffect(() => {
+    return () => {
+      if (pendingTimerRef.current) clearTimeout(pendingTimerRef.current);
+    };
+  }, []);
 
   return { pendingKey };
 }

--- a/src/lib/hooks/useKubeconfigWatcher.ts
+++ b/src/lib/hooks/useKubeconfigWatcher.ts
@@ -11,6 +11,7 @@ import { getKubeconfigSources } from "../tauri/commands";
 export function useKubeconfigWatcher() {
   const fetchClusters = useClusterStore((s) => s.fetchClusters);
   const unwatchRef = useRef<(() => void) | null>(null);
+  const disposedRef = useRef(false);
 
   const setupWatcher = useCallback(async () => {
     // Clean up previous watcher
@@ -79,13 +80,22 @@ export function useKubeconfigWatcher() {
         }
       });
 
-      unwatchRef.current = () => unwatchers.forEach((u) => u());
+      const unwatch = () => unwatchers.forEach((u) => u());
+
+      // Unmounted while the watches were being set up - the effect cleanup
+      // already ran, so release them immediately
+      if (disposedRef.current) {
+        unwatch();
+        return;
+      }
+      unwatchRef.current = unwatch;
     } catch (e) {
       console.error("Failed to setup kubeconfig watcher:", e);
     }
   }, [fetchClusters]);
 
   useEffect(() => {
+    disposedRef.current = false;
     setupWatcher();
 
     // Restart watcher when sources are added/removed in settings
@@ -93,6 +103,7 @@ export function useKubeconfigWatcher() {
     window.addEventListener("kubeconfig-sources-changed", handleSourcesChanged);
 
     return () => {
+      disposedRef.current = true;
       window.removeEventListener("kubeconfig-sources-changed", handleSourcesChanged);
       if (unwatchRef.current) {
         unwatchRef.current();

--- a/src/lib/hooks/useMetricsHistory.ts
+++ b/src/lib/hooks/useMetricsHistory.ts
@@ -23,7 +23,20 @@ const POLL_INTERVAL = 10_000; // 10 seconds
  */
 const historyStore = new Map<string, MetricsSnapshot[]>();
 
+// Cluster context the stored history belongs to. Checked on every access so
+// sparklines never show data from a previously connected cluster.
+let historyContext: string | null = null;
+
+function syncHistoryContext(): void {
+  const context = useClusterStore.getState().currentCluster?.context ?? null;
+  if (context !== historyContext) {
+    historyStore.clear();
+    historyContext = context;
+  }
+}
+
 function getHistory(key: string): MetricsSnapshot[] {
+  syncHistoryContext();
   let arr = historyStore.get(key);
   if (!arr) {
     arr = [];
@@ -75,6 +88,7 @@ export function seedHistoryFromBulkMetrics(metrics: PodMetrics[]) {
 /** Non-reactive read of history for a pod key ("namespace/podName").
  *  Returns the current snapshot array (or empty). */
 export function getHistorySnapshot(key: string): MetricsSnapshot[] {
+  syncHistoryContext();
   return historyStore.get(key) || [];
 }
 
@@ -93,16 +107,18 @@ export function useMetricsHistory(
   namespace: string,
 ): MetricsHistoryResult {
   const isConnected = useClusterStore((s) => s.isConnected);
+  const context = useClusterStore((s) => s.currentCluster?.context ?? null);
   const key = `${namespace}/${podName}`;
   const [history, setHistory] = useState<MetricsSnapshot[]>(() => [...getHistory(key)]);
   const [polled, setPolled] = useState(() => getHistory(key).length > 0);
 
-  // Reset when pod changes (key changes)
+  // Reset when pod changes (key changes) or the cluster context switches
+  // (getHistory then returns the cleared store)
   useEffect(() => {
     const existing = getHistory(key);
     setHistory([...existing]);
     setPolled(existing.length > 0);
-  }, [key]);
+  }, [key, context]);
 
   const poll = useCallback(async () => {
     if (!isConnected) return;

--- a/src/lib/hooks/useUpdater.tsx
+++ b/src/lib/hooks/useUpdater.tsx
@@ -73,7 +73,9 @@ export function useUpdater(options: UseUpdaterOptions = {}) {
   }, []);
 
   const checkForUpdates = useCallback(async (showToast: boolean = false) => {
-    if (checking) return null;
+    // Read from store directly - a `checking` dep would recreate this
+    // callback (and reset the interval effect) on every check.
+    if (useUpdaterStore.getState().checking) return null;
 
     setChecking(true);
 
@@ -116,7 +118,7 @@ export function useUpdater(options: UseUpdaterOptions = {}) {
       }
       return null;
     }
-  }, [checking, setChecking, setAvailable, setError, toastStrings]);
+  }, [setChecking, setAvailable, setError, toastStrings]);
 
   const downloadAndInstall = useCallback(async (_autoRestart: boolean = false, isAutoInstall: boolean = false) => {
     // Get current state directly from store to avoid stale closure

--- a/src/lib/stores/__tests__/log-store.test.ts
+++ b/src/lib/stores/__tests__/log-store.test.ts
@@ -1,0 +1,65 @@
+import { useLogStore, type LogTabState } from "../log-store";
+
+// Mock Tauri commands
+const mockStreamPodLogs = jest.fn();
+const mockStopLogStream = jest.fn();
+
+jest.mock("../../tauri/commands", () => ({
+  getPodLogs: jest.fn(),
+  streamPodLogs: (...args: unknown[]) => mockStreamPodLogs(...args),
+  stopLogStream: (...args: unknown[]) => mockStopLogStream(...args),
+  getPodContainers: jest.fn(),
+  watchPods: jest.fn(),
+  stopWatch: jest.fn().mockResolvedValue(undefined),
+}));
+
+function makeTabState(): LogTabState {
+  return {
+    logs: [],
+    isStreaming: false,
+    isLoading: false,
+    error: null,
+    containers: [],
+    selectedContainer: null,
+    streamId: null,
+    scrollTop: 0,
+    autoScroll: true,
+  };
+}
+
+describe("log-store startStream", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamPodLogs.mockResolvedValue(undefined);
+    mockStopLogStream.mockResolvedValue(undefined);
+    useLogStore.setState({
+      activeTabId: null,
+      logTabs: { tab1: makeTabState() },
+    });
+  });
+
+  // Regression: isStreaming only turns true after an await, so two rapid
+  // calls for the same tab both passed the guard and started two backend
+  // streams (the second one first tearing down the half-started first).
+  it("starts only one stream when called twice rapidly for the same tab", async () => {
+    const { startStream } = useLogStore.getState();
+
+    await Promise.all([
+      startStream("tab1", "default", "my-pod"),
+      startStream("tab1", "default", "my-pod"),
+    ]);
+
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(1);
+    expect(mockStopLogStream).not.toHaveBeenCalled();
+  });
+
+  it("allows starting again after a failed start", async () => {
+    mockStreamPodLogs.mockRejectedValueOnce(new Error("boom"));
+
+    await useLogStore.getState().startStream("tab1", "default", "my-pod");
+    expect(useLogStore.getState().logTabs.tab1.error).not.toBeNull();
+
+    await useLogStore.getState().startStream("tab1", "default", "my-pod");
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/stores/ai-store/__tests__/helpers.test.ts
+++ b/src/lib/stores/ai-store/__tests__/helpers.test.ts
@@ -1,14 +1,16 @@
 import {
   buildFallbackSystemPrompt,
+  buildResumeContext,
   finalizeStreamingMessage,
   findConversationById,
   generateId,
   getErrorMessage,
   removeConversationByClusterContext,
+  RESUME_CONTEXT_MAX_CHARS,
   STORE_NAME,
   toChatMessages,
 } from "../helpers";
-import type { Conversation } from "../types";
+import type { ChatMessage, Conversation } from "../types";
 
 describe("ai-store helpers", () => {
   it("exposes the expected store name", () => {
@@ -95,6 +97,53 @@ describe("ai-store helpers", () => {
         toolCalls: undefined,
       },
     ]);
+  });
+
+  describe("buildResumeContext", () => {
+    const msg = (role: ChatMessage["role"], content: string, id = "m"): ChatMessage => ({
+      id,
+      role,
+      content,
+      timestamp: 1,
+    });
+
+    it("builds a transcript of prior user/assistant messages, oldest first", () => {
+      const context = buildResumeContext([
+        msg("user", "why is my pod crashing?"),
+        msg("assistant", "It is OOMKilled."),
+      ]);
+
+      expect(context).toContain("## Previous conversation");
+      expect(context).toContain(
+        "User: why is my pod crashing?\n\nAssistant: It is OOMKilled."
+      );
+    });
+
+    it("returns null when there is no usable history", () => {
+      expect(buildResumeContext([])).toBeNull();
+      expect(buildResumeContext([msg("assistant", "   ")])).toBeNull();
+    });
+
+    it("drops the oldest messages first when over budget", () => {
+      const big = "x".repeat(RESUME_CONTEXT_MAX_CHARS - 50);
+      const context = buildResumeContext([
+        msg("user", "oldest question"),
+        msg("assistant", big),
+        msg("user", "newest question"),
+      ]);
+
+      expect(context).not.toContain("oldest question");
+      expect(context).toContain("newest question");
+      expect(context).toContain(big);
+    });
+
+    it("truncates a single over-budget message instead of dropping everything", () => {
+      const huge = "y".repeat(RESUME_CONTEXT_MAX_CHARS * 2);
+      const context = buildResumeContext([msg("user", huge)]);
+
+      expect(context).not.toBeNull();
+      expect(context!.length).toBeLessThan(RESUME_CONTEXT_MAX_CHARS + 200);
+    });
   });
 
   describe("finalizeStreamingMessage", () => {

--- a/src/lib/stores/ai-store/actions/__tests__/session-actions.test.ts
+++ b/src/lib/stores/ai-store/actions/__tests__/session-actions.test.ts
@@ -168,6 +168,40 @@ describe("createSessionActions", () => {
     expect(console.warn).toHaveBeenCalledTimes(2);
   });
 
+  it("injects prior conversation history into the initial context when resuming", async () => {
+    const { actions } = createHarness({
+      currentConversationId: "existing-conversation",
+      conversations: {
+        "kind-dev": {
+          id: "existing-conversation",
+          clusterContext: "kind-dev",
+          messages: [
+            { id: "m1", role: "user", content: "why is my pod crashing?", timestamp: 1 },
+            { id: "m2", role: "assistant", content: "It is OOMKilled.", timestamp: 2 },
+          ],
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      },
+    });
+
+    await actions.startSession("kind-dev", "default");
+
+    const initialContext = (aiStartSession as jest.Mock).mock.calls[0][1] as string;
+    expect(initialContext).toContain("system prompt");
+    expect(initialContext).toContain("## Previous conversation");
+    expect(initialContext).toContain("User: why is my pod crashing?");
+    expect(initialContext).toContain("Assistant: It is OOMKilled.");
+  });
+
+  it("does not inject a resume block when the conversation has no messages", async () => {
+    const { actions } = createHarness();
+
+    await actions.startSession("kind-dev", "default");
+
+    expect(aiStartSession).toHaveBeenCalledWith("kind-dev", "system prompt", "claude");
+  });
+
   it("stores a normalized error when starting a session fails", async () => {
     (aiStartSession as jest.Mock).mockRejectedValueOnce(new Error("start failed"));
     const { state, actions } = createHarness();

--- a/src/lib/stores/ai-store/actions/session-actions.ts
+++ b/src/lib/stores/ai-store/actions/session-actions.ts
@@ -13,6 +13,7 @@ import {
 import { useUIStore } from "../../ui-store";
 import {
   buildFallbackSystemPrompt,
+  buildResumeContext,
   finalizeStreamingMessage,
   findConversationById,
   generateId,
@@ -51,6 +52,16 @@ export function createSessionActions(
         } catch (error) {
           console.warn("Failed to build cluster context, using fallback:", error);
           initialContext = buildFallbackSystemPrompt(clusterContext);
+        }
+
+        // When resuming a conversation with stored history, the backend CLI
+        // session is brand new and has no memory of it - inject a compact
+        // transcript so the model keeps the context the UI displays.
+        const priorMessages =
+          get().conversations[clusterContext]?.messages ?? [];
+        const resumeContext = buildResumeContext(priorMessages);
+        if (resumeContext) {
+          initialContext = `${initialContext}\n\n${resumeContext}`;
         }
 
         const sessionId = await aiStartSession(

--- a/src/lib/stores/ai-store/helpers.ts
+++ b/src/lib/stores/ai-store/helpers.ts
@@ -61,6 +61,43 @@ export function finalizeStreamingMessage(
   return { ...conversation, messages, updatedAt: Date.now() };
 }
 
+// Character budget for the transcript injected when resuming a session.
+// Oldest messages are dropped first when the history exceeds it.
+export const RESUME_CONTEXT_MAX_CHARS = 10000;
+
+/**
+ * Builds a compact transcript of prior messages so a resumed session's
+ * fresh backend CLI process knows what was already discussed.
+ * Returns null when there is no usable history.
+ */
+export function buildResumeContext(messages: ChatMessage[]): string | null {
+  const lines: string[] = [];
+  let total = 0;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const { role, content } = messages[i];
+    if ((role !== "user" && role !== "assistant") || !content.trim()) continue;
+
+    const line = `${role === "user" ? "User" : "Assistant"}: ${content.trim()}`;
+    if (total + line.length > RESUME_CONTEXT_MAX_CHARS) {
+      // Keep at least the most recent message, truncated to the budget.
+      if (lines.length === 0) {
+        lines.unshift(line.slice(0, RESUME_CONTEXT_MAX_CHARS));
+      }
+      break;
+    }
+    lines.unshift(line);
+    total += line.length;
+  }
+
+  if (lines.length === 0) return null;
+
+  return `## Previous conversation
+This session was resumed. The prior exchange with the user (oldest first):
+
+${lines.join("\n\n")}`;
+}
+
 export function toChatMessages(records: MessageRecord[]): ChatMessage[] {
   return records.map((record) => ({
     id: record.message_id,

--- a/src/lib/stores/log-store.ts
+++ b/src/lib/stores/log-store.ts
@@ -71,6 +71,9 @@ let logSeq = 0;
 const stampSeq = (entry: LogEntry): LogEntry => ({ ...entry, seq: ++logSeq });
 
 const listeners = new Map<string, UnlistenFn>();
+// Tabs with a startStream call in flight - isStreaming only turns true after
+// an await, so this synchronous marker is what stops rapid double-starts
+const startingStreams = new Set<string>();
 const pendingLogs = new Map<string, LogEntry[]>();
 const flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const podWatchers = new Map<string, () => void>();
@@ -247,7 +250,8 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
 
   async startStream(tabId, ns, pod, container, tailLines) {
     const tab = get().logTabs[tabId];
-    if (!tab || tab.isStreaming) return;
+    if (!tab || tab.isStreaming || startingStreams.has(tabId)) return;
+    startingStreams.add(tabId);
 
     // Stop existing stream if any
     if (tab.streamId) {
@@ -360,6 +364,8 @@ export const useLogStore = create<LogStoreState>((set, get) => ({
       });
       listeners.get(tabId)?.();
       listeners.delete(tabId);
+    } finally {
+      startingStreams.delete(tabId);
     }
   },
 

--- a/src/lib/tauri/commands/__tests__/wrappers.test.ts
+++ b/src/lib/tauri/commands/__tests__/wrappers.test.ts
@@ -36,6 +36,8 @@ const shellOptions = { namespace: "default", pod_name: "demo", container: "app",
 
 const cases: TestCase[] = [
   { name: "restartApp", run: () => appCommands.restartApp(), expectedCommand: "restart_app" },
+  { name: "showMainWindow", run: () => appCommands.showMainWindow(), expectedCommand: "show_main_window_command" },
+  { name: "quitApp", run: () => appCommands.quitApp(), expectedCommand: "quit_app" },
   { name: "listClusters", run: () => cluster.listClusters(), expectedCommand: "list_clusters" },
   { name: "connectCluster", run: () => cluster.connectCluster("ctx"), expectedCommand: "connect_cluster", expectedPayload: { context: "ctx" } },
   { name: "disconnectCluster", run: () => cluster.disconnectCluster(), expectedCommand: "disconnect_cluster" },

--- a/src/lib/tauri/commands/app.ts
+++ b/src/lib/tauri/commands/app.ts
@@ -1,3 +1,6 @@
 import { invoke } from "./core";
 
 export const restartApp = (): Promise<void> => invoke("restart_app");
+export const showMainWindow = (): Promise<void> =>
+  invoke("show_main_window_command");
+export const quitApp = (): Promise<void> => invoke("quit_app");


### PR DESCRIPTION
## What does this PR do?

Cleans up race conditions and leaks in the frontend (Phase 4) and hardens the remaining Rust backend items from task 3.6.

### Frontend
- **Stale data**: fast namespace/cluster switches could let old API responses overwrite newer ones — superseded responses are now discarded
- **Duplicate log streams**: double-clicking quickly started two streams for the same pod
- **Sparklines**: briefly showed the previous cluster's data after switching
- **Leaks**: event listeners and timers kept running after unmount (tray, logs, shortcuts, settings)
- **Terminal**: was fully torn down and rebuilt on every reconnect — now stable
- **AI**: resumed chats now give the model the actual history; the provider choice is no longer overridden; a failed send no longer loses the prompt
- **Search**: now matches label/selector values (previously "[object Object]")
- **PodsView**: noticeably faster with many pods (memoization)

### Backend
- Errors are detected structurally (401/403/404, invalid_grant) instead of text guessing
- Node-shell debug pods clean up after themselves (1h deadline + sweep on connect)
- MCP server uses the same kubeconfig sources as the app and marks truncated responses
- Tray quit actually exits the app on Windows/Linux
- Assorted crash fixes (panic on short URLs, startup crash, keyring no longer blocks the runtime)

## Tests
17+ new test files. All green: 277 Rust, 665 Jest, tsc, ESLint, clippy `-D warnings`.

## Manual smoke checklist
- [ ] Switch quickly between clusters/namespaces → no stale data, sparklines start empty
- [ ] Start pod logs twice quickly → only one stream
- [ ] Terminal: type, resize, reconnect → no flicker
- [ ] AI: resume a saved session → model knows the history
- [ ] Search for a label value (e.g. app=web) → matches
- [ ] Port forward "Open in Browser" → opens
- [ ] Tray quit (Windows/Linux) → app exits