### PR TITLE
feat: render URL annotations as clickable links

### DIFF
--- a/src/components/features/resources/components/AnnotationsSection.tsx
+++ b/src/components/features/resources/components/AnnotationsSection.tsx
@@ -6,6 +6,16 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 
 const TRUNCATE_LENGTH = 120;
+const HTTP_URL_PATTERN = /^https?:\/\/\S+$/;
+
+async function openExternal(url: string): Promise<void> {
+  try {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+  } catch {
+    // Opening the browser is best-effort; ignore failures.
+  }
+}
 
 interface AnnotationsSectionProps {
   annotations: Record<string, string>;
@@ -37,6 +47,8 @@ function AnnotationEntry({
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
+  const trimmedValue = value.trim();
+  const isUrl = HTTP_URL_PATTERN.test(trimmedValue);
   const isLong = value.length > TRUNCATE_LENGTH;
   const isJson = isLong && (value.startsWith("{") || value.startsWith("["));
 
@@ -76,6 +88,13 @@ function AnnotationEntry({
         <pre className="mt-1 bg-muted/50 rounded-md p-2 text-xs overflow-x-auto whitespace-pre-wrap break-all">
           {displayValue}
         </pre>
+      ) : isUrl ? (
+        <button
+          onClick={() => void openExternal(trimmedValue)}
+          className="mt-0.5 block text-left text-primary hover:underline break-all"
+        >
+          {displayValue}
+        </button>
       ) : (
         <p className="mt-0.5 break-all">{displayValue}</p>
       )}

--- a/src/components/features/resources/components/__tests__/AnnotationsSection.test.tsx
+++ b/src/components/features/resources/components/__tests__/AnnotationsSection.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { AnnotationsSection } from "../AnnotationsSection";
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn() },
+}));
+
+const renderSection = (annotations: Record<string, string>) =>
+  render(
+    <AnnotationsSection
+      annotations={annotations}
+      label="Annotations"
+      copyToastMessage="Copied"
+    />,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AnnotationsSection", () => {
+  it("renders a URL-valued annotation as a link that opens the system browser", async () => {
+    renderSection({
+      "example.com/docs-url": "https://example.com/docs",
+    });
+
+    const link = screen.getByRole("button", {
+      name: "https://example.com/docs",
+    });
+    fireEvent.click(link);
+
+    await waitFor(() => {
+      expect(openUrl).toHaveBeenCalledWith("https://example.com/docs");
+    });
+  });
+
+  it("trims surrounding whitespace before opening the URL", async () => {
+    renderSection({
+      "example.com/docs-url": "  https://example.com/docs  ",
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "https://example.com/docs" }),
+    );
+
+    await waitFor(() => {
+      expect(openUrl).toHaveBeenCalledWith("https://example.com/docs");
+    });
+  });
+
+  it("renders a non-URL value as plain text", () => {
+    renderSection({
+      "example.com/description": "just a plain value",
+    });
+
+    const value = screen.getByText("just a plain value");
+    expect(value.tagName).toBe("P");
+    expect(
+      screen.queryByRole("button", { name: "just a plain value" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not linkify URLs embedded in longer text", () => {
+    renderSection({
+      "example.com/mixed": "see https://example.com/docs for details",
+    });
+
+    const value = screen.getByText("see https://example.com/docs for details");
+    expect(value.tagName).toBe("P");
+  });
+
+  it("keeps copy-to-clipboard working for URL values", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const { container } = renderSection({
+      "example.com/docs-url": "https://example.com/docs",
+    });
+
+    const copyButton = container.querySelector("button[data-slot='button']");
+    expect(copyButton).not.toBeNull();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("https://example.com/docs");
+    });
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Annotation values in the resource detail view render as plain text, even when the value is a URL (e.g. `kubernetes.io/ingress` docs links, ArgoCD tracking URLs). Opening one meant copying it and pasting it into a browser.

## Fix

In `AnnotationsSection.tsx`, values that are entirely a single `http://` or `https://` URL (after trimming) now render as a clickable link that opens in the system browser via `openUrl` from `@tauri-apps/plugin-opener` — the same mechanism used elsewhere (e.g. `ArgoCDHistoryTab`), so the webview never navigates. URLs embedded in longer text stay plain text to keep behavior predictable, and copy-to-clipboard is unchanged. The labels section is untouched.

## Testing

- New regression tests in `src/components/features/resources/components/__tests__/AnnotationsSection.test.tsx`: URL value renders as a link and invokes the opener with the URL (incl. trimmed whitespace), non-URL and mixed-text values stay plain text, and copy-to-clipboard still works for URL values without triggering the opener.
- `npx jest` (new tests), `npm run typecheck`, and `npm run lint` all pass.

Closes #259.