### PR TITLE
Add fallback options for release changelog generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ yarn-error.log*
 # Task management (local)
 .taskmaster/
 .release-notes.md
+.changelog-ai-prompt.md
 
 # Test coverage
 coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,10 +49,10 @@ make build
 
 | Command | Description |
 |---------|-------------|
-| `make release` | Release via CI: version bump, changelog, commit, tag push → CI builds all platforms |
+| `make release` | Release via CI: version bump, AI-generated changelog, commit, tag push → CI builds all platforms |
 | `make build-deploy` | Alias for `make release` |
 
-The release flow: `make release` → tag push triggers GitHub Actions → builds macOS (ARM + x86), Windows, Linux → waits for manual approval → deploys to FTP + publishes GitHub Release.
+The release flow: `make release` → changelog generation tries Claude, then Codex, then OpenCode → if all CLIs fail, `.changelog-ai-prompt.md` is created for use in any AI chat and the generated bullet points can be pasted back into the terminal → tag push triggers GitHub Actions → builds macOS (ARM + x86), Windows, Linux → waits for manual approval → deploys to FTP + publishes GitHub Release.
 
 ### Using npm
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,12 +50,13 @@ make build
 | Command | Description |
 |---------|-------------|
 | `make release` | Release via CI: version bump, AI-generated changelog, commit, tag push → CI builds all platforms |
+| `make release-push` | Review and publish a prepared release after explicit terminal confirmation |
 | `make release-ai-dry-run` | Test Claude, Codex, and OpenCode release integration without changing release files |
 | `make release-changelog-dry-run` | Test the real Claude → Codex → OpenCode fallback chain without changing release files |
 | `make release-manual-dry-run` | Test the Markdown prompt and terminal paste fallback without changing release files |
 | `make build-deploy` | Alias for `make release` |
 
-The release flow: `make release` → changelog generation tries Claude, then Codex, then OpenCode → if all CLIs fail, `.changelog-ai-prompt.md` is created for use in any AI chat and the generated bullet points can be pasted back into the terminal → tag push triggers GitHub Actions → builds macOS (ARM + x86), Windows, Linux → waits for manual approval → deploys to FTP + publishes GitHub Release.
+The release flow: `make release` → changelog generation tries Claude, then Codex, then OpenCode → if all CLIs fail, `.changelog-ai-prompt.md` is created for use in any AI chat and the generated bullet points can be pasted back into the terminal → release files and notes are shown for review → pressing Enter confirms commit, push, and tag creation; any other input aborts → tag push triggers GitHub Actions → builds macOS (ARM + x86), Windows, Linux → waits for manual approval → deploys to FTP + publishes GitHub Release. After an abort, edit the prepared files and run `make release-push` to review and continue without another version bump.
 
 ### Using npm
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ make build
 |---------|-------------|
 | `make release` | Release via CI: version bump, AI-generated changelog, commit, tag push → CI builds all platforms |
 | `make release-ai-dry-run` | Test Claude, Codex, and OpenCode release integration without changing release files |
+| `make release-changelog-dry-run` | Test the real Claude → Codex → OpenCode fallback chain without changing release files |
+| `make release-manual-dry-run` | Test the Markdown prompt and terminal paste fallback without changing release files |
 | `make build-deploy` | Alias for `make release` |
 
 The release flow: `make release` → changelog generation tries Claude, then Codex, then OpenCode → if all CLIs fail, `.changelog-ai-prompt.md` is created for use in any AI chat and the generated bullet points can be pasted back into the terminal → tag push triggers GitHub Actions → builds macOS (ARM + x86), Windows, Linux → waits for manual approval → deploys to FTP + publishes GitHub Release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ make build
 | Command | Description |
 |---------|-------------|
 | `make release` | Release via CI: version bump, AI-generated changelog, commit, tag push → CI builds all platforms |
+| `make release-ai-dry-run` | Test Claude, Codex, and OpenCode release integration without changing release files |
 | `make build-deploy` | Alias for `make release` |
 
 The release flow: `make release` → changelog generation tries Claude, then Codex, then OpenCode → if all CLIs fail, `.changelog-ai-prompt.md` is created for use in any AI chat and the generated bullet points can be pasted back into the terminal → tag push triggers GitHub Actions → builds macOS (ARM + x86), Windows, Linux → waits for manual approval → deploys to FTP + publishes GitHub Release.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Kubeli - Kubernetes Management Desktop App
 # Makefile for common development tasks
 
-.PHONY: dev build build-start build-all clean install install-windows-build-deps build-windows test test-all test-e2e test-coverage test-coverage-frontend test-coverage-rust lint format check tauri-dev tauri-build web-dev dmg build-dmg build-universal minikube-start minikube-stop minikube-status minikube-setup-samples minikube-setup-flux minikube-setup-argocd minikube-clean-samples minikube-setup-openshift minikube-clean-openshift minikube-setup-scale minikube-clean-scale minikube-serve kubeconfig-fake-eks kubeconfig-fake-gke kubeconfig-fake-aks kubeconfig-auth-error kubeconfig-cleanup oidc-dev oidc-dev-stop astro astro-build astro-public build-deploy release generate-changelog sbom sbom-npm sbom-rust sbom-validate security-scan security-trivy security-semgrep screenshots screenshot-setup screenshot-build vet vet-install
+.PHONY: dev build build-start build-all clean install install-windows-build-deps build-windows test test-all test-e2e test-coverage test-coverage-frontend test-coverage-rust lint format check tauri-dev tauri-build web-dev dmg build-dmg build-universal minikube-start minikube-stop minikube-status minikube-setup-samples minikube-setup-flux minikube-setup-argocd minikube-clean-samples minikube-setup-openshift minikube-clean-openshift minikube-setup-scale minikube-clean-scale minikube-serve kubeconfig-fake-eks kubeconfig-fake-gke kubeconfig-fake-aks kubeconfig-auth-error kubeconfig-cleanup oidc-dev oidc-dev-stop astro astro-build astro-public build-deploy release generate-changelog release-ai-dry-run sbom sbom-npm sbom-rust sbom-validate security-scan security-trivy security-semgrep screenshots screenshot-setup screenshot-build vet vet-install
 
 # Default target
 .DEFAULT_GOAL := help
@@ -201,6 +201,10 @@ generate-changelog: ## Generate changelog using Claude, Codex, or OpenCode CLI
 	@if [ -f .release-notes.md ]; then \
 		echo "$(GREEN)✓ Changelog files updated$(RESET)"; \
 	fi
