### PR TITLE
feat: ServiceAccount link and scheduling info in Pod detail

### DIFF
--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -10,7 +10,9 @@ use k8s_openapi::api::autoscaling::v2::HorizontalPodAutoscaler;
 use k8s_openapi::api::batch::v1::{CronJob, Job};
 use k8s_openapi::api::coordination::v1::Lease;
 use k8s_openapi::api::core::v1::ServiceAccount;
-use k8s_openapi::api::core::v1::{ConfigMap, Event, Namespace, Node, Pod, Secret, Service};
+use k8s_openapi::api::core::v1::{
+    ConfigMap, Event, Namespace, Node, Pod, Secret, Service, Toleration,
+};
 use k8s_openapi::api::core::v1::{LimitRange, ResourceQuota};
 use k8s_openapi::api::core::v1::{PersistentVolume, PersistentVolumeClaim};
 use k8s_openapi::api::discovery::v1::EndpointSlice;
@@ -214,6 +216,33 @@ pub struct PodInfo {
     pub labels: HashMap<String, String>,
     pub restart_count: i32,
     pub ready_containers: String,
+    pub service_account: Option<String>,
+    pub node_selector: HashMap<String, String>,
+    pub tolerations: Vec<TolerationInfo>,
+}
+
+/// Toleration entry from a pod spec
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TolerationInfo {
+    pub key: Option<String>,
+    pub operator: Option<String>,
+    pub value: Option<String>,
+    pub effect: Option<String>,
+    pub toleration_seconds: Option<i64>,
+}
+
+pub fn extract_tolerations(tolerations: Option<Vec<Toleration>>) -> Vec<TolerationInfo> {
+    tolerations
+        .unwrap_or_default()
+        .into_iter()
+        .map(|t| TolerationInfo {
+            key: t.key,
+            operator: t.operator,
+            value: t.value,
+            effect: t.effect,
+            toleration_seconds: t.toleration_seconds,
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -419,6 +448,9 @@ pub async fn list_pods(
                 labels: btree_to_hashmap(metadata.labels),
                 restart_count: total_restarts,
                 ready_containers: format!("{}/{}", ready_count, total_count),
+                service_account: spec.service_account_name,
+                node_selector: btree_to_hashmap(spec.node_selector),
+                tolerations: extract_tolerations(spec.tolerations),
             }
         })
         .collect();
@@ -913,6 +945,9 @@ pub async fn get_pod(
         labels: pod_ctx.labels,
         restart_count: total_restarts,
         ready_containers: format!("{}/{}", ready_count, total_count),
+        service_account: pod_ctx.service_account,
+        node_selector: btree_to_hashmap(spec.node_selector),
+        tolerations: extract_tolerations(spec.tolerations),
     })
 }
 
@@ -4360,6 +4395,45 @@ mod tests {
             labels,
             annotations,
         }
