### PR TITLE
fix(portforward): scope OIDC-refresh restart to the refreshed cluster

### DIFF
--- a/src-tauri/src/commands/clusters/commands.rs
+++ b/src-tauri/src/commands/clusters/commands.rs
@@ -650,7 +650,10 @@ fn spawn_oidc_refresh_task(
                     drop(client_guard);
                     tracing::info!("OIDC token refreshed and kube client reinitialized");
                     use tauri::Emitter;
-                    let _ = app_handle.emit("oidc-token-refreshed", ());
+                    // Carry the refreshed context so the frontend restarts only
+                    // this cluster's forwards, not forwards that survived a
+                    // switch and belong to another cluster.
+                    let _ = app_handle.emit("oidc-token-refreshed", context_name.clone());
                 }
                 Err(e) => {
                     tracing::error!("Failed to create client after OIDC refresh: {}", e);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, lazy, Suspense } from "react";
 import { useClusterStore } from "@/lib/stores/cluster-store";
 import { usePortForwardStore } from "@/lib/stores/portforward-store";
+import { forwardsToRestartAfterRefresh } from "@/components/features/portforward/forwardsToRestartAfterRefresh";
 import { useUIStore } from "@/lib/stores/ui-store";
 import { applyProxyFromSettings } from "@/lib/tauri/commands/network";
 import { useKubeconfigWatcher } from "@/lib/hooks/useKubeconfigWatcher";
@@ -108,10 +109,12 @@ export default function Home() {
     let unlisten: (() => void) | undefined;
     let cancelled = false;
     import("@tauri-apps/api/event").then(({ listen }) => {
-      listen("oidc-token-refreshed", async () => {
+      listen<string>("oidc-token-refreshed", async (event) => {
+        const refreshedContext = event.payload;
         const pfStore = usePortForwardStore.getState();
-        const activeForwards = pfStore.forwards.filter((f) => f.status === "connected");
-        for (const fwd of activeForwards) {
+        // Scope to the refreshed cluster (see forwardsToRestartAfterRefresh).
+        const forwardsToRestart = forwardsToRestartAfterRefresh(pfStore.forwards, refreshedContext);
+        for (const fwd of forwardsToRestart) {
           // Per-forward try/catch so one failure doesn't strand the rest.
           try {
             await pfStore.stopForward(fwd.forward_id);

--- a/src/components/features/portforward/__tests__/forwardsToRestartAfterRefresh.test.ts
+++ b/src/components/features/portforward/__tests__/forwardsToRestartAfterRefresh.test.ts
@@ -1,0 +1,61 @@
+import { forwardsToRestartAfterRefresh } from "../forwardsToRestartAfterRefresh";
+import type { PortForwardInfo } from "@/lib/types";
+
+function fwd(overrides: Partial<PortForwardInfo>): PortForwardInfo {
+  return {
+    forward_id: "id",
+    cluster_context: "cluster-a",
+    namespace: "default",
+    name: "api",
+    target_type: "service",
+    target_port: 80,
+    local_port: 8080,
+    status: "connected",
+    ...overrides,
+  };
+}
+
+describe("forwardsToRestartAfterRefresh", () => {
+  it("restarts only forwards owned by the refreshed cluster", () => {
+    const forwards = [
+      fwd({ forward_id: "a", cluster_context: "cluster-a" }),
+      fwd({ forward_id: "b", cluster_context: "cluster-b" }),
+    ];
+
+    const result = forwardsToRestartAfterRefresh(forwards, "cluster-a");
+
+    expect(result.map((f) => f.forward_id)).toEqual(["a"]);
+  });
+
+  // Regression: a refresh on one cluster must not rebuild another cluster's
+  // forward that shares the same namespace/name. Without the cluster_context
+  // filter that forward would silently restart against the refreshed cluster's
+  // same-named service.
+  it("leaves a same-namespace/name forward in another cluster untouched", () => {
+    const forwards = [
+      fwd({ forward_id: "a", cluster_context: "cluster-a", namespace: "default", name: "api" }),
+      fwd({ forward_id: "b", cluster_context: "cluster-b", namespace: "default", name: "api" }),
+    ];
+
+    const result = forwardsToRestartAfterRefresh(forwards, "cluster-b");
+
+    expect(result.map((f) => f.forward_id)).toEqual(["b"]);
+  });
+
+  it("skips forwards that are not connected", () => {
+    const forwards = [
+      fwd({ forward_id: "a", cluster_context: "cluster-a", status: "reconnecting" }),
+      fwd({ forward_id: "b", cluster_context: "cluster-a", status: "connected" }),
+    ];
+
+    const result = forwardsToRestartAfterRefresh(forwards, "cluster-a");
+
+    expect(result.map((f) => f.forward_id)).toEqual(["b"]);
+  });
+
+  it("returns nothing when no forward belongs to the refreshed cluster", () => {
+    const forwards = [fwd({ forward_id: "a", cluster_context: "cluster-a" })];
+
+    expect(forwardsToRestartAfterRefresh(forwards, "cluster-b")).toEqual([]);
+  });
+});

--- a/src/components/features/portforward/forwardsToRestartAfterRefresh.ts
+++ b/src/components/features/portforward/forwardsToRestartAfterRefresh.ts
@@ -1,0 +1,21 @@
+import type { PortForwardInfo } from "@/lib/types";
+
+/**
+ * Pick the forwards to restart after an OIDC token refresh.
+ *
+ * Restart goes through `startForward`, which rebinds to the *active* cluster's
+ * client and re-tags the forward with the active context. So only the refreshed
+ * cluster's own connected forwards may be restarted. Restarting a forward that
+ * belongs to another cluster would repoint it at the active cluster — silently,
+ * if that cluster has a service with the same namespace/name, or as a failed
+ * restart otherwise. Since forwards now survive across clusters, scope the
+ * restart to the cluster that actually refreshed.
+ */
+export function forwardsToRestartAfterRefresh(
+  forwards: PortForwardInfo[],
+  refreshedContext: string,
+): PortForwardInfo[] {
+  return forwards.filter(
+    (f) => f.status === "connected" && f.cluster_context === refreshedContext,
+  );
+}


### PR DESCRIPTION
## Description

The oidc-token-refreshed handler restarted every connected forward via startForward, which rebinds to the active cluster. Now that forwards survive across clusters (#388), a refresh on the active cluster would rebuild another cluster's forward against the wrong cluster - silently if that cluster has a service with the same namespace/name, or as a failed restart otherwise.

Emit the refreshed context from the backend refresh task and restart only the forwards whose cluster_context matches it. Extract the selection into a pure forwardsToRestartAfterRefresh helper (feature folder) with a regression test

## Related Issue

Follow-up to #389 (which closes #388).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

N/A — no visual changes.

## Testing

- Added `forwardsToRestartAfterRefresh.test.ts`, including the regression case
  where a same-namespace/name forward in another cluster must be left untouched.
- Full suite green locally: 647 jest, 280 cargo, typecheck, eslint, cargo fmt,
  clippy.
- Verified in dev mode that forwards survive a cluster switch and a full
  disconnect (across two clusters). The OIDC refresh fires on a timer (~3/4 of
  token lifetime), so the scoping is covered by the unit test rather than a live
  token-refresh repro.

- [x] Tested on macOS (MacOs Tahoe V 26.5.1)
- [ ] Tested with Kubernetes cluster (provider: )