+
+release-ai-dry-run: ## Test release AI providers without changing release files (optional: PROVIDER=codex)
+	@echo "$(CYAN)Testing release AI providers (no release files will be changed)...$(RESET)"
+	@PROVIDER="$(PROVIDER)" node scripts/generate-changelog.js --dry-run
 
 ## Code Quality
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,20 @@
 # Kubeli - Kubernetes Management Desktop App
 # Makefile for common development tasks
 
-.PHONY: dev build build-start build-all clean install install-windows-build-deps build-windows test test-all test-e2e test-coverage test-coverage-frontend test-coverage-rust lint format check tauri-dev tauri-build web-dev dmg build-dmg build-universal minikube-start minikube-stop minikube-status minikube-setup-samples minikube-setup-flux minikube-setup-argocd minikube-clean-samples minikube-setup-openshift minikube-clean-openshift minikube-setup-scale minikube-clean-scale minikube-serve kubeconfig-fake-eks kubeconfig-fake-gke kubeconfig-fake-aks kubeconfig-auth-error kubeconfig-cleanup oidc-dev oidc-dev-stop astro astro-build astro-public build-deploy release generate-changelog release-ai-dry-run sbom sbom-npm sbom-rust sbom-validate security-scan security-trivy security-semgrep screenshots screenshot-setup screenshot-build vet vet-install
+.PHONY: help
+.PHONY: dev web-dev tauri-dev
+.PHONY: build build-start web-build tauri-build build-universal dmg build-dmg build-universal-dmg build-all build-windows
+.PHONY: astro astro-build astro-public
+.PHONY: build-deploy release generate-changelog release-ai-dry-run release-changelog-dry-run release-manual-dry-run version-bump
+.PHONY: lint format check rust-check rust-fmt rust-lint vet vet-install
+.PHONY: test test-watch test-all test-e2e test-coverage test-coverage-frontend test-coverage-rust rust-test
+.PHONY: clean clean-all install reinstall install-windows-build-deps deps update-deps
+.PHONY: minikube-start minikube-stop minikube-status minikube-serve minikube-setup-samples minikube-clean-samples minikube-setup-flux minikube-setup-argocd minikube-setup-helm
+.PHONY: minikube-setup-openshift minikube-clean-openshift minikube-setup-scale minikube-clean-scale
+.PHONY: kubeconfig-setup-samples kubeconfig-clean-samples kubeconfig-fake-eks kubeconfig-fake-gke kubeconfig-fake-aks kubeconfig-auth-error kubeconfig-same-user kubeconfig-cleanup
+.PHONY: k8s-pods k8s-services k8s-namespaces oidc-dev oidc-dev-stop
+.PHONY: sbom sbom-npm sbom-rust sbom-validate security-scan security-trivy security-semgrep
+.PHONY: screenshots screenshot-setup screenshot-build
 
 # Default target
 .DEFAULT_GOAL := help
@@ -172,7 +185,7 @@ astro-public: astro-build ## Build and deploy landing page to FTP
 	done; \
 	echo "$(GREEN)✓ Landing page deployed to https://$$DEPLOY_LANDING_URL$(RESET)"
 
-## Deployment
+## Release & Deployment
 
 build-deploy: release ## Release via CI (version bump, changelog, commit, tag, push)
 
@@ -205,6 +218,14 @@ generate-changelog: ## Generate changelog using Claude, Codex, or OpenCode CLI
 release-ai-dry-run: ## Test release AI providers without changing release files (optional: PROVIDER=codex)
 	@echo "$(CYAN)Testing release AI providers (no release files will be changed)...$(RESET)"
 	@PROVIDER="$(PROVIDER)" node scripts/generate-changelog.js --dry-run
+
+release-changelog-dry-run: ## Test the Claude → Codex → OpenCode fallback chain without changing release files
+	@echo "$(CYAN)Testing the release changelog fallback chain...$(RESET)"
+	@node scripts/generate-changelog.js --fallback-dry-run
+
+release-manual-dry-run: ## Test the manual Markdown copy/paste fallback without changing release files
+	@echo "$(CYAN)Testing the manual Markdown changelog fallback...$(RESET)"
+	@node scripts/generate-changelog.js --manual-dry-run
 
 ## Code Quality
 
@@ -274,7 +295,7 @@ clean-all: clean ## Deep clean including node_modules
 	rm -rf node_modules
 	rm -rf src-tauri/target
 
-## Installation
+## Installation & Windows Builds
 
 install: ## Install all dependencies
 	npm install
@@ -588,7 +609,7 @@ oidc-dev: ## Start local OIDC stack (HTTPS Dex + minikube that trusts it) to tes
 oidc-dev-stop: ## Tear down the local OIDC stack (Dex + minikube profile + context)
 	@./scripts/oidc-dev.sh down
 
-## Security / SBOM
+## Software Bill of Materials (SBOM)
 
 sbom-npm: ## Generate npm SBOM (CycloneDX JSON)
 	npm run sbom:npm
@@ -623,7 +644,7 @@ security-semgrep: ## Run Semgrep SAST scan (requires Docker)
 	docker run --rm --platform linux/amd64 -v $(PWD):/src semgrep/semgrep:1.112.0 semgrep scan --config p/default --config p/secrets --config p/typescript --config p/react --config p/rust --config /src/.semgrep.yaml --metrics off
 	@echo "$(GREEN)✓ Semgrep scan completed$(RESET)"
 
-## Utilities
+## Versioning & Dependencies
 
 version-bump: ## Bump version interactively (or use TYPE=patch|minor|major)
 	@TYPE="$(TYPE)"; \
@@ -742,4 +763,10 @@ help: ## Show this help message
 	@echo ""
 	@echo "$(YELLOW)Usage:$(RESET) make [target]"
 	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  $(GREEN)%-15s$(RESET) %s\n", $$1, $$2}'
+	@awk '\
+		/^## / { printf "\n$(YELLOW)%s$(RESET)\n", substr($$0, 4); next } \
+		/^[a-zA-Z0-9_-]+:.*## / { \
+			target = $$0; sub(/:.*/, "", target); \
+			description = $$0; sub(/^.*## /, "", description); \
+			printf "  $(GREEN)%-28s$(RESET) %s\n", target, description \
+		}' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -195,8 +195,8 @@ release: ## Release: version bump, changelog, commit, tag push → CI builds all
 	echo "$(CYAN)CI will now build macOS, Windows, and Linux.$(RESET)"; \
 	echo "$(CYAN)Watch progress: https://github.com/atilladeniz/Kubeli/actions$(RESET)"
 