+    }
+
+    #[test]
+    fn test_extract_tolerations_maps_all_fields() {
+        let tolerations = vec![
+            Toleration {
+                key: Some("node.kubernetes.io/not-ready".to_string()),
+                operator: Some("Exists".to_string()),
+                value: None,
+                effect: Some("NoExecute".to_string()),
+                toleration_seconds: Some(300),
+            },
+            Toleration {
+                key: Some("dedicated".to_string()),
+                operator: Some("Equal".to_string()),
+                value: Some("gpu".to_string()),
+                effect: Some("NoSchedule".to_string()),
+                toleration_seconds: None,
+            },
+        ];
+
+        let infos = extract_tolerations(Some(tolerations));
+
+        assert_eq!(infos.len(), 2);
+        assert_eq!(
+            infos[0].key.as_deref(),
+            Some("node.kubernetes.io/not-ready")
+        );
+        assert_eq!(infos[0].operator.as_deref(), Some("Exists"));
+        assert_eq!(infos[0].value, None);
+        assert_eq!(infos[0].effect.as_deref(), Some("NoExecute"));
+        assert_eq!(infos[0].toleration_seconds, Some(300));
+        assert_eq!(infos[1].value.as_deref(), Some("gpu"));
+        assert_eq!(infos[1].toleration_seconds, None);
+    }
+
+    #[test]
+    fn test_extract_tolerations_none_is_empty() {
+        assert!(extract_tolerations(None).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands/watch.rs
+++ b/src-tauri/src/commands/watch.rs
@@ -1,4 +1,6 @@
-use crate::commands::resources::{extract_container_info, ContainerInfo, NamespaceInfo, PodInfo};
+use crate::commands::resources::{
+    extract_container_info, extract_tolerations, ContainerInfo, NamespaceInfo, PodInfo,
+};
 use crate::error::KubeliError;
 use crate::k8s::AppState;
 use futures::StreamExt;
@@ -158,6 +160,9 @@ fn pod_to_info(pod: Pod) -> PodInfo {
         labels: btree_to_hashmap(metadata.labels),
         restart_count: total_restarts,
         ready_containers: format!("{}/{}", ready_count, total_count),
+        service_account: spec.service_account_name,
+        node_selector: btree_to_hashmap(spec.node_selector),
+        tolerations: extract_tolerations(spec.tolerations),
     }
 }
 

--- a/src/components/features/resources/columns/__tests__/workloads.test.ts
+++ b/src/components/features/resources/columns/__tests__/workloads.test.ts
@@ -32,6 +32,9 @@ const createMockPod = (overrides: Partial<PodInfo> = {}): PodInfo => ({
   labels: {},
   restart_count: 0,
   ready_containers: "1/1",
+  service_account: null,
+  node_selector: {},
+  tolerations: [],
   ...overrides,
 });
 

--- a/src/components/features/resources/components/OverviewTab.tsx
+++ b/src/components/features/resources/components/OverviewTab.tsx
@@ -12,9 +12,10 @@ import { ContainerStatusSection } from "./ContainerStatusSection";
 import { PodMetricsSection } from "./PodMetricsSection";
 import { AnnotationsSection } from "./AnnotationsSection";
 import { OwnerReferencesSection } from "./OwnerReferencesSection";
+import { PodSchedulingSection } from "./PodSchedulingSection";
 import { getPod } from "@/lib/tauri/commands";
 import type { ResourceData } from "../types";
-import type { ContainerInfo } from "@/lib/types";
+import type { ContainerInfo, TolerationInfo } from "@/lib/types";
 
 function formatDate(dateString: string, locale: string): string {
   const date = new Date(dateString);
@@ -37,15 +38,39 @@ export function OverviewTab({ resource, resourceType, onNavigateToOwner }: Overv
     key: string;
     initContainers: ContainerInfo[];
     containers: ContainerInfo[];
-  }>({ key: "", initContainers: [], containers: [] });
+    serviceAccount: string | null;
+    nodeSelector: Record<string, string>;
+    tolerations: TolerationInfo[];
+  }>({
+    key: "",
+    initContainers: [],
+    containers: [],
+    serviceAccount: null,
+    nodeSelector: {},
+    tolerations: [],
+  });
 
   const fetchContainers = useCallback(async (name: string, namespace: string, key: string) => {
     try {
       const podInfo = await getPod(name, namespace);
-      return { key, initContainers: podInfo.init_containers, containers: podInfo.containers };
+      return {
+        key,
+        initContainers: podInfo.init_containers,
+        containers: podInfo.containers,
+        serviceAccount: podInfo.service_account,
+        nodeSelector: podInfo.node_selector,
+        tolerations: podInfo.tolerations,
+      };
     } catch (err) {
       console.error("Failed to load pod containers:", err);
-      return { key, initContainers: [] as ContainerInfo[], containers: [] as ContainerInfo[] };
+      return {
+        key,
+        initContainers: [] as ContainerInfo[],
+        containers: [] as ContainerInfo[],
+        serviceAccount: null,
+        nodeSelector: {} as Record<string, string>,
+        tolerations: [] as TolerationInfo[],
+      };
     }
   }, []);
 
@@ -67,9 +92,13 @@ export function OverviewTab({ resource, resourceType, onNavigateToOwner }: Overv
     };
   }, [resourceType, resource.name, resource.namespace, resourceKey, fetchContainers]);
 
