### PR TITLE
feat(cronjobs): Edit & Trigger - review the generated Job YAML before creating

### DIFF
--- a/src-tauri/src/app/command_registry/mod.rs
+++ b/src-tauri/src/app/command_registry/mod.rs
@@ -74,6 +74,7 @@ pub fn handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Syn
         crate::commands::resources::delete_resource,
         crate::commands::resources::scale_deployment,
         crate::commands::resources::trigger_cronjob,
+        crate::commands::resources::get_cronjob_job_yaml,
         crate::commands::resources::suspend_cronjob,
         crate::commands::resources::resume_cronjob,
         crate::commands::watch::watch_pods,

--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -1666,28 +1666,32 @@ pub async fn resume_cronjob(
     set_cronjob_suspend(state, &name, &namespace, false).await
 }
 
-#[command]
-pub async fn trigger_cronjob(
-    state: State<'_, AppState>,
-    name: String,
-    namespace: String,
-) -> Result<(), KubeliError> {
-    let client = state.k8s.get_client().await?;
+/// Build the manual Job a CronJob trigger creates, like
+/// `kubectl create job --from=cronjob/<name>`.
+fn manual_job_from_cronjob(
+    name: &str,
+    namespace: &str,
+    cronjob: CronJob,
+) -> Result<Job, KubeliError> {
+    let cronjob_uid = cronjob.metadata.uid.unwrap_or_default();
+    let template = cronjob
+        .spec
+        .ok_or_else(|| KubeliError::unknown(format!("CronJob {name} has no spec")))?
+        .job_template;
 
-    let cronjobs: Api<CronJob> = Api::namespaced(client.clone(), &namespace);
-    let cronjob = cronjobs.get(&name).await?;
-
-    let template = cronjob.spec.unwrap_or_default().job_template;
-
+    // Job names are DNS labels (max 63 chars); leave room for the suffix.
+    // Millisecond resolution so two quick triggers don't collide on the name.
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|elapsed| elapsed.as_secs())
+        .map(|elapsed| elapsed.as_millis())
         .unwrap_or_default();
-    let job_name = format!("{name}-{timestamp}");
+    let suffix = format!("-{timestamp}");
+    let base: String = name.chars().take(63 - suffix.len()).collect();
+    let job_name = format!("{}{}", base.trim_end_matches('-'), suffix);
 
     let mut metadata = template.metadata.unwrap_or_default();
-    metadata.name = Some(job_name.clone());
-    metadata.namespace = Some(namespace.clone());
+    metadata.name = Some(job_name);
+    metadata.namespace = Some(namespace.to_string());
     metadata
         .annotations
         .get_or_insert_with(Default::default)
@@ -1698,16 +1702,51 @@ pub async fn trigger_cronjob(
     metadata.owner_references = Some(vec![OwnerReference {
         api_version: CronJob::API_VERSION.to_string(),
         kind: CronJob::KIND.to_string(),
-        name: name.clone(),
-        uid: cronjob.metadata.uid.unwrap_or_default(),
+        name: name.to_string(),
+        uid: cronjob_uid,
         ..Default::default()
     }]);
 
-    let job = Job {
+    Ok(Job {
         metadata,
         spec: template.spec,
         status: None,
-    };
+    })
+}
+
+/// Render the manual Job for a CronJob as YAML so the user can review or
+/// tweak it before creating (applied via apply_resource_yaml).
+#[command]
+pub async fn get_cronjob_job_yaml(
+    state: State<'_, AppState>,
+    name: String,
+    namespace: String,
+) -> Result<String, KubeliError> {
+    let client = state.k8s.get_client().await?;
+
+    let cronjobs: Api<CronJob> = Api::namespaced(client, &namespace);
+    let cronjob = cronjobs.get(&name).await?;
+    let job = manual_job_from_cronjob(&name, &namespace, cronjob)?;
+
+    // k8s-openapi types don't serialize apiVersion/kind; apply_resource_yaml needs both.
+    let mut value = serde_json::to_value(&job)?;
+    value["apiVersion"] = Job::API_VERSION.into();
+    value["kind"] = Job::KIND.into();
+    Ok(serde_yaml::to_string(&value)?)
+}
+
+#[command]
+pub async fn trigger_cronjob(
+    state: State<'_, AppState>,
+    name: String,
+    namespace: String,
+) -> Result<(), KubeliError> {
+    let client = state.k8s.get_client().await?;
+
+    let cronjobs: Api<CronJob> = Api::namespaced(client.clone(), &namespace);
+    let cronjob = cronjobs.get(&name).await?;
+    let job = manual_job_from_cronjob(&name, &namespace, cronjob)?;
+    let job_name = job.metadata.name.clone().unwrap_or_default();
 
     let jobs: Api<Job> = Api::namespaced(client, &namespace);
     jobs.create(&PostParams::default(), &job).await?;
@@ -4473,6 +4512,51 @@ pub async fn list_validating_webhooks(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn manual_job_keeps_template_metadata_and_respects_name_limit() {
+        use k8s_openapi::api::batch::v1::{CronJobSpec, JobTemplateSpec};
+
+        let long_name = "a".repeat(80);
+        let cronjob = CronJob {
+            metadata: kube::core::ObjectMeta {
+                uid: Some("cronjob-uid-1".to_string()),
+                ..Default::default()
+            },
+            spec: Some(CronJobSpec {
+                schedule: "* * * * *".to_string(),
+                job_template: JobTemplateSpec {
+                    metadata: Some(kube::core::ObjectMeta {
+                        labels: Some([("app".to_string(), "demo".to_string())].into()),
+                        annotations: Some([("team".to_string(), "platform".to_string())].into()),
+                        ..Default::default()
+                    }),
+                    spec: None,
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let job = manual_job_from_cronjob(&long_name, "kubeli-demo", cronjob).unwrap();
+        let name = job.metadata.name.unwrap();
+        assert!(name.len() <= 63, "job name must stay a DNS label: {name}");
+        let annotations = job.metadata.annotations.unwrap();
+        assert_eq!(annotations["cronjob.kubernetes.io/instantiate"], "manual");
+        // Template annotations survive alongside the manual marker
+        assert_eq!(annotations["team"], "platform");
+        assert_eq!(job.metadata.labels.unwrap()["app"], "demo");
+        assert_eq!(job.metadata.namespace.as_deref(), Some("kubeli-demo"));
+        let owners = job.metadata.owner_references.unwrap();
+        assert_eq!(owners[0].kind, "CronJob");
+        assert_eq!(owners[0].uid, "cronjob-uid-1");
+        assert_eq!(owners[0].name, long_name);
+    }
+
+    #[test]
+    fn manual_job_fails_without_spec() {
+        assert!(manual_job_from_cronjob("x", "ns", CronJob::default()).is_err());
+    }
 
     fn test_pod_context() -> PodContext {
         let mut labels = HashMap::new();

--- a/src/components/features/dashboard/views/workloads/CronJobsView.tsx
+++ b/src/components/features/dashboard/views/workloads/CronJobsView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PlayCircle, Pause, Play } from "lucide-react";
+import { FilePen, PlayCircle, Pause, Play } from "lucide-react";
 import { toast } from "sonner";
 import { useCronJobs } from "@/lib/hooks/useK8sResources";
 import {
@@ -9,7 +9,14 @@ import {
   type TranslateFunc,
 } from "../../../resources/columns";
 import { createResourceView } from "../_createResourceView";
-import { triggerCronjob, suspendCronjob, resumeCronjob } from "@/lib/tauri/commands";
+import {
+  triggerCronjob,
+  suspendCronjob,
+  resumeCronjob,
+  getCronjobJobYaml,
+} from "@/lib/tauri/commands";
+import { useUIStore } from "@/lib/stores/ui-store";
+import { useClusterStore } from "@/lib/stores/cluster-store";
 import { getErrorMessage } from "@/lib/types/errors";
 import type { CronJobInfo } from "@/lib/types";
 
@@ -63,6 +70,25 @@ function cronJobActions(
           success: t("workloads.triggerSuccess"),
           error: t("workloads.triggerError"),
         }, refresh),
+    },
+    {
+      label: t("workloads.editTrigger"),
+      icon: <FilePen className="size-4" />,
+      onClick: async () => {
+        const context = useClusterStore.getState().currentCluster?.context;
+        try {
+          const yaml = await getCronjobJobYaml(cronJob.name, cronJob.namespace);
+          // A cluster switch while the YAML was loading must not open cluster
+          // A's job against cluster B.
+          if (useClusterStore.getState().currentCluster?.context !== context) return;
+          // Review/tweak the generated Job in the create panel before applying
+          useUIStore.getState().openCreateResourceWithYaml(yaml);
+        } catch (error) {
+          toast.error(t("workloads.editTriggerError"), {
+            description: getErrorMessage(error),
+          });
+        }
+      },
     },
     toggle,
   ];

--- a/src/components/features/dashboard/views/workloads/__tests__/CronJobsView.test.tsx
+++ b/src/components/features/dashboard/views/workloads/__tests__/CronJobsView.test.tsx
@@ -1,0 +1,146 @@
+import { render, waitFor } from "@testing-library/react";
+import { CronJobsView } from "../CronJobsView";
+import {
+  getCronjobJobYaml,
+  suspendCronjob,
+  resumeCronjob,
+  triggerCronjob,
+} from "@/lib/tauri/commands";
+import { useUIStore } from "@/lib/stores/ui-store";
+import { useClusterStore } from "@/lib/stores/cluster-store";
+import type { ContextMenuItemDef } from "../../../../resources/columns";
+import type { CronJobInfo } from "@/lib/types";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("@/lib/hooks/useRefreshOnDelete", () => ({
+  useRefreshOnDelete: jest.fn(),
+}));
+
+jest.mock("../../../context", () => ({
+  useResourceDetail: () => ({
+    openResourceDetail: jest.fn(),
+    handleDeleteFromContext: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/tauri/commands", () => ({
+  triggerCronjob: jest.fn().mockResolvedValue(undefined),
+  suspendCronjob: jest.fn().mockResolvedValue(undefined),
+  resumeCronjob: jest.fn().mockResolvedValue(undefined),
+  getCronjobJobYaml: jest.fn().mockResolvedValue("apiVersion: batch/v1\nkind: Job\n"),
+}));
+
+const makeCronJob = (suspend: boolean): CronJobInfo => ({
+  name: "demo-cleanup",
+  namespace: "kubeli-demo",
+  uid: "uid-1",
+  schedule: "0 * * * *",
+  suspend,
+  active_jobs: 0,
+  last_schedule_time: null,
+  last_successful_time: null,
+  created_at: null,
+  labels: {},
+});
+
+let mockData: CronJobInfo[] = [];
+jest.mock("@/lib/hooks/useK8sResources", () => ({
+  useCronJobs: () => ({
+    data: mockData,
+    isLoading: false,
+    error: null,
+    refresh: jest.fn(),
+    retry: jest.fn(),
+  }),
+}));
+
+let capturedContextMenuItems:
+  | ((cj: CronJobInfo) => ContextMenuItemDef[])
+  | undefined;
+jest.mock("../../../../resources/ResourceList", () => ({
+  ResourceList: (props: {
+    contextMenuItems?: (cj: CronJobInfo) => ContextMenuItemDef[];
+  }) => {
+    capturedContextMenuItems = props.contextMenuItems;
+    return null;
+  },
+}));
+
+const menuFor = (suspend: boolean) => {
+  mockData = [makeCronJob(suspend)];
+  render(<CronJobsView />);
+  return capturedContextMenuItems!(mockData[0]);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("CronJobsView actions", () => {
+  it("triggers a job from the cronjob", async () => {
+    menuFor(false)
+      .find((i) => i.label === "workloads.trigger")!
+      .onClick();
+
+    await waitFor(() =>
+      expect(triggerCronjob).toHaveBeenCalledWith("demo-cleanup", "kubeli-demo")
+    );
+  });
+
+  it("opens the create panel pre-filled with the generated job YAML", async () => {
+    const openCreateResourceWithYaml = jest.fn();
+    useUIStore.setState({ openCreateResourceWithYaml });
+
+    menuFor(false)
+      .find((i) => i.label === "workloads.editTrigger")!
+      .onClick();
+
+    await waitFor(() =>
+      expect(openCreateResourceWithYaml).toHaveBeenCalledWith(
+        "apiVersion: batch/v1\nkind: Job\n"
+      )
+    );
+    expect(getCronjobJobYaml).toHaveBeenCalledWith("demo-cleanup", "kubeli-demo");
+  });
+
+  it("does not open the panel when the cluster changed while loading YAML", async () => {
+    const openCreateResourceWithYaml = jest.fn();
+    useUIStore.setState({ openCreateResourceWithYaml });
+    useClusterStore.setState({
+      currentCluster: { context: "cluster-a" } as never,
+    });
+    (getCronjobJobYaml as jest.Mock).mockImplementation(async () => {
+      // Simulate a cluster switch during the backend round-trip
+      useClusterStore.setState({
+        currentCluster: { context: "cluster-b" } as never,
+      });
+      return "kind: Job\n";
+    });
+
+    menuFor(false)
+      .find((i) => i.label === "workloads.editTrigger")!
+      .onClick();
+
+    await waitFor(() => expect(getCronjobJobYaml).toHaveBeenCalled());
+    expect(openCreateResourceWithYaml).not.toHaveBeenCalled();
+  });
+
+  it("offers Suspend for an active cronjob and Resume for a suspended one", async () => {
+    const active = menuFor(false);
+    expect(active.find((i) => i.label === "workloads.resume")).toBeUndefined();
+    active.find((i) => i.label === "workloads.suspend")!.onClick();
+    await waitFor(() =>
+      expect(suspendCronjob).toHaveBeenCalledWith("demo-cleanup", "kubeli-demo")
+    );
+
+    const suspended = menuFor(true);
+    expect(suspended.find((i) => i.label === "workloads.suspend")).toBeUndefined();
+    suspended.find((i) => i.label === "workloads.resume")!.onClick();
+    await waitFor(() =>
+      expect(resumeCronjob).toHaveBeenCalledWith("demo-cleanup", "kubeli-demo")
+    );
+  });
+});

--- a/src/components/features/resources/CreateResourcePanel.tsx
+++ b/src/components/features/resources/CreateResourcePanel.tsx
@@ -50,11 +50,16 @@ export function CreateResourcePanel({ onClose, onApplied }: CreateResourcePanelP
   const monacoRef = useRef<Monaco | null>(null);
   const validationDispose = useRef<(() => void) | null>(null);
 
+  const initialYaml = useUIStore((s) => s.createResourceInitialYaml);
   const defaultTemplate = k8sTemplates[0];
   const defaultValue = `${defaultTemplate.category}/${defaultTemplate.kind}`;
-  const [yamlContent, setYamlContent] = useState(defaultTemplate.yaml);
-  const [selectedTemplate, setSelectedTemplate] = useState<string>(defaultValue);
-  const [templateYaml, setTemplateYaml] = useState(defaultTemplate.yaml);
+  const [yamlContent, setYamlContent] = useState(initialYaml ?? defaultTemplate.yaml);
+  // Pre-filled content is not one of the templates — show the placeholder
+  // instead of falsely claiming the first template is selected.
+  const [selectedTemplate, setSelectedTemplate] = useState<string>(
+    initialYaml ? "" : defaultValue
+  );
+  const [templateYaml, setTemplateYaml] = useState(initialYaml ?? defaultTemplate.yaml);
   const [isApplying, setIsApplying] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
@@ -62,6 +67,23 @@ export function CreateResourcePanel({ onClose, onApplied }: CreateResourcePanelP
   const [showLintPanel, setShowLintPanel] = useState(false);
 
   const hasChanges = yamlContent !== templateYaml;
+  const hasChangesRef = useRef(hasChanges);
+  hasChangesRef.current = hasChanges;
+
+  // Pre-filled YAML can arrive while the panel is already open (e.g. a second
+  // "Edit & Trigger" from a CronJob) — adopt it as the new baseline, but never
+  // silently discard edits the user already made.
+  useEffect(() => {
+    if (!initialYaml) return;
+    if (hasChangesRef.current) {
+      toast.info(t("unsavedChangesKeep"));
+      return;
+    }
+    setYamlContent(initialYaml);
+    setTemplateYaml(initialYaml);
+    setSelectedTemplate("");
+    setError(null);
+  }, [initialYaml, t]);
   const hasLintErrors = lintErrors.length > 0;
 
   const templatesByCategory = getTemplatesByCategory();

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -218,6 +218,8 @@
     "restart": "Neustarten",
     "trigger": "Auslösen",
     "triggerSuccess": "Job ausgelöst",
+    "editTrigger": "Bearbeiten & Auslösen...",
+    "editTriggerError": "Job-YAML konnte nicht erstellt werden",
     "triggerError": "Auslösen fehlgeschlagen",
     "suspendSuccess": "CronJob pausiert",
     "suspendError": "Pausieren fehlgeschlagen",
@@ -1014,6 +1016,7 @@
     "apply": "Anwenden",
     "applying": "Wird angewendet...",
     "applySuccess": "Ressource erfolgreich erstellt",
+    "unsavedChangesKeep": "Ungespeicherte Änderungen vorhanden - erst schließen oder anwenden",
     "applyError": "Ressource konnte nicht erstellt werden",
     "categories": {
       "workloads": "Workloads",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -218,6 +218,8 @@
     "restart": "Restart",
     "trigger": "Trigger",
     "triggerSuccess": "Job triggered",
+    "editTrigger": "Edit & Trigger...",
+    "editTriggerError": "Failed to generate Job YAML",
     "triggerError": "Failed to trigger job",
     "suspendSuccess": "CronJob suspended",
     "suspendError": "Failed to suspend",
@@ -1014,6 +1016,7 @@
     "apply": "Apply",
     "applying": "Applying...",
     "applySuccess": "Resource created successfully",
+    "unsavedChangesKeep": "You have unsaved changes - close or apply them first",
     "applyError": "Failed to create resource",
     "categories": {
       "workloads": "Workloads",

--- a/src/lib/stores/__tests__/cluster-store.test.ts
+++ b/src/lib/stores/__tests__/cluster-store.test.ts
@@ -834,6 +834,18 @@ describe("ClusterStore", () => {
       expect(state.error).toBeNull();
     });
 
+    it("closes the create panel so its YAML cannot leak into the next cluster", async () => {
+      mockDisconnectCluster.mockResolvedValue(undefined);
+      useUIStore.getState().openCreateResourceWithYaml("kind: Job\n");
+
+      await act(async () => {
+        await useClusterStore.getState().disconnect();
+      });
+
+      expect(useUIStore.getState().isCreateResourceOpen).toBe(false);
+      expect(useUIStore.getState().createResourceInitialYaml).toBeNull();
+    });
+
     it("should stop namespace watch on disconnect", async () => {
       const mockUnlisten = jest.fn();
       useClusterStore.setState({

--- a/src/lib/stores/__tests__/ui-store.test.ts
+++ b/src/lib/stores/__tests__/ui-store.test.ts
@@ -278,6 +278,17 @@ describe("UIStore", () => {
     });
   });
 
+  describe("create resource panel with initial YAML", () => {
+    it("opens the panel with the given YAML and clears it on close", () => {
+      useUIStore.getState().openCreateResourceWithYaml("kind: Job\n");
+      expect(useUIStore.getState().isCreateResourceOpen).toBe(true);
+      expect(useUIStore.getState().createResourceInitialYaml).toBe("kind: Job\n");
+
+      useUIStore.getState().setCreateResourceOpen(false);
+      expect(useUIStore.getState().createResourceInitialYaml).toBeNull();
+    });
+  });
+
   describe("default settings values", () => {
     it("should have correct default values", () => {
       expect(defaultSettings.theme).toBe("classic-dark");

--- a/src/lib/stores/cluster-store.ts
+++ b/src/lib/stores/cluster-store.ts
@@ -491,6 +491,9 @@ export const useClusterStore = create<ClusterState>((set, get) => ({
     const generation = get().connectGeneration + 1;
     set({ connectGeneration: generation });
     useResourceCacheStore.getState().clearCache();
+    // Close the create panel: its content (e.g. a Job generated from this
+    // cluster's CronJob) must not survive into the next connection.
+    useUIStore.getState().setCreateResourceOpen(false);
     try {
       await disconnectCluster();
       // A connect started after this disconnect (newer generation) wins — don't

--- a/src/lib/stores/ui-store.ts
+++ b/src/lib/stores/ui-store.ts
@@ -111,6 +111,9 @@ interface UIState {
 
   // Create resource panel state
   isCreateResourceOpen: boolean;
+  // Pre-filled YAML for the create panel (e.g. Job generated from a CronJob);
+  // consumed once by CreateResourcePanel on mount
+  createResourceInitialYaml: string | null;
 
   // Actions
   setTheme: (theme: Theme) => void;
@@ -129,6 +132,8 @@ interface UIState {
   triggerRefresh: () => void;
   triggerSearchFocus: () => void;
   setCreateResourceOpen: (open: boolean) => void;
+  /** Open the create panel pre-filled with the given YAML. */
+  openCreateResourceWithYaml: (yaml: string) => void;
 }
 
 // Helper to get valid vibrancy level
@@ -153,6 +158,7 @@ export const useUIStore = create<UIState>()(
       refreshTrigger: 0,
       searchFocusTrigger: 0,
       isCreateResourceOpen: false,
+      createResourceInitialYaml: null,
 
       setTheme: (theme) => {
         set((state) => ({
@@ -229,7 +235,11 @@ export const useUIStore = create<UIState>()(
       triggerSearchFocus: () =>
         set((state) => ({ searchFocusTrigger: state.searchFocusTrigger + 1 })),
 
-      setCreateResourceOpen: (open) => set({ isCreateResourceOpen: open }),
+      setCreateResourceOpen: (open) =>
+        set({ isCreateResourceOpen: open, ...(!open && { createResourceInitialYaml: null }) }),
+
+      openCreateResourceWithYaml: (yaml) =>
+        set({ isCreateResourceOpen: true, createResourceInitialYaml: yaml }),
     }),
     {
       name: "kubeli-ui-settings",

--- a/src/lib/tauri/commands/__tests__/wrappers.test.ts
+++ b/src/lib/tauri/commands/__tests__/wrappers.test.ts
@@ -184,6 +184,7 @@ const cases: TestCase[] = [
   { name: "triggerCronjob", run: () => resources.triggerCronjob("demo", "default"), expectedCommand: "trigger_cronjob", expectedPayload: { name: "demo", namespace: "default" } },
   { name: "suspendCronjob", run: () => resources.suspendCronjob("demo", "default"), expectedCommand: "suspend_cronjob", expectedPayload: { name: "demo", namespace: "default" } },
   { name: "resumeCronjob", run: () => resources.resumeCronjob("demo", "default"), expectedCommand: "resume_cronjob", expectedPayload: { name: "demo", namespace: "default" } },
+  { name: "getCronjobJobYaml", run: () => resources.getCronjobJobYaml("demo", "default"), expectedCommand: "get_cronjob_job_yaml", expectedPayload: { name: "demo", namespace: "default" } },
 ];
 
 describe("tauri command wrappers", () => {

--- a/src/lib/tauri/commands/resources.ts
+++ b/src/lib/tauri/commands/resources.ts
@@ -304,3 +304,8 @@ export async function suspendCronjob(name: string, namespace: string): Promise<v
 export async function resumeCronjob(name: string, namespace: string): Promise<void> {
   return invoke("resume_cronjob", { name, namespace });
 }
+
+/** Renders the manual Job for a CronJob as YAML for review before creating. */
+export async function getCronjobJobYaml(name: string, namespace: string): Promise<string> {
+  return invoke("get_cronjob_job_yaml", { name, namespace });
+}


### PR DESCRIPTION
Builds on #364 (thanks @thanipro!). Closes #264.

## Changes

**Backend** (`resources.rs`):
- The Job construction from #364 moved into a shared `manual_job_from_cronjob` builder, hardened per review: millisecond timestamps + 63-char DNS-label truncation for the generated name (same-second double-triggers collided with AlreadyExists), and an explicit error when the CronJob has no spec instead of silently creating an empty Job.
- New `get_cronjob_job_yaml(name, namespace)` renders the manual Job as YAML (apiVersion/kind injected) for review. `trigger_cronjob` uses the same builder, so both paths create identical Jobs.

**Frontend**:
- New **Edit & Trigger...** context-menu entry (i18n de/en) on CronJobs: fetches the generated YAML and opens the create-resource panel pre-filled — full Monaco editor, linting and server-side apply reused.
- Safety: disconnect closes the create panel; a cluster switch while the YAML is loading drops the in-flight result (cluster A's job can never be applied to cluster B).
- The panel never overwrites unsaved editor changes when a new pre-fill arrives (info toast instead), and the template selector shows its placeholder for pre-filled content instead of falsely claiming Pod.

## Testing

- `CronJobsView.test.tsx`: trigger, Edit & Trigger opens the panel with the YAML, in-flight cluster-switch guard, suspend/resume states.
- `ui-store.test.ts` (pre-fill set/cleared), `cluster-store.test.ts` (disconnect closes panel), wrapper coverage for `get_cronjob_job_yaml`.
- Rust: builder unit tests (template annotations preserved + manual marker, ownerReference, name truncation, missing-spec error).
- Full jest suite (680), `tsc --noEmit`, ESLint, `cargo clippy -D warnings`, `cargo test` (287) — all green.