-generate-changelog: ## Generate changelog using Claude Code CLI
-	@echo "$(CYAN)Generating changelog with Claude Code CLI...$(RESET)"
+generate-changelog: ## Generate changelog using Claude, Codex, or OpenCode CLI
+	@echo "$(CYAN)Generating changelog with AI CLI fallback (Claude → Codex → OpenCode)...$(RESET)"
 	@node scripts/generate-changelog.js
 	@if [ -f .release-notes.md ]; then \
 		echo "$(GREEN)✓ Changelog files updated$(RESET)"; \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .PHONY: dev web-dev tauri-dev
 .PHONY: build build-start web-build tauri-build build-universal dmg build-dmg build-universal-dmg build-all build-windows
 .PHONY: astro astro-build astro-public
-.PHONY: build-deploy release generate-changelog release-ai-dry-run release-changelog-dry-run release-manual-dry-run version-bump
+.PHONY: build-deploy release release-push generate-changelog release-ai-dry-run release-changelog-dry-run release-manual-dry-run version-bump
 .PHONY: lint format check rust-check rust-fmt rust-lint vet vet-install
 .PHONY: test test-watch test-all test-e2e test-coverage test-coverage-frontend test-coverage-rust rust-test
 .PHONY: clean clean-all install reinstall install-windows-build-deps deps update-deps
@@ -194,7 +194,41 @@ release: ## Release: version bump, changelog, commit, tag push → CI builds all
 	@echo ""
 	@$(MAKE) generate-changelog
 	@echo ""
+	@$(MAKE) release-push
+
+release-push: ## Review and publish an already prepared release (requires confirmation)
 	@VERSION=$$(node -e "console.log(require('./package.json').version)"); \
+	if [ ! -f .release-notes.md ]; then \
+		echo "$(YELLOW)Error: .release-notes.md not found. Run 'make generate-changelog' first.$(RESET)"; \
+		exit 1; \
+	fi; \
+	if git rev-parse --verify "refs/tags/v$$VERSION" >/dev/null 2>&1; then \
+		echo "$(YELLOW)Error: tag v$$VERSION already exists.$(RESET)"; \
+		exit 1; \
+	fi; \
+	echo "$(CYAN)Release v$$VERSION is prepared for review.$(RESET)"; \
+	echo ""; \
+	echo "$(CYAN)Changed release files:$(RESET)"; \
+	git --no-pager diff --stat -- package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json src-tauri/gen/schemas/ CHANGELOG.md web/src/data/changelog.md .release-notes.md; \
+	echo ""; \
+	echo "$(CYAN)GitHub release notes preview:$(RESET)"; \
+	echo "$(YELLOW)----------------------------------------$(RESET)"; \
+	cat .release-notes.md; \
+	echo ""; \
+	echo "$(YELLOW)----------------------------------------$(RESET)"; \
+	echo "$(CYAN)Review or edit the files now. Nothing has been committed or pushed yet.$(RESET)"; \
+	printf "$(YELLOW)Press Enter to commit and push, or type anything to abort: $(RESET)"; \
+	if ! IFS= read -r approval; then \
+		echo ""; \
+		echo "$(YELLOW)No interactive confirmation received. Release aborted.$(RESET)"; \
+		exit 1; \
+	fi; \
+	if [ -n "$$approval" ]; then \
+		echo "$(YELLOW)Release aborted. Prepared files were left unchanged.$(RESET)"; \
+		echo "$(CYAN)After reviewing them, run 'make release-push' to continue.$(RESET)"; \
+		exit 1; \
+	fi; \
+	echo ""; \
 	echo "$(CYAN)Committing release...$(RESET)"; \
 	git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json src-tauri/gen/schemas/ CHANGELOG.md web/src/data/changelog.md .release-notes.md; \
 	git commit -m "chore(release): bump version to $$VERSION and update changelog"; \

--- a/scripts/__tests__/generate-changelog.test.js
+++ b/scripts/__tests__/generate-changelog.test.js
@@ -99,6 +99,18 @@ describe('generateWithAiFallback', () => {
     expect(extractMarkdownBullets('Usage limit reached')).toBe('');
     expect(extractMarkdownBullets('Here you go:\n- Added a feature\nThanks')).toBe('- Added a feature');
   });
+
+  it('joins indented continuation lines from pasted chat output', () => {
+    const pasted = `  - Fixed memory leaks, race conditions, and error handling in the
+    frontend
+  - Virtualized resource tables, log viewers, and AI chat components to improve
+    rendering efficiency`;
+
+    expect(extractMarkdownBullets(pasted)).toBe(
+      '- Fixed memory leaks, race conditions, and error handling in the frontend\n' +
+      '- Virtualized resource tables, log viewers, and AI chat components to improve rendering efficiency'
+    );
+  });
 });
 
 describe('dryRunProviders', () => {

--- a/scripts/__tests__/generate-changelog.test.js
+++ b/scripts/__tests__/generate-changelog.test.js
@@ -3,6 +3,7 @@
 const {
   MANUAL_PROMPT_PATH,
   buildChangelogPrompt,
+  dryRunProviders,
   extractMarkdownBullets,
   generateWithAiFallback,
   readPastedResponse,
@@ -95,6 +96,60 @@ describe('generateWithAiFallback', () => {
   it('rejects non-bullet output so limit messages trigger fallback', () => {
     expect(extractMarkdownBullets('Usage limit reached')).toBe('');
     expect(extractMarkdownBullets('Here you go:\n- Added a feature\nThanks')).toBe('- Added a feature');
+  });
+});
+
+describe('dryRunProviders', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('checks all providers independently with their production parsers', () => {
+    const spawn = jest.fn(command => {
+      if (command === 'claude') return result({ stdout: '- Claude provider OK' });
+      if (command === 'codex') {
+        return result({
+          stdout: JSON.stringify({
+            type: 'item.completed',
+            item: { type: 'agent_message', text: '- Codex provider OK' }
+          })
+        });
+      }
+      return result({
+        stdout: JSON.stringify({
+          type: 'text',
+          part: { text: '- OpenCode provider OK' }
+        })
+      });
+    });
+
+    expect(dryRunProviders('', spawn)).toEqual([
+      { id: 'claude', passed: true },
+      { id: 'codex', passed: true },
+      { id: 'opencode', passed: true }
+    ]);
+    expect(spawn.mock.calls.map(call => call[0])).toEqual(['claude', 'codex', 'opencode']);
+  });
+
+  it('can test one provider and rejects unknown provider names', () => {
+    const spawn = jest.fn().mockReturnValue(result({
+      stdout: JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: '- Codex provider OK' }
+      })
+    }));
+
+    expect(dryRunProviders('codex', spawn)).toEqual([{ id: 'codex', passed: true }]);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(() => dryRunProviders('unknown', spawn)).toThrow(
+      'Unknown provider "unknown". Use claude, codex, or opencode.'
+    );
   });
 });
 

--- a/scripts/__tests__/generate-changelog.test.js
+++ b/scripts/__tests__/generate-changelog.test.js
@@ -1,0 +1,136 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global afterEach, beforeEach, describe, expect, it, jest */
+const {
+  MANUAL_PROMPT_PATH,
+  buildChangelogPrompt,
+  extractMarkdownBullets,
+  generateWithAiFallback,
+  readPastedResponse,
+  requestManualChangelog
+} = require('../generate-changelog');
+const { PassThrough } = require('stream');
+
+function result({ status = 0, stdout = '', error } = {}) {
+  return { status, stdout, stderr: '', error };
+}
+
+describe('generateWithAiFallback', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('uses Codex when Claude fails, including limit-related failures', () => {
+    const spawn = jest
+      .fn()
+      .mockReturnValueOnce(result({ status: 1, stdout: 'Usage limit reached' }))
+      .mockReturnValueOnce(result({
+        stdout: JSON.stringify({
+          type: 'item.completed',
+          item: { type: 'agent_message', text: '- Added Codex fallback' }
+        })
+      }));
+
+    const generated = generateWithAiFallback('prompt', spawn);
+
+    expect(generated).toEqual({
+      changelogItems: '- Added Codex fallback',
+      provider: 'Codex'
+    });
+    expect(spawn.mock.calls.map(call => call[0])).toEqual(['claude', 'codex']);
+  });
+
+  it('uses OpenCode when Claude and Codex fail', () => {
+    const spawn = jest
+      .fn()
+      .mockReturnValueOnce(result({ status: 1 }))
+      .mockReturnValueOnce(result({ status: 1 }))
+      .mockReturnValueOnce(result({
+        stdout: JSON.stringify({ type: 'text', part: { text: '- Fixed release generation' } })
+      }));
+
+    const generated = generateWithAiFallback('prompt', spawn);
+
+    expect(generated.provider).toBe('OpenCode');
+    expect(generated.changelogItems).toBe('- Fixed release generation');
+    expect(spawn.mock.calls.map(call => call[0])).toEqual(['claude', 'codex', 'opencode']);
+  });
+
+  it('stops after the first valid provider response', () => {
+    const spawn = jest.fn().mockReturnValue(result({ stdout: '- Added a feature' }));
+
+    expect(generateWithAiFallback('prompt', spawn).provider).toBe('Claude Code');
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects non-bullet output so limit messages trigger fallback', () => {
+    expect(extractMarkdownBullets('Usage limit reached')).toBe('');
+    expect(extractMarkdownBullets('Here you go:\n- Added a feature\nThanks')).toBe('- Added a feature');
+  });
+});
+
+describe('manual changelog fallback', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('creates an LLM-friendly Markdown prompt', () => {
+    const prompt = buildChangelogPrompt('1.2.3', 'abc123 Added release fallback');
+
+    expect(prompt).toContain('# Task: Generate the Kubeli changelog for version 1.2.3');
+    expect(prompt).toContain('```text\nabc123 Added release fallback\n```');
+    expect(prompt).toContain('Return only the Markdown bullet points');
+  });
+
+  it('writes the prompt and accepts a pasted multi-line response', async () => {
+    const writeFile = jest.fn();
+    const readResponse = jest.fn().mockResolvedValue(
+      'Here is the changelog:\n- Added manual AI fallback\n- Fixed release flow'
+    );
+
+    const changelogItems = await requestManualChangelog('prompt contents', {
+      interactive: true,
+      readResponse,
+      writeFile
+    });
+
+    expect(writeFile).toHaveBeenCalledWith(MANUAL_PROMPT_PATH, 'prompt contents');
+    expect(changelogItems).toBe('- Added manual AI fallback\n- Fixed release flow');
+  });
+
+  it('reads pasted terminal lines until the END marker', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const responsePromise = readPastedResponse(input, output);
+
+    input.end('- Added terminal fallback\n- Fixed formatting\nEND\nignored');
+
+    await expect(responsePromise).resolves.toBe(
+      '- Added terminal fallback\n- Fixed formatting'
+    );
+  });
+
+  it('writes the prompt but does not wait without an interactive terminal', async () => {
+    const writeFile = jest.fn();
+    const readResponse = jest.fn();
+
+    await expect(requestManualChangelog('prompt contents', {
+      interactive: false,
+      readResponse,
+      writeFile
+    })).resolves.toBe('');
+    expect(writeFile).toHaveBeenCalledWith(MANUAL_PROMPT_PATH, 'prompt contents');
+    expect(readResponse).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/__tests__/generate-changelog.test.js
+++ b/scripts/__tests__/generate-changelog.test.js
@@ -66,6 +66,30 @@ describe('generateWithAiFallback', () => {
 
     expect(generateWithAiFallback('prompt', spawn).provider).toBe('Claude Code');
     expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0][1]).toEqual([
+      '--print',
+      '--no-session-persistence',
+      '--disable-slash-commands',
+      '--tools',
+      ''
+    ]);
+  });
+
+  it('denies all OpenCode tools through its inline runtime config', () => {
+    const spawn = jest
+      .fn()
+      .mockReturnValueOnce(result({ status: 1 }))
+      .mockReturnValueOnce(result({ status: 1 }))
+      .mockReturnValueOnce(result({
+        stdout: JSON.stringify({ type: 'text', part: { text: '- Added safe fallback' } })
+      }));
+
+    generateWithAiFallback('prompt', spawn);
+
+    const openCodeOptions = spawn.mock.calls[2][2];
+    expect(JSON.parse(openCodeOptions.env.OPENCODE_CONFIG_CONTENT)).toEqual({
+      permission: { '*': 'deny' }
+    });
   });
 
   it('rejects non-bullet output so limit messages trigger fallback', () => {

--- a/scripts/__tests__/generate-changelog.test.js
+++ b/scripts/__tests__/generate-changelog.test.js
@@ -68,11 +68,11 @@ describe('generateWithAiFallback', () => {
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(spawn.mock.calls[0][1]).toEqual([
       '--print',
-      '--no-session-persistence',
       '--disable-slash-commands',
       '--tools',
       ''
     ]);
+    expect(spawn.mock.calls[0][2].env.CLAUDE_CODE_SKIP_PROMPT_HISTORY).toBe('1');
   });
 
   it('denies all OpenCode tools through its inline runtime config', () => {

--- a/scripts/__tests__/generate-changelog.test.js
+++ b/scripts/__tests__/generate-changelog.test.js
@@ -202,6 +202,9 @@ describe('manual changelog fallback', () => {
     expect(prompt).toContain('# Task: Generate the Kubeli changelog for version 1.2.3');
     expect(prompt).toContain('```text\nabc123 Added release fallback\n```');
     expect(prompt).toContain('Return only the Markdown bullet points');
+    expect(prompt).toContain('Never wrap or continue a bullet on the next line');
+    expect(prompt).toContain('Do not infer or invent features');
+    expect(prompt).toContain('Start every bullet at column 1');
   });
 
   it('writes the prompt and accepts a pasted multi-line response', async () => {

--- a/scripts/__tests__/generate-changelog.test.js
+++ b/scripts/__tests__/generate-changelog.test.js
@@ -3,6 +3,8 @@
 const {
   MANUAL_PROMPT_PATH,
   buildChangelogPrompt,
+  dryRunFallback,
+  dryRunManualFallback,
   dryRunProviders,
   extractMarkdownBullets,
   generateWithAiFallback,
@@ -104,6 +106,24 @@ describe('dryRunProviders', () => {
 
   beforeEach(() => {
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('tests the real fallback chain without requiring every provider to pass', () => {
+    const spawn = jest
+      .fn()
+      .mockReturnValueOnce(result({ status: 1 }))
+      .mockReturnValueOnce(result({
+        stdout: JSON.stringify({
+          type: 'item.completed',
+          item: { type: 'agent_message', text: '- Release fallback OK' }
+        })
+      }));
+
+    expect(dryRunFallback(spawn)).toEqual({
+      changelogItems: '- Release fallback OK',
+      provider: 'Codex'
+    });
+    expect(spawn.mock.calls.map(call => call[0])).toEqual(['claude', 'codex']);
   });
 
   afterEach(() => {
@@ -211,5 +231,17 @@ describe('manual changelog fallback', () => {
     })).resolves.toBe('');
     expect(writeFile).toHaveBeenCalledWith(MANUAL_PROMPT_PATH, 'prompt contents');
     expect(readResponse).not.toHaveBeenCalled();
+  });
+
+  it('dry-runs the copy and paste flow without updating changelog files', async () => {
+    const writeFile = jest.fn();
+    const readResponse = jest.fn().mockResolvedValue('- Added pasted changelog entry');
+
+    await expect(dryRunManualFallback({
+      interactive: true,
+      readResponse,
+      writeFile
+    })).resolves.toBe('- Added pasted changelog entry');
+    expect(writeFile.mock.calls[0][0]).toBe(MANUAL_PROMPT_PATH);
   });
 });

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -134,7 +134,13 @@ const CHANGELOG_PROVIDERS = [
   {
     name: 'Claude Code',
     command: 'claude',
-    args: ['--print'],
+    args: [
+      '--print',
+      '--no-session-persistence',
+      '--disable-slash-commands',
+      '--tools',
+      ''
+    ],
     useStdin: true,
     parse: output => output
   },
@@ -154,6 +160,9 @@ const CHANGELOG_PROVIDERS = [
     name: 'OpenCode',
     command: 'opencode',
     args: prompt => ['run', '--pure', '--format', 'json', '--dir', os.tmpdir(), prompt],
+    env: {
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({ permission: { '*': 'deny' } })
+    },
     useStdin: false,
     parse: output =>
       parseJsonLines(output, event =>
@@ -178,7 +187,8 @@ function generateWithAiFallback(prompt, spawn = spawnSync) {
     const result = spawn(provider.command, args, {
       input: provider.useStdin ? prompt : undefined,
       encoding: 'utf8',
-      timeout: 60000
+      timeout: 60000,
+      env: provider.env ? { ...process.env, ...provider.env } : process.env
     });
     const parsedOutput = result.status === 0
       ? provider.parse(result.stdout?.trim() || '')

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -58,14 +58,16 @@ ${commits}
 
 1. Group related changes together.
 2. Use past tense (Added, Fixed, Updated, etc.).
-3. Keep every item to a maximum of one line.
+3. Put each bullet on exactly one physical line. Never wrap or continue a bullet on the next line.
 4. Focus on user-facing changes.
 5. Skip merge commits and version bumps.
-6. Format every item as a Markdown bullet beginning with \`- \`.
+6. Include only changes supported by the supplied commits. Do not infer or invent features.
+7. Start every bullet at column 1 with \`- \`. Do not indent bullets.
+8. Keep wording concise and combine closely related implementation details.
 
 ## Output contract
 
-Return only the Markdown bullet points. Do not add a heading, explanation, greeting, or code fence.
+Return only the Markdown bullet points. Do not add a heading, explanation, greeting, code fence, blank line between bullets, or trailing commentary. Every bullet must remain on one physical line even if it is long.
 
 Example:
 

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -136,11 +136,13 @@ const CHANGELOG_PROVIDERS = [
     command: 'claude',
     args: [
       '--print',
-      '--no-session-persistence',
       '--disable-slash-commands',
       '--tools',
       ''
     ],
+    env: {
+      CLAUDE_CODE_SKIP_PROMPT_HISTORY: '1'
+    },
     useStdin: true,
     parse: output => output
   },

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -252,6 +252,35 @@ function dryRunProviders(providerId = '', spawn = spawnSync) {
   return results;
 }
 
+function dryRunFallback(spawn = spawnSync) {
+  const prompt = 'Return exactly this Markdown bullet and nothing else: - Release fallback OK';
+  console.log('No release or changelog files will be changed.\n');
+  const generated = generateWithAiFallback(prompt, spawn);
+
+  if (!generated.changelogItems) {
+    throw new Error('No AI provider completed the fallback dry run.');
+  }
+
+  log(GREEN, `Fallback dry run passed with ${generated.provider}.`);
+  return generated;
+}
+
+async function dryRunManualFallback(options = {}) {
+  const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  const commits = exec('git log --oneline --no-merges -20');
+  const prompt = buildChangelogPrompt(packageJson.version, commits || 'No commits available');
+
+  console.log('No release or changelog files will be changed.\n');
+  const changelogItems = await requestManualChangelog(prompt, options);
+  if (!changelogItems) {
+    throw new Error('Manual changelog dry run did not receive valid Markdown bullet points.');
+  }
+
+  log(GREEN, 'Manual changelog dry run passed:');
+  console.log(changelogItems);
+  return changelogItems;
+}
+
 async function main() {
   const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
   const version = packageJson.version;
@@ -357,15 +386,22 @@ ${changelogItems}
 }
 
 if (require.main === module) {
-  const command = process.argv.includes('--dry-run')
-    ? Promise.resolve().then(() => {
+  let command;
+  if (process.argv.includes('--dry-run')) {
+    command = Promise.resolve().then(() => {
       const results = dryRunProviders(process.env.PROVIDER || '');
       if (results.some(result => !result.passed)) {
         throw new Error('One or more AI provider checks failed.');
       }
       log(GREEN, 'All selected AI provider checks passed.');
-    })
-    : main();
+    });
+  } else if (process.argv.includes('--fallback-dry-run')) {
+    command = Promise.resolve().then(() => dryRunFallback());
+  } else if (process.argv.includes('--manual-dry-run')) {
+    command = dryRunManualFallback();
+  } else {
+    command = main();
+  }
 
   command.catch(error => {
     console.error(error);
@@ -377,6 +413,8 @@ module.exports = {
   CHANGELOG_PROVIDERS,
   MANUAL_PROMPT_PATH,
   buildChangelogPrompt,
+  dryRunFallback,
+  dryRunManualFallback,
   dryRunProviders,
   extractMarkdownBullets,
   generateWithAiFallback,

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -29,11 +29,18 @@ function exec(cmd) {
 }
 
 function extractMarkdownBullets(output) {
-  return output
-    .split('\n')
-    .map(line => line.trim())
-    .filter(line => /^-\s+\S/.test(line))
-    .join('\n');
+  const bullets = [];
+
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (/^-\s+\S/.test(trimmed)) {
+      bullets.push(trimmed);
+    } else if (bullets.length > 0 && /^\s+\S/.test(line)) {
+      bullets[bullets.length - 1] += ` ${trimmed}`;
+    }
+  }
+
+  return bullets.join('\n');
 }
 
 function buildChangelogPrompt(version, commits) {

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -132,6 +132,7 @@ function parseJsonLines(output, getText) {
 
 const CHANGELOG_PROVIDERS = [
   {
+    id: 'claude',
     name: 'Claude Code',
     command: 'claude',
     args: [
@@ -147,6 +148,7 @@ const CHANGELOG_PROVIDERS = [
     parse: output => output
   },
   {
+    id: 'codex',
     name: 'Codex',
     command: 'codex',
     args: ['exec', '--json', '--sandbox', 'read-only', '--skip-git-repo-check', '--ephemeral', '-'],
@@ -159,6 +161,7 @@ const CHANGELOG_PROVIDERS = [
       )
   },
   {
+    id: 'opencode',
     name: 'OpenCode',
     command: 'opencode',
     args: prompt => ['run', '--pure', '--format', 'json', '--dir', os.tmpdir(), prompt],
@@ -181,21 +184,29 @@ function failureReason(result) {
   return 'returned no valid changelog items';
 }
 
+function invokeProvider(provider, prompt, spawn = spawnSync) {
+  const args = typeof provider.args === 'function' ? provider.args(prompt) : provider.args;
+  const result = spawn(provider.command, args, {
+    input: provider.useStdin ? prompt : undefined,
+    encoding: 'utf8',
+    timeout: 60000,
+    env: provider.env ? { ...process.env, ...provider.env } : process.env
+  });
+  const parsedOutput = result.status === 0
+    ? provider.parse(result.stdout?.trim() || '')
+    : '';
+
+  return {
+    changelogItems: extractMarkdownBullets(parsedOutput),
+    result
+  };
+}
+
 function generateWithAiFallback(prompt, spawn = spawnSync) {
   for (const provider of CHANGELOG_PROVIDERS) {
     log(CYAN, `Calling ${provider.name} CLI...`);
 
-    const args = typeof provider.args === 'function' ? provider.args(prompt) : provider.args;
-    const result = spawn(provider.command, args, {
-      input: provider.useStdin ? prompt : undefined,
-      encoding: 'utf8',
-      timeout: 60000,
-      env: provider.env ? { ...process.env, ...provider.env } : process.env
-    });
-    const parsedOutput = result.status === 0
-      ? provider.parse(result.stdout?.trim() || '')
-      : '';
-    const changelogItems = extractMarkdownBullets(parsedOutput);
+    const { changelogItems, result } = invokeProvider(provider, prompt, spawn);
 
     if (changelogItems) {
       log(GREEN, `Generated changelog with ${provider.name}.`);
@@ -206,6 +217,39 @@ function generateWithAiFallback(prompt, spawn = spawnSync) {
   }
 
   return { changelogItems: '', provider: null };
+}
+
+function dryRunProviders(providerId = '', spawn = spawnSync) {
+  const normalizedId = providerId.trim().toLowerCase();
+  const providers = normalizedId
+    ? CHANGELOG_PROVIDERS.filter(provider => provider.id === normalizedId)
+    : CHANGELOG_PROVIDERS;
+
+  if (providers.length === 0) {
+    throw new Error(
+      `Unknown provider "${providerId}". Use claude, codex, or opencode.`
+    );
+  }
+
+  log(CYAN, `Testing ${providers.map(provider => provider.name).join(', ')}...`);
+  console.log('No release or changelog files will be changed.\n');
+
+  const results = providers.map(provider => {
+    const prompt = `Return exactly this Markdown bullet and nothing else: - ${provider.name} provider OK`;
+    const invocation = invokeProvider(provider, prompt, spawn);
+    const passed = Boolean(invocation.changelogItems);
+
+    if (passed) {
+      log(GREEN, `✓ ${provider.name}: ${invocation.changelogItems}`);
+    } else {
+      log(YELLOW, `✗ ${provider.name}: ${failureReason(invocation.result)}`);
+    }
+
+    return { id: provider.id, passed };
+  });
+
+  console.log('');
+  return results;
 }
 
 async function main() {
@@ -313,7 +357,17 @@ ${changelogItems}
 }
 
 if (require.main === module) {
-  main().catch(error => {
+  const command = process.argv.includes('--dry-run')
+    ? Promise.resolve().then(() => {
+      const results = dryRunProviders(process.env.PROVIDER || '');
+      if (results.some(result => !result.passed)) {
+        throw new Error('One or more AI provider checks failed.');
+      }
+      log(GREEN, 'All selected AI provider checks passed.');
+    })
+    : main();
+
+  command.catch(error => {
     console.error(error);
     process.exitCode = 1;
   });
@@ -323,8 +377,10 @@ module.exports = {
   CHANGELOG_PROVIDERS,
   MANUAL_PROMPT_PATH,
   buildChangelogPrompt,
+  dryRunProviders,
   extractMarkdownBullets,
   generateWithAiFallback,
+  invokeProvider,
   parseJsonLines,
   readPastedResponse,
   requestManualChangelog

--- a/scripts/generate-changelog.js
+++ b/scripts/generate-changelog.js
@@ -1,17 +1,20 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-require-imports */
 /**
- * Generate changelog entries using Claude Code CLI
+ * Generate changelog entries using Claude, Codex, or OpenCode CLI
  * Analyzes commits since last release and updates all changelog files
  */
 
 const { execSync, spawnSync } = require('child_process');
 const fs = require('fs');
+const os = require('os');
+const readline = require('readline');
 
 const CYAN = '\x1b[36m';
 const GREEN = '\x1b[32m';
 const YELLOW = '\x1b[33m';
 const RESET = '\x1b[0m';
+const MANUAL_PROMPT_PATH = '.changelog-ai-prompt.md';
 
 function log(color, msg) {
   console.log(`${color}${msg}${RESET}`);
@@ -23,6 +26,174 @@ function exec(cmd) {
   } catch {
     return '';
   }
+}
+
+function extractMarkdownBullets(output) {
+  return output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => /^-\s+\S/.test(line))
+    .join('\n');
+}
+
+function buildChangelogPrompt(version, commits) {
+  return `# Task: Generate the Kubeli changelog for version ${version}
+
+Create a concise changelog from the git commits below.
+
+## Git commits
+
+\`\`\`text
+${commits}
+\`\`\`
+
+## Requirements
+
+1. Group related changes together.
+2. Use past tense (Added, Fixed, Updated, etc.).
+3. Keep every item to a maximum of one line.
+4. Focus on user-facing changes.
+5. Skip merge commits and version bumps.
+6. Format every item as a Markdown bullet beginning with \`- \`.
+
+## Output contract
+
+Return only the Markdown bullet points. Do not add a heading, explanation, greeting, or code fence.
+
+Example:
+
+- Added feature X for better Y
+- Fixed bug in Z component
+- Updated dependencies to their latest versions
+`;
+}
+
+function readPastedResponse(input = process.stdin, output = process.stdout) {
+  output.write('Paste the AI response below, then enter END on its own line:\n\n');
+
+  return new Promise(resolve => {
+    const lines = [];
+    const rl = readline.createInterface({ input, terminal: false });
+    let resolved = false;
+
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      resolve(lines.join('\n'));
+    };
+
+    rl.on('line', line => {
+      if (line.trim() === 'END') {
+        finish();
+        rl.close();
+        return;
+      }
+      lines.push(line);
+    });
+    rl.on('close', finish);
+  });
+}
+
+async function requestManualChangelog(prompt, options = {}) {
+  const {
+    interactive = process.stdin.isTTY,
+    readResponse = readPastedResponse,
+    writeFile = fs.writeFileSync
+  } = options;
+
+  writeFile(MANUAL_PROMPT_PATH, prompt);
+  log(YELLOW, `All AI CLIs failed. Manual prompt written to ${MANUAL_PROMPT_PATH}`);
+  console.log(`\nCopy the prompt into an AI chat (show it with: cat ${MANUAL_PROMPT_PATH}).`);
+
+  if (!interactive) return '';
+
+  const response = await readResponse();
+  const changelogItems = extractMarkdownBullets(response);
+  if (!changelogItems) {
+    log(YELLOW, 'The pasted response did not contain valid Markdown bullet points.');
+  }
+  return changelogItems;
+}
+
+function parseJsonLines(output, getText) {
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .flatMap(line => {
+      try {
+        const text = getText(JSON.parse(line));
+        return text ? [text] : [];
+      } catch {
+        return [];
+      }
+    })
+    .join('\n');
+}
+
+const CHANGELOG_PROVIDERS = [
+  {
+    name: 'Claude Code',
+    command: 'claude',
+    args: ['--print'],
+    useStdin: true,
+    parse: output => output
+  },
+  {
+    name: 'Codex',
+    command: 'codex',
+    args: ['exec', '--json', '--sandbox', 'read-only', '--skip-git-repo-check', '--ephemeral', '-'],
+    useStdin: true,
+    parse: output =>
+      parseJsonLines(output, event =>
+        event.type === 'item.completed' && event.item?.type === 'agent_message'
+          ? event.item.text
+          : ''
+      )
+  },
+  {
+    name: 'OpenCode',
+    command: 'opencode',
+    args: prompt => ['run', '--pure', '--format', 'json', '--dir', os.tmpdir(), prompt],
+    useStdin: false,
+    parse: output =>
+      parseJsonLines(output, event =>
+        event.type === 'text' ? event.part?.text : ''
+      )
+  }
+];
+
+function failureReason(result) {
+  if (result.error?.code === 'ETIMEDOUT') return 'timed out';
+  if (result.error?.code === 'ENOENT') return 'CLI not installed';
+  if (result.error) return result.error.message;
+  if (result.status !== 0) return `exited with status ${result.status}`;
+  return 'returned no valid changelog items';
+}
+
+function generateWithAiFallback(prompt, spawn = spawnSync) {
+  for (const provider of CHANGELOG_PROVIDERS) {
+    log(CYAN, `Calling ${provider.name} CLI...`);
+
+    const args = typeof provider.args === 'function' ? provider.args(prompt) : provider.args;
+    const result = spawn(provider.command, args, {
+      input: provider.useStdin ? prompt : undefined,
+      encoding: 'utf8',
+      timeout: 60000
+    });
+    const parsedOutput = result.status === 0
+      ? provider.parse(result.stdout?.trim() || '')
+      : '';
+    const changelogItems = extractMarkdownBullets(parsedOutput);
+
+    if (changelogItems) {
+      log(GREEN, `Generated changelog with ${provider.name}.`);
+      return { changelogItems, provider: provider.name };
+    }
+
+    log(YELLOW, `${provider.name} unavailable (${failureReason(result)}). Trying next provider...`);
+  }
+
+  return { changelogItems: '', provider: null };
 }
 
 async function main() {
@@ -51,46 +222,19 @@ async function main() {
   console.log(commits);
   console.log('');
 
-  // Create prompt for Claude
-  const prompt = `Analyze these git commits and generate a concise changelog entry for version ${version}.
+  // Create one portable prompt for both local CLIs and the manual chat fallback.
+  const prompt = buildChangelogPrompt(version, commits);
 
-Commits:
-${commits}
+  let { changelogItems } = generateWithAiFallback(prompt);
 
-Requirements:
-1. Group related changes together
-2. Use past tense (Added, Fixed, Updated, etc.)
-3. Be concise - max 1 line per item
-4. Focus on user-facing changes
-5. Skip merge commits and version bumps
-6. Format as markdown bullet points (- item)
-
-Output ONLY the bullet points, nothing else. Example format:
-- Added feature X for better Y
-- Fixed bug in Z component
-- Updated dependencies to latest versions`;
-
-  log(CYAN, 'Calling Claude Code CLI...');
-
-  // Call Claude Code CLI
-  let changelogItems;
-  try {
-    const result = spawnSync('claude', ['--print'], {
-      input: prompt,
-      encoding: 'utf8',
-      timeout: 60000
-    });
-    changelogItems = result.stdout?.trim();
-  } catch {
-    changelogItems = '';
+  if (!changelogItems) {
+    changelogItems = await requestManualChangelog(prompt);
   }
 
   if (!changelogItems) {
-    log(YELLOW, 'Claude CLI not available or no output. Using commit summary.');
-    changelogItems = commits
-      .split('\n')
-      .map(line => `- ${line.replace(/^[a-f0-9]+ /, '')}`)
-      .join('\n');
+    throw new Error(
+      `Changelog generation stopped. Use ${MANUAL_PROMPT_PATH} in an AI chat, then rerun make release.`
+    );
   }
 
   log(GREEN, 'Generated changelog:');
@@ -156,4 +300,20 @@ ${changelogItems}
   log(GREEN, 'Release notes written to .release-notes.md');
 }
 
-main().catch(console.error);
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  CHANGELOG_PROVIDERS,
+  MANUAL_PROMPT_PATH,
+  buildChangelogPrompt,
+  extractMarkdownBullets,
+  generateWithAiFallback,
+  parseJsonLines,
+  readPastedResponse,
+  requestManualChangelog
+};


### PR DESCRIPTION
## Why

`make release` previously depended on Claude for its changelog. If Claude was unavailable, out of usage, or returned an empty response, the script dropped straight back to commit subjects. That made release notes noticeably worse whenever one provider had a bad day.

This change lets the release continue with another installed CLI. If none of them works, it gives the maintainer a copyable prompt and waits for the answer instead of quietly publishing raw commit messages.

## What changed

The changelog generator now tries providers in this order:

1. Claude Code
2. Codex
3. OpenCode

A response is accepted only when the command exits successfully and contains Markdown bullet points. Timeouts, missing commands, non-zero exit codes, limit messages, empty output, and malformed responses all move on to the next provider.

Claude runs without tools or slash commands and skips prompt-history persistence. Codex uses a read-only sandbox and an ephemeral session. OpenCode uses JSON output, pure mode, a temporary working directory, and an inline permission rule that denies every tool. All three providers receive the same self-contained prompt.

## Provider dry run

`make release-ai-dry-run` calls all three providers independently with a one-line test prompt. It uses the same arguments and output parsers as the release path but does not read or write release files. A single provider can be checked with `make release-ai-dry-run PROVIDER=claude`, `PROVIDER=codex`, or `PROVIDER=opencode`. The command exits non-zero if any selected provider fails.

`make release-changelog-dry-run` tests the actual fallback order and succeeds as soon as one provider returns a valid changelog bullet. `make release-manual-dry-run` skips provider calls and exercises the Markdown prompt plus terminal paste workflow. Neither command changes version or changelog files.

## Manual fallback

If all three CLIs fail, the script writes `.changelog-ai-prompt.md`. The file contains the release version, relevant commits, formatting rules, and an explicit output contract, so it can be pasted into any AI chat without extra context. It requires bullets to start at column 1, stay on one physical line, and avoid claims not supported by the supplied commits. The parser still joins indented continuation lines when a chat wraps them anyway.

For an interactive `make release`, the terminal then waits for the generated bullet points. The maintainer pastes the response and enters `END` on its own line. The script strips surrounding chat text, validates the bullets, and continues with the normal changelog and release-note updates.

In a non-interactive shell, the prompt file is still created but the release stops with an error. This avoids publishing an unreviewed commit dump from CI or another unattended process. The generated prompt file is ignored by Git.

## Confirmation before publishing

After the version and changelog are prepared, `make release` now shows the changed release files and a preview of `.release-notes.md`. It does not commit, push, or create a tag until the maintainer presses Enter. Any other input, or a missing interactive terminal, aborts safely and leaves the prepared files untouched. After reviewing or editing them, `make release-push` reopens the same preview and confirmation without bumping the version again.

## Documentation

The Make target descriptions and `CLAUDE.md` now document the provider order, dry runs, and manual handoff. `make help` preserves the Makefile's section order and prints targets under descriptive headings instead of flattening everything into one alphabetical list. The `.PHONY` declarations are split into the same functional groups.

## Checks

- `npm test -- --runInBand scripts/__tests__/generate-changelog.test.js`
- `npx eslint scripts/generate-changelog.js scripts/__tests__/generate-changelog.test.js`
- `node --check scripts/generate-changelog.js`
- `make -n generate-changelog`
- `make -n release-ai-dry-run`
- `make -n release-changelog-dry-run`
- `make -n release-manual-dry-run`
- `make help`
- `git diff --check`

The test suite covers Claude limit failures, Codex and OpenCode selection, independent and chained provider dry runs, provider permission settings, invalid output, prompt generation, manual dry runs, wrapped Markdown bullet continuation lines, multi-line terminal input, the `END` marker, and non-interactive behavior.