-  // Only show containers if they match the current resource (prevents stale data)
-  const initContainers = containerData.key === resourceKey ? containerData.initContainers : [];
-  const containers = containerData.key === resourceKey ? containerData.containers : [];
+  // Only show pod details if they match the current resource (prevents stale data)
+  const podDataCurrent = containerData.key === resourceKey;
+  const initContainers = podDataCurrent ? containerData.initContainers : [];
+  const containers = podDataCurrent ? containerData.containers : [];
+  const serviceAccount = podDataCurrent ? containerData.serviceAccount : null;
+  const nodeSelector = podDataCurrent ? containerData.nodeSelector : {};
+  const tolerations = podDataCurrent ? containerData.tolerations : [];
 
   return (
     <div className="h-full overflow-y-auto">
@@ -113,6 +142,17 @@ export function OverviewTab({ resource, resourceType, onNavigateToOwner }: Overv
             ownerReferences={resource.ownerReferences}
             onNavigate={onNavigateToOwner}
             namespace={resource.namespace}
+          />
+        )}
+
+        {/* Scheduling Section (for Pods only) */}
+        {resourceType === "pod" && (
+          <PodSchedulingSection
+            serviceAccount={serviceAccount}
+            nodeSelector={nodeSelector}
+            tolerations={tolerations}
+            namespace={resource.namespace}
+            onNavigate={onNavigateToOwner}
           />
         )}
 

--- a/src/components/features/resources/components/PodSchedulingSection.tsx
+++ b/src/components/features/resources/components/PodSchedulingSection.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { SlidersHorizontal } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { useTranslations } from "next-intl";
+import type { TolerationInfo } from "@/lib/types";
+
+interface PodSchedulingSectionProps {
+  serviceAccount: string | null;
+  nodeSelector: Record<string, string>;
+  tolerations: TolerationInfo[];
+  namespace?: string;
+  onNavigate?: (kind: string, name: string, namespace?: string) => void;
+}
+
+function formatToleration(toleration: TolerationInfo): string {
+  const parts: string[] = [];
+  if (toleration.key) {
+    parts.push(toleration.key);
+  }
+  if (toleration.operator) {
+    parts.push(toleration.operator);
+  }
+  if (toleration.value) {
+    parts.push(toleration.value);
+  }
+  return parts.join(" ");
+}
+
+export function PodSchedulingSection({
+  serviceAccount,
+  nodeSelector,
+  tolerations,
+  namespace,
+  onNavigate,
+}: PodSchedulingSectionProps) {
+  const t = useTranslations();
+  const nodeSelectorEntries = Object.entries(nodeSelector);
+
+  if (!serviceAccount && nodeSelectorEntries.length === 0 && tolerations.length === 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
+        <SlidersHorizontal className="size-4" />
+        {t("podDetail.scheduling")}
+      </h3>
+      <div className="space-y-4 text-sm">
+        {serviceAccount && (
+          <div>
+            <dt className="text-muted-foreground">{t("podDetail.serviceAccount")}</dt>
+            <dd className="mt-0.5">
+              {onNavigate ? (
+                <button
+                  type="button"
+                  onClick={() => onNavigate("ServiceAccount", serviceAccount, namespace)}
+                  className="text-primary hover:underline"
+                >
+                  {serviceAccount}
+                </button>
+              ) : (
+                serviceAccount
+              )}
+            </dd>
+          </div>
+        )}
+        {nodeSelectorEntries.length > 0 && (
+          <div>
+            <dt className="text-muted-foreground">{t("podDetail.nodeSelector")}</dt>
+            <dd className="mt-0.5 flex flex-wrap gap-2 min-w-0">
+              {nodeSelectorEntries.map(([key, value]) => (
+                <Badge
+                  key={key}
+                  variant="secondary"
+                  className="font-mono text-xs max-w-full min-w-0"
+                  title={`${key}=${value}`}
+                >
+                  <span className="truncate">{key}={value}</span>
+                </Badge>
+              ))}
+            </dd>
+          </div>
+        )}
+        {tolerations.length > 0 && (
+          <div>
+            <dt className="text-muted-foreground">{t("podDetail.tolerations")}</dt>
+            <dd className="mt-0.5 space-y-2">
+              {tolerations.map((toleration, index) => (
+                <div
+                  key={index}
+                  className="flex flex-wrap items-center gap-2 rounded-md border border-border/60 bg-muted/30 px-3 py-2"
+                >
+                  <span className="min-w-0 truncate font-mono text-xs">
+                    {formatToleration(toleration)}
+                  </span>
+                  {toleration.effect && (
+                    <Badge variant="outline" className="shrink-0 text-xs font-normal">
+                      {toleration.effect}
+                    </Badge>
+                  )}
+                  {toleration.toleration_seconds !== null && (
+                    <Badge
+                      variant="outline"
+                      className="shrink-0 text-xs font-normal text-muted-foreground"
+                    >
+                      {toleration.toleration_seconds}s
+                    </Badge>
+                  )}
+                </div>
+              ))}
+            </dd>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/resources/components/__tests__/OverviewTab.test.tsx
+++ b/src/components/features/resources/components/__tests__/OverviewTab.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OverviewTab } from "../OverviewTab";
+import { getPod } from "@/lib/tauri/commands";
+import type { ResourceData } from "../../types";
+import type { PodInfo } from "@/lib/types";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("@/components/providers/I18nProvider", () => ({
+  useLocale: () => "en",
+}));
+
+jest.mock("@/lib/tauri/commands", () => ({
+  getPod: jest.fn(),
+}));
+
+jest.mock("../PodMetricsSection", () => ({
+  PodMetricsSection: () => null,
+}));
+
+jest.mock("../ContainerStatusSection", () => ({
+  ContainerStatusSection: () => null,
+}));
+
+const makePodInfo = (overrides: Partial<PodInfo> = {}): PodInfo => ({
+  name: "demo-api-abc123",
+  namespace: "kubeli-demo",
+  uid: "pod-uid",
+  phase: "Running",
+  node_name: "minikube",
+  pod_ip: "10.244.0.5",
+  host_ip: "192.168.49.2",
+  init_containers: [],
+  containers: [],
+  created_at: null,
+  deletion_timestamp: null,
+  labels: {},
+  restart_count: 0,
+  ready_containers: "0/0",
+  service_account: "demo-sa",
+  node_selector: { "kubernetes.io/os": "linux" },
+  tolerations: [
+    {
+      key: "node.kubernetes.io/not-ready",
+      operator: "Exists",
+      value: null,
+      effect: "NoExecute",
+      toleration_seconds: 300,
+    },
+  ],
+  ...overrides,
+});
+
+const resource: ResourceData = {
+  name: "demo-api-abc123",
+  namespace: "kubeli-demo",
+  uid: "pod-uid",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("OverviewTab scheduling section", () => {
+  it("renders serviceAccount, nodeSelector and tolerations for pods", async () => {
+    (getPod as jest.Mock).mockResolvedValue(makePodInfo());
+
+    render(<OverviewTab resource={resource} resourceType="pod" />);
+
+    await waitFor(() =>
+      expect(screen.getByText("podDetail.scheduling")).toBeTruthy()
+    );
+
+    expect(screen.getByText("podDetail.serviceAccount")).toBeTruthy();
+    expect(screen.getByText("demo-sa")).toBeTruthy();
+
+    expect(screen.getByText("podDetail.nodeSelector")).toBeTruthy();
+    expect(screen.getByText("kubernetes.io/os=linux")).toBeTruthy();
+
+    expect(screen.getByText("podDetail.tolerations")).toBeTruthy();
+    expect(
+      screen.getByText("node.kubernetes.io/not-ready Exists")
+    ).toBeTruthy();
+    expect(screen.getByText("NoExecute")).toBeTruthy();
+    expect(screen.getByText("300s")).toBeTruthy();
+  });
+
+  it("navigates to the ServiceAccount when the link is clicked", async () => {
+    (getPod as jest.Mock).mockResolvedValue(makePodInfo());
+    const onNavigateToOwner = jest.fn();
+
+    render(
+      <OverviewTab
+        resource={resource}
+        resourceType="pod"
+        onNavigateToOwner={onNavigateToOwner}
+      />
+    );
+
+    const link = await screen.findByRole("button", { name: "demo-sa" });
+    await userEvent.click(link);
+
+    expect(onNavigateToOwner).toHaveBeenCalledWith(
+      "ServiceAccount",
+      "demo-sa",
+      "kubeli-demo"
+    );
+  });
+
+  it("omits the scheduling section when the pod has no scheduling data", async () => {
+    (getPod as jest.Mock).mockResolvedValue(
+      makePodInfo({ service_account: null, node_selector: {}, tolerations: [] })
+    );
+
+    render(<OverviewTab resource={resource} resourceType="pod" />);
+
+    await waitFor(() => expect(getPod).toHaveBeenCalled());
+    expect(screen.queryByText("podDetail.scheduling")).toBeNull();
+  });
+
+  it("does not render the scheduling section for non-pod resources", () => {
+    render(<OverviewTab resource={resource} resourceType="deployment" />);
+
+    expect(getPod).not.toHaveBeenCalled();
+    expect(screen.queryByText("podDetail.scheduling")).toBeNull();
+  });
+});

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -995,7 +995,11 @@
     "exitCodeSigint": "SIGINT (Strg+C)",
     "exitCodeSignal": "Signal {signal}",
     "exitCodeGeneric": "Exit {code}",
-    "environmentVariables": "Umgebungsvariablen"
+    "environmentVariables": "Umgebungsvariablen",
+    "scheduling": "Scheduling",
+    "serviceAccount": "Service Account",
+    "nodeSelector": "Node Selector",
+    "tolerations": "Tolerations"
   },
   "createResource": {
     "title": "Ressource erstellen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -995,7 +995,11 @@
     "exitCodeSigint": "SIGINT (Ctrl+C)",
     "exitCodeSignal": "Signal {signal}",
     "exitCodeGeneric": "Exit {code}",
-    "environmentVariables": "Environment Variables"
+    "environmentVariables": "Environment Variables",
+    "scheduling": "Scheduling",
+    "serviceAccount": "Service Account",
+    "nodeSelector": "Node Selector",
+    "tolerations": "Tolerations"
   },
   "createResource": {
     "title": "Create Resource",

--- a/src/lib/tauri/mock.ts
+++ b/src/lib/tauri/mock.ts
@@ -182,6 +182,9 @@ const mockPods: PodInfo[] = mockPodDefs.map((d) => ({
   labels: { app: d.name.replace(/-[a-z0-9]+-[a-z0-9]+$/, "").replace(/-\d+$/, "") },
   restart_count: 0,
   ready_containers: "1/1",
+  service_account: "default",
+  node_selector: {},
+  tolerations: [],
 }));
 
 function buildMockGraph() {

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -294,6 +294,17 @@ export interface PodInfo {
   labels: Record<string, string>;
   restart_count: number;
   ready_containers: string;
+  service_account: string | null;
+  node_selector: Record<string, string>;
+  tolerations: TolerationInfo[];
+}
+
+export interface TolerationInfo {
+  key: string | null;
+  operator: string | null;
+  value: string | null;
+  effect: string | null;
+  toleration_seconds: number | null;
 }
 
 export type EnvVarSourceKind = "secret" | "configMap" | "field" | "resource" | "unknown";


### PR DESCRIPTION
## Problem

Tolerations, nodeSelector, and serviceAccount of a pod were only visible in the raw Spec JSON at the bottom of the Overview tab or in the YAML tab. There was no structured UI for them, and no way to jump from a pod to its ServiceAccount.

## Fix

**Backend (Rust)**
- `PodInfo` gains `service_account`, `node_selector`, and `tolerations` (new `TolerationInfo` struct with key/operator/value/effect/toleration_seconds), extracted from the pod spec in `list_pods`, `get_pod`, and the pod watcher (`watch.rs`).

**Frontend**
- New `PodSchedulingSection` component renders a "Scheduling" section on the Pod overview tab:
  - **Service Account** as a clickable link that opens the ServiceAccount resource detail, reusing the owner-reference navigation callback (`onNavigateToOwner` -> `openResourceDetail("serviceaccount", ...)`).
  - **Node Selector** as key=value badges, same style as the Labels section.
  - **Tolerations** as a list with key/operator/value plus effect and tolerationSeconds badges.
- `OverviewTab` passes the scheduling data from the existing `getPod` fetch (no extra request) with the same stale-data guard used for containers.
- TS types extended (`PodInfo`, `TolerationInfo`), i18n keys added for en/de.

## Testing

- New jest test `OverviewTab.test.tsx` (4 tests): scheduling section renders serviceAccount/nodeSelector/tolerations, the ServiceAccount link calls the navigation callback with `("ServiceAccount", name, namespace)`, the section is omitted without scheduling data, and non-pod resources never fetch/show it.
- New Rust unit tests for `extract_tolerations` (field mapping and empty case).
- `npx jest`: 661 passed. `npm run typecheck`: clean. `npm run lint`: clean.
- `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`: 285 passed.

Closes #271, closes #260.