### PR TITLE
fix(resources): stop pod list scroll jitter by measuring real row heights

### DIFF
--- a/src/components/features/resources/components/ResourceTable.tsx
+++ b/src/components/features/resources/components/ResourceTable.tsx
@@ -61,6 +61,9 @@ interface ResourceTableProps<T> {
 interface ResourceTableRowProps<T> {
   item: T;
   itemKey: string;
+  /** Index into `data`; read back by the virtualizer via the data-index attribute. */
+  dataIndex: number;
+  measureRef: (el: HTMLElement | null) => void;
   columns: Column<T>[];
   isSelected: boolean;
   namespace?: string;
@@ -75,6 +78,8 @@ interface ResourceTableRowProps<T> {
 function ResourceTableRowInner<T>({
   item,
   itemKey,
+  dataIndex,
+  measureRef,
   columns,
   isSelected,
   namespace,
@@ -90,6 +95,8 @@ function ResourceTableRowInner<T>({
 
   const rowContent = (
     <TableRow
+      ref={measureRef}
+      data-index={dataIndex}
       onClick={() => onRowClick?.(item)}
       className={cn(
         onRowClick && "cursor-pointer",
@@ -188,6 +195,14 @@ export function ResourceTable<T>({
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ROW_HEIGHT,
     overscan: OVERSCAN,
+    // Rows are not all ROW_HEIGHT tall: cells like PodMetricsCell grow once
+    // metrics arrive (usage bar, sparkline). With only the flat estimate the
+    // total size is wrong, so scrolling far down lands past the real end and
+    // the virtualizer snaps back -- the "jitter". Measuring corrects it.
+    // A 0 height means the row isn't laid out yet (detached/hidden, or jsdom);
+    // trusting it would make the window grow to hundreds of rows, so keep the
+    // estimate until a real height is available.
+    measureElement: (el) => el.getBoundingClientRect().height || ROW_HEIGHT,
   });
 
   const virtualRows = virtualizer.getVirtualItems();
@@ -280,6 +295,8 @@ export function ResourceTable<T>({
             return (
               <ResourceTableRow
                 key={itemKey}
+                dataIndex={virtualRow.index}
+                measureRef={virtualizer.measureElement}
                 item={item}
                 itemKey={itemKey}
                 columns={columns}

--- a/src/components/features/resources/components/ResourceTable.tsx
+++ b/src/components/features/resources/components/ResourceTable.tsx
@@ -224,7 +224,7 @@ export function ResourceTable<T>({
     // can't renegotiate widths as rows scroll through the virtual window.
     <div
       ref={scrollRef}
-      className="h-full overflow-auto [overscroll-behavior:none]"
+      className="h-full overflow-auto overscroll-none"
     >
       {/* table-fixed only when columns declare widths: widths then come from the
           headers, not per-row content, so variable action buttons can't jitter

--- a/src/components/features/resources/components/__tests__/ResourceTable.test.tsx
+++ b/src/components/features/resources/components/__tests__/ResourceTable.test.tsx
@@ -98,4 +98,30 @@ describe("ResourceTable virtualization", () => {
 
     expect(contextMenuItems).not.toHaveBeenCalled();
   });
+
+  // Regression: rows were sized by the flat ROW_HEIGHT estimate only. Rows
+  // whose real height differs (PodMetricsCell grows a usage bar and sparkline
+  // once metrics arrive) made getTotalSize() wrong, so scrolling to the bottom
+  // overshot the real end and snapped back -- visible as jitter. Every row must
+  // carry a data-index so the virtualizer can measure it and correct the size.
+  it("marks every rendered row with its data index for measurement", () => {
+    const { container } = render(
+      <ResourceTable {...baseProps} data={makeItems(1000)} />
+    );
+
+    const rows = dataRows(container);
+    expect(rows.length).toBeGreaterThan(0);
+
+    const indices = Array.from(rows, (row) =>
+      row.getAttribute("data-index")
+    );
+    expect(indices.every((i) => i !== null)).toBe(true);
+
+    // Indices are the real positions in `data`, contiguous and ascending --
+    // measurements would be attributed to the wrong rows otherwise.
+    const numeric = indices.map(Number);
+    expect(numeric).toEqual(
+      Array.from({ length: numeric.length }, (_, i) => numeric[0] + i)
+    );
+  });
 });


### PR DESCRIPTION
## Problem

Scrolling the pod list quickly to the bottom made the rows shake up and down for a moment before settling.

## Cause

`ResourceTable` told the virtualizer every row is exactly `ROW_HEIGHT` (44px) via `estimateSize`, and never measured the real heights. Pod rows are not uniform:

- `PodMetricsCell` adds a `h-1` usage bar plus `gap-0.5` when the pod has CPU/memory requests set
- a sparkline (`height={16}`) appears once at least two history samples exist
- rows without metrics render only a short `-`

Metrics also arrive asynchronously (3s initial, then 10s refresh), so rows **grow after the first paint** while the virtualizer still assumes the flat estimate.

The accumulated error makes `getTotalSize()` smaller than the real content. Scrolling far down lands past the actual end, the virtualizer corrects the offset, and that correction is the visible jitter. It shows up when scrolling fast because that is when the largest number of mis-estimated rows is crossed at once.

## Fix

Rows now carry a `data-index` and the virtualizer's `measureElement` ref, so estimates get replaced with measured heights — the same pattern already used in `DeploymentLogViewer` and `LogContent`.

A zero measurement falls back to the estimate. A row that is not laid out yet (detached, hidden, or jsdom) reports height 0, and trusting that would make the rendered window grow to hundreds of rows. This was caught by an existing test, which failed with 511 rows rendered before the guard was added.

Also swaps the arbitrary `[overscroll-behavior:none]` for the `overscroll-none` utility used by every other scroll area in the app. Identical compiled CSS (verified in the production build output), consistent source.

## Testing

- Added a regression test asserting every rendered row carries a contiguous, ascending `data-index`. Verified it **fails** when `data-index` is removed and passes with it restored.
- Full suite: 681 passed, 0 failed
- `tsc --noEmit` clean, ESLint clean, production build succeeds

## Note

The visual behaviour was verified by reasoning about the layout and the compiled CSS, not by scrolling the app against a live cluster — worth a quick manual check on the pod list before merging.