### PR TITLE
fix(settings): apply default namespace setting on cluster connect

### DIFF
--- a/src/lib/stores/__tests__/cluster-store.test.ts
+++ b/src/lib/stores/__tests__/cluster-store.test.ts
@@ -257,6 +257,33 @@ describe("ClusterStore", () => {
 
       expect(useClusterStore.getState().selectedNamespaces).toEqual([]);
     });
+
+    it("falls back to all namespaces when the cluster lacks the default", async () => {
+      useUIStore.setState({
+        settings: { ...defaultSettings, defaultNamespace: "ghost" },
+      });
+
+      await act(async () => {
+        await useClusterStore.getState().connect("test-context");
+      });
+
+      // "ghost" isn't in the fetched namespace list — views would be silently empty
+      expect(useClusterStore.getState().selectedNamespaces).toEqual([]);
+    });
+
+    it("keeps the default when the namespace list is unknown", async () => {
+      useUIStore.setState({
+        settings: { ...defaultSettings, defaultNamespace: "restricted-ns" },
+      });
+      mockGetNamespaces.mockResolvedValue({ namespaces: [], source: "none" });
+
+      await act(async () => {
+        await useClusterStore.getState().connect("test-context");
+      });
+
+      // Without list permissions we can't validate — trust the user's setting
+      expect(useClusterStore.getState().selectedNamespaces).toEqual(["restricted-ns"]);
+    });
   });
 
   describe("connect with OIDC auth", () => {

--- a/src/lib/stores/__tests__/cluster-store.test.ts
+++ b/src/lib/stores/__tests__/cluster-store.test.ts
@@ -1,6 +1,7 @@
 import { act } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
 import { useClusterStore, selectCurrentNamespace } from "../cluster-store";
+import { useUIStore, defaultSettings } from "../ui-store";
 import { toKubeliError } from "../../types/errors";
 
 // Mock Tauri commands
@@ -214,6 +215,47 @@ describe("ClusterStore", () => {
       const state = useClusterStore.getState();
       expect(state.isConnected).toBe(false);
       expect(state.error?.message).toBe("Timeout");
+    });
+  });
+
+  describe("default namespace on connect (#347)", () => {
+    beforeEach(() => {
+      useClusterStore.setState({ clusters: mockClusters });
+      mockConnectCluster.mockResolvedValue({
+        connected: true,
+        context: "test-context",
+        latency_ms: 50,
+      });
+      mockGetNamespaces.mockResolvedValue({
+        namespaces: ["default", "kubeli-demo"],
+        source: "auto",
+      });
+      mockCheckConnectionHealth.mockResolvedValue({ healthy: true, latency_ms: 50 });
+      mockWatchNamespaces.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      useUIStore.setState({ settings: { ...defaultSettings } });
+    });
+
+    it("applies the configured default namespace on connect", async () => {
+      useUIStore.setState({
+        settings: { ...defaultSettings, defaultNamespace: " kubeli-demo " },
+      });
+
+      await act(async () => {
+        await useClusterStore.getState().connect("test-context");
+      });
+
+      expect(useClusterStore.getState().selectedNamespaces).toEqual(["kubeli-demo"]);
+    });
+
+    it("keeps all namespaces selected when no default is configured", async () => {
+      await act(async () => {
+        await useClusterStore.getState().connect("test-context");
+      });
+
+      expect(useClusterStore.getState().selectedNamespaces).toEqual([]);
     });
   });
 

--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -196,6 +196,19 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
     // True once a newer connect started or the user cancelled/disconnected while
     // this attempt was awaiting — then we must not apply its (stale) result.
     const superseded = () => get().connectGeneration !== generation;
+    // The default namespace is a global setting; this cluster may not have it.
+    // Fall back to all namespaces instead of leaving every view silently empty.
+    // Skipped when the namespace list isn't known (source "none").
+    const dropMissingNamespaceSelection = () => {
+      const { namespaces, namespaceSource, selectedNamespaces } = get();
+      if (
+        namespaceSource !== "none" &&
+        selectedNamespaces.length === 1 &&
+        !namespaces.includes(selectedNamespaces[0])
+      ) {
+        set({ selectedNamespaces: [] });
+      }
+    };
     useResourceCacheStore.getState().clearCache();
     try {
       const status = await connectCluster(context);
@@ -321,6 +334,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
             // A disconnect during fetchNamespaces() would leave a leaked watch
             // and health interval running for a connection that's already gone.
             if (superseded()) return retryStatus;
+            dropMissingNamespaceSelection();
             if (get().namespaceSource === "auto") {
               get().startNamespaceWatch();
             }
@@ -396,6 +410,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
         // A disconnect during fetchNamespaces() would leave a leaked watch and
         // health interval running for a connection that's already gone.
         if (superseded()) return status;
+        dropMissingNamespaceSelection();
         // Only start namespace watch for auto-discovered namespaces (not configured)
         if (get().namespaceSource === "auto") {
           get().startNamespaceWatch();

--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -16,7 +16,15 @@ import {
 } from "../tauri/commands";
 import { oidcStartAuth, oidcHandleCallback } from "../tauri/commands/oidc";
 import { useResourceCacheStore } from "./resource-cache-store";
+import { useUIStore } from "./ui-store";
 import type { WatchEvent } from "../types";
+
+// Applies the "Default Namespace" setting when a connection is established
+// (#347). Empty setting = all namespaces.
+const initialNamespaceSelection = (): string[] => {
+  const ns = useUIStore.getState().settings.defaultNamespace.trim();
+  return ns ? [ns] : [];
+};
 
 // Debug logger - only logs in development
 const isDev = process.env.NODE_ENV === "development";
@@ -298,7 +306,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
             set({
               isConnected: true,
               currentCluster,
-              selectedNamespaces: [],
+              selectedNamespaces: initialNamespaceSelection(),
               error: null,
               isLoading: false,
               latencyMs: retryStatus.latency_ms,
@@ -372,7 +380,7 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
         set({
           isConnected: true,
           currentCluster,
-          selectedNamespaces: [],
+          selectedNamespaces: initialNamespaceSelection(),
           error: null,
           isLoading: false,
           latencyMs: status.latency_ms,


### PR DESCRIPTION
Fixes #347.

## Problem

The General settings tab offers a Default Namespace, but the value was never applied: every successful cluster connect reset `selectedNamespaces` to `[]`, so the view always fell back to All Namespaces.

## Fix

Both connect success paths (plain connect and the OIDC cached-token retry) seed the namespace selection from `settings.defaultNamespace` (trimmed). An empty setting keeps the current all-namespaces behavior. Disconnect, manual namespace switching, and the accessible-namespaces flows are untouched.

## Regression tests

`cluster-store.test.ts`: connecting with a configured default (including surrounding whitespace) selects exactly that namespace; connecting without one keeps all namespaces. Full store suite (53 tests), `tsc --noEmit` and ESLint pass.