### PR TITLE
fix(flux): resume suspended resources before reconciling

### DIFF
--- a/src/components/features/dashboard/views/gitops/FluxKustomizationsView.tsx
+++ b/src/components/features/dashboard/views/gitops/FluxKustomizationsView.tsx
@@ -41,12 +41,19 @@ export function FluxKustomizationsView() {
     },
     { separator: true, label: "", onClick: () => {} },
     {
-      label: "Reconcile",
+      label: k.suspended ? "Resume & Reconcile" : "Reconcile",
       icon: <RefreshCw className="size-4" />,
       onClick: async () => {
         try {
+          // Flux ignores reconcile requests while suspended, so resume first
+          if (k.suspended) {
+            await resumeFluxKustomization(k.name, k.namespace);
+          }
           await reconcileFluxKustomization(k.name, k.namespace);
-          toast.success("Reconciliation triggered", { description: k.name });
+          toast.success(
+            k.suspended ? "Resumed, reconciliation triggered" : "Reconciliation triggered",
+            { description: k.name }
+          );
           refresh();
         } catch (e) {
           toast.error("Failed to trigger reconciliation", { description: String(e) });

--- a/src/components/features/dashboard/views/gitops/HelmReleasesView.tsx
+++ b/src/components/features/dashboard/views/gitops/HelmReleasesView.tsx
@@ -52,12 +52,19 @@ export function HelmReleasesView() {
     if (release.managed_by === "flux") {
       items.push({ separator: true, label: "", onClick: () => {} });
       items.push({
-        label: "Reconcile",
+        label: release.suspended ? "Resume & Reconcile" : "Reconcile",
         icon: <RefreshCw className="size-4" />,
         onClick: async () => {
           try {
+            // Flux ignores reconcile requests while suspended, so resume first
+            if (release.suspended) {
+              await resumeFluxHelmRelease(release.name, release.namespace);
+            }
             await reconcileFluxHelmRelease(release.name, release.namespace);
-            toast.success("Reconciliation triggered", { description: release.name });
+            toast.success(
+              release.suspended ? "Resumed, reconciliation triggered" : "Reconciliation triggered",
+              { description: release.name }
+            );
             refresh();
           } catch (e) {
             toast.error("Failed to trigger reconciliation", { description: String(e) });

--- a/src/components/features/dashboard/views/gitops/__tests__/FluxKustomizationsView.test.tsx
+++ b/src/components/features/dashboard/views/gitops/__tests__/FluxKustomizationsView.test.tsx
@@ -1,0 +1,104 @@
+import { render, waitFor } from "@testing-library/react";
+import { FluxKustomizationsView } from "../FluxKustomizationsView";
+import {
+  reconcileFluxKustomization,
+  resumeFluxKustomization,
+} from "@/lib/tauri/commands";
+import type { ContextMenuItemDef } from "../../../../resources/columns";
+import type { FluxKustomizationInfo } from "@/lib/types";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("@/lib/hooks/useRefreshOnDelete", () => ({
+  useRefreshOnDelete: jest.fn(),
+}));
+
+jest.mock("../../../context", () => ({
+  useResourceDetail: () => ({
+    openResourceDetail: jest.fn(),
+    handleDeleteFromContext: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/tauri/commands", () => ({
+  reconcileFluxKustomization: jest.fn(),
+  suspendFluxKustomization: jest.fn(),
+  resumeFluxKustomization: jest.fn(),
+}));
+
+const makeKustomization = (suspended: boolean): FluxKustomizationInfo => ({
+  name: "apps",
+  namespace: "flux-system",
+  path: "./apps",
+  source_ref: "GitRepository/flux-system/flux-system",
+  interval: "10m",
+  status: "ready",
+  suspended,
+  message: null,
+  last_applied_revision: null,
+  created_at: null,
+});
+
+let mockData: FluxKustomizationInfo[] = [];
+jest.mock("@/lib/hooks/useK8sResources", () => ({
+  useFluxKustomizations: () => ({
+    data: mockData,
+    isLoading: false,
+    error: null,
+    refresh: jest.fn(),
+    retry: jest.fn(),
+  }),
+}));
+
+let capturedContextMenuItems:
+  | ((k: FluxKustomizationInfo) => ContextMenuItemDef[])
+  | undefined;
+jest.mock("../../../../resources/ResourceList", () => ({
+  ResourceList: (props: {
+    contextMenuItems?: (k: FluxKustomizationInfo) => ContextMenuItemDef[];
+  }) => {
+    capturedContextMenuItems = props.contextMenuItems;
+    return null;
+  },
+}));
+
+const menuFor = (suspended: boolean) => {
+  mockData = [makeKustomization(suspended)];
+  render(<FluxKustomizationsView />);
+  return capturedContextMenuItems!(mockData[0]);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("FluxKustomizationsView reconcile action", () => {
+  it("resumes before reconciling a suspended kustomization", async () => {
+    const item = menuFor(true).find((i) => i.label === "Resume & Reconcile")!;
+    expect(item.disabled).toBeFalsy();
+
+    item.onClick();
+    await waitFor(() =>
+      expect(reconcileFluxKustomization).toHaveBeenCalledWith("apps", "flux-system")
+    );
+    expect(resumeFluxKustomization).toHaveBeenCalledWith("apps", "flux-system");
+    // Resume must run first — Flux ignores reconcile requests while suspended
+    expect(
+      (resumeFluxKustomization as jest.Mock).mock.invocationCallOrder[0]
+    ).toBeLessThan(
+      (reconcileFluxKustomization as jest.Mock).mock.invocationCallOrder[0]
+    );
+  });
+
+  it("reconciles directly when not suspended", async () => {
+    const item = menuFor(false).find((i) => i.label === "Reconcile")!;
+
+    item.onClick();
+    await waitFor(() =>
+      expect(reconcileFluxKustomization).toHaveBeenCalledWith("apps", "flux-system")
+    );
+    expect(resumeFluxKustomization).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Flux ignores `reconcile.fluxcd.io/requestedAt` on suspended resources. The context menu still offered **Reconcile** for suspended Kustomizations and HelmReleases, showing a success toast ("Reconciliation triggered") while nothing happened — a silent no-op. The `flux` CLI refuses this case with "resource is suspended".

## Fix

For suspended resources the action is labeled **Resume & Reconcile** and resumes the resource (`spec.suspend: false`) before patching the reconcile annotation, so the reconcile actually runs. Non-suspended resources behave as before. Applied to both:

- `FluxKustomizationsView`
- `HelmReleasesView` (Flux-managed releases, same pattern)

## Regression test

`FluxKustomizationsView.test.tsx` asserts that for a suspended Kustomization resume is called before reconcile, and that a non-suspended one reconciles without touching `spec.suspend`.

Jest, `tsc --noEmit` and ESLint pass.