### PR TITLE
ci: pin sccache version and rename SignPath upload artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: "v0.16.0"
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -241,6 +243,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: "v0.16.0"
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -230,7 +230,7 @@ jobs:
         id: upload-unsigned
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: windows-unsigned
+          name: windows-to-sign
           path: to-sign/
 
       - name: Submit signing request to SignPath


### PR DESCRIPTION
Fixes #316, fixes #338.

## Changes

**Pin sccache to v0.16.0** (`ci.yml`, both backend jobs): without a pinned `version:`, mozilla-actions/sccache-action queries the GitHub API for the latest sccache release on every run and intermittently fails with `HttpError: Bad credentials` — the flake documented in #316. With the version pinned the API call is skipped entirely. v0.16.0 is the current latest release.

**Rename SignPath upload artifact** `windows-unsigned` → `windows-to-sign` (`publish.yml`): SignPath names its signed output zip after the input artifact, so the signed container showed up as `windows-unsigned.zip` in the portal (#338). The submit step references the artifact by `artifact-id`, and the SignPath artifact configuration matches files at the zip root without referencing the zip name — verified against the live config — so no portal change is needed and nothing else in the workflow is affected.

## Testing

- CI on this PR exercises the sccache pin directly (both backend jobs).
- The publish path only runs on a release tag; the rename is a label-only change with the artifact referenced by id.