### PR TITLE
feat: aggregated logs for StatefulSets, DaemonSets, ReplicaSets and Jobs

### DIFF
--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -2100,6 +2100,8 @@ pub struct DaemonSetInfo {
     pub created_at: Option<String>,
     pub labels: HashMap<String, String>,
     pub node_selector: HashMap<String, String>,
+    /// Pod selector from spec.selector — resolves the DaemonSet's pods
+    pub selector: HashMap<String, String>,
 }
 
 /// List all daemon sets
@@ -2134,6 +2136,7 @@ pub async fn list_daemonsets(
             let spec = ds.spec.unwrap_or_default();
             let status = ds.status.unwrap_or_default();
 
+            let selector = btree_to_hashmap(spec.selector.match_labels);
             let node_selector = spec
                 .template
                 .spec
@@ -2154,6 +2157,7 @@ pub async fn list_daemonsets(
                 created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
                 labels: btree_to_hashmap(metadata.labels),
                 node_selector,
+                selector,
             }
         })
         .collect();
@@ -2175,6 +2179,8 @@ pub struct StatefulSetInfo {
     pub service_name: Option<String>,
     pub created_at: Option<String>,
     pub labels: HashMap<String, String>,
+    /// Pod selector from spec.selector — resolves the StatefulSet's pods
+    pub selector: HashMap<String, String>,
 }
 
 /// List all stateful sets
@@ -2209,6 +2215,8 @@ pub async fn list_statefulsets(
             let spec = sts.spec.unwrap_or_default();
             let status = sts.status.unwrap_or_default();
 
+            let selector = btree_to_hashmap(spec.selector.match_labels);
+
             StatefulSetInfo {
                 name: metadata.name.unwrap_or_default(),
                 namespace: metadata.namespace.unwrap_or_default(),
@@ -2220,6 +2228,7 @@ pub async fn list_statefulsets(
                 service_name: spec.service_name,
                 created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
                 labels: btree_to_hashmap(metadata.labels),
+                selector,
             }
         })
         .collect();
@@ -2245,6 +2254,9 @@ pub struct JobInfo {
     pub created_at: Option<String>,
     pub labels: HashMap<String, String>,
     pub status: String,
+    /// Pod selector from spec.selector — resolves the Job's pods. Normally
+    /// the controller-generated `batch.kubernetes.io/controller-uid` label.
+    pub selector: HashMap<String, String>,
 }
 
 /// List all jobs
@@ -2312,6 +2324,11 @@ pub async fn list_jobs(
                 created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
                 labels: btree_to_hashmap(metadata.labels),
                 status: job_status.to_string(),
+                selector: spec
+                    .selector
+                    .and_then(|s| s.match_labels)
+                    .map(|l| l.into_iter().collect())
+                    .unwrap_or_default(),
             }
         })
         .collect();

--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -23,7 +23,7 @@ use k8s_openapi::api::rbac::v1::{ClusterRole, ClusterRoleBinding, Role, RoleBind
 use k8s_openapi::api::scheduling::v1::PriorityClass;
 use k8s_openapi::api::storage::v1::{CSIDriver, CSINode, StorageClass, VolumeAttachment};
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, OwnerReference};
 use k8s_openapi::Resource;
 use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams};
 use kube::core::DynamicObject;
@@ -41,6 +41,33 @@ fn btree_to_hashmap(
     btree: Option<std::collections::BTreeMap<String, String>>,
 ) -> HashMap<String, String> {
     btree.map(|b| b.into_iter().collect()).unwrap_or_default()
+}
+
+/// Converts a Kubernetes LabelSelector into the query syntax accepted by
+/// ListParams and watcher Config, preserving both matchLabels and
+/// matchExpressions.
+fn label_selector_to_query(selector: &LabelSelector) -> String {
+    let mut parts = Vec::new();
+
+    if let Some(labels) = &selector.match_labels {
+        parts.extend(labels.iter().map(|(key, value)| format!("{key}={value}")));
+    }
+
+    if let Some(expressions) = &selector.match_expressions {
+        for expression in expressions {
+            let values = expression.values.as_deref().unwrap_or_default().join(",");
+            let part = match expression.operator.as_str() {
+                "In" => format!("{} in ({})", expression.key, values),
+                "NotIn" => format!("{} notin ({})", expression.key, values),
+                "Exists" => expression.key.clone(),
+                "DoesNotExist" => format!("!{}", expression.key),
+                _ => continue,
+            };
+            parts.push(part);
+        }
+    }
+
+    parts.join(",")
 }
 
 pub fn extract_container_info(
@@ -293,6 +320,8 @@ pub struct DeploymentInfo {
     pub created_at: Option<String>,
     pub labels: HashMap<String, String>,
     pub selector: HashMap<String, String>,
+    /// Full pod selector, including matchExpressions, in Kubernetes query syntax.
+    pub selector_query: String,
 }
 
 /// Service-specific information
@@ -494,6 +523,7 @@ pub async fn list_deployments(
             let spec = deployment.spec.unwrap_or_default();
             let status = deployment.status.unwrap_or_default();
 
+            let selector_query = label_selector_to_query(&spec.selector);
             DeploymentInfo {
                 name: metadata.name.unwrap_or_default(),
                 namespace: metadata.namespace.unwrap_or_default(),
@@ -505,6 +535,7 @@ pub async fn list_deployments(
                 created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
                 labels: btree_to_hashmap(metadata.labels),
                 selector: btree_to_hashmap(spec.selector.match_labels),
+                selector_query,
             }
         })
         .collect();
@@ -2024,6 +2055,8 @@ pub struct ReplicaSetInfo {
     pub created_at: Option<String>,
     pub labels: HashMap<String, String>,
     pub selector: HashMap<String, String>,
+    /// Full pod selector, including matchExpressions, in Kubernetes query syntax.
+    pub selector_query: String,
 }
 
 /// List all replica sets
@@ -2065,6 +2098,7 @@ pub async fn list_replicasets(
                 .map(|r| (Some(r.name.clone()), Some(r.kind.clone())))
                 .unwrap_or((None, None));
 
+            let selector_query = label_selector_to_query(&spec.selector);
             ReplicaSetInfo {
                 name: metadata.name.unwrap_or_default(),
                 namespace: metadata.namespace.unwrap_or_default(),
@@ -2077,6 +2111,7 @@ pub async fn list_replicasets(
                 created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
                 labels: btree_to_hashmap(metadata.labels),
                 selector: btree_to_hashmap(spec.selector.match_labels),
+                selector_query,
             }
         })
         .collect();
@@ -2102,6 +2137,8 @@ pub struct DaemonSetInfo {
     pub node_selector: HashMap<String, String>,
     /// Pod selector from spec.selector — resolves the DaemonSet's pods
     pub selector: HashMap<String, String>,
+    /// Full pod selector, including matchExpressions, in Kubernetes query syntax.
+    pub selector_query: String,
 }
 
 /// List all daemon sets
@@ -2136,6 +2173,7 @@ pub async fn list_daemonsets(
             let spec = ds.spec.unwrap_or_default();
             let status = ds.status.unwrap_or_default();
 
+            let selector_query = label_selector_to_query(&spec.selector);
             let selector = btree_to_hashmap(spec.selector.match_labels);
             let node_selector = spec
                 .template
@@ -2158,6 +2196,7 @@ pub async fn list_daemonsets(
                 labels: btree_to_hashmap(metadata.labels),
                 node_selector,
                 selector,
+                selector_query,
             }
         })
         .collect();
@@ -2181,6 +2220,8 @@ pub struct StatefulSetInfo {
     pub labels: HashMap<String, String>,
     /// Pod selector from spec.selector — resolves the StatefulSet's pods
     pub selector: HashMap<String, String>,
+    /// Full pod selector, including matchExpressions, in Kubernetes query syntax.
+    pub selector_query: String,
 }
 
 /// List all stateful sets
@@ -2215,6 +2256,7 @@ pub async fn list_statefulsets(
             let spec = sts.spec.unwrap_or_default();
             let status = sts.status.unwrap_or_default();
 
+            let selector_query = label_selector_to_query(&spec.selector);
             let selector = btree_to_hashmap(spec.selector.match_labels);
 
             StatefulSetInfo {
@@ -2229,6 +2271,7 @@ pub async fn list_statefulsets(
                 created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
                 labels: btree_to_hashmap(metadata.labels),
                 selector,
+                selector_query,
             }
         })
         .collect();
@@ -2257,6 +2300,8 @@ pub struct JobInfo {
     /// Pod selector from spec.selector — resolves the Job's pods. Normally
     /// the controller-generated `batch.kubernetes.io/controller-uid` label.
     pub selector: HashMap<String, String>,
+    /// Full pod selector, including matchExpressions, in Kubernetes query syntax.
+    pub selector_query: String,
 }
 
 /// List all jobs
@@ -2309,6 +2354,12 @@ pub async fn list_jobs(
                 "Pending"
             };
 
+            let selector_query = spec
+                .selector
+                .as_ref()
+                .map(label_selector_to_query)
+                .unwrap_or_default();
+
             JobInfo {
                 name: metadata.name.unwrap_or_default(),
                 namespace: metadata.namespace.unwrap_or_default(),
@@ -2329,6 +2380,7 @@ pub async fn list_jobs(
                     .and_then(|s| s.match_labels)
                     .map(|l| l.into_iter().collect())
                     .unwrap_or_default(),
+                selector_query,
             }
         })
         .collect();
@@ -4529,6 +4581,45 @@ pub async fn list_validating_webhooks(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelectorRequirement;
+
+    #[test]
+    fn label_selector_query_preserves_labels_and_expressions() {
+        let selector = LabelSelector {
+            match_labels: Some(
+                [("app".to_string(), "demo".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            match_expressions: Some(vec![
+                LabelSelectorRequirement {
+                    key: "tier".to_string(),
+                    operator: "In".to_string(),
+                    values: Some(vec!["api".to_string(), "worker".to_string()]),
+                },
+                LabelSelectorRequirement {
+                    key: "track".to_string(),
+                    operator: "NotIn".to_string(),
+                    values: Some(vec!["legacy".to_string()]),
+                },
+                LabelSelectorRequirement {
+                    key: "managed".to_string(),
+                    operator: "Exists".to_string(),
+                    values: None,
+                },
+                LabelSelectorRequirement {
+                    key: "debug".to_string(),
+                    operator: "DoesNotExist".to_string(),
+                    values: None,
+                },
+            ]),
+        };
+
+        assert_eq!(
+            label_selector_to_query(&selector),
+            "app=demo,tier in (api,worker),track notin (legacy),managed,!debug"
+        );
+    }
 
     #[test]
     fn manual_job_keeps_template_metadata_and_respects_name_limit() {

--- a/src-tauri/src/commands/watch.rs
+++ b/src-tauri/src/commands/watch.rs
@@ -245,6 +245,7 @@ pub async fn watch_pods(
     state: State<'_, AppState>,
     watch_manager: State<'_, Arc<WatchManager>>,
     namespace: Option<String>,
+    label_selector: Option<String>,
     watch_id: String,
 ) -> Result<(), KubeliError> {
     let client = state.k8s.get_client().await.map_err(KubeliError::from)?;
@@ -259,7 +260,12 @@ pub async fn watch_pods(
 
     let watch_id_clone = watch_id.clone();
     tokio::spawn(async move {
-        let stream = watcher(pods, Config::default()).boxed();
+        let config = label_selector
+            .as_deref()
+            .filter(|selector| !selector.is_empty())
+            .map(|selector| Config::default().labels(selector))
+            .unwrap_or_default();
+        let stream = watcher(pods, config).boxed();
         run_watch_loop(
             app,
             manager,

--- a/src/components/features/dashboard/views/ResourceView.tsx
+++ b/src/components/features/dashboard/views/ResourceView.tsx
@@ -18,7 +18,7 @@ import { WorkloadsOverview } from "./WorkloadsOverview";
 import { PortForwardsView } from "./PortForwardsView";
 import { AllPortForwardsView } from "./AllPortForwardsView";
 import { PodLogsView } from "./PodLogsView";
-import { DeploymentLogsView } from "./DeploymentLogsView";
+import { WorkloadLogsView } from "./WorkloadLogsView";
 
 // Cluster views
 import {
@@ -230,7 +230,7 @@ export function ResourceView({ activeResource }: ResourceViewProps) {
     case "pod-logs":
       return <PodLogsView />;
     case "deployment-logs":
-      return <DeploymentLogsView />;
+      return <WorkloadLogsView />;
 
     default:
       return <ComingSoon resource={activeResource} />;

--- a/src/components/features/dashboard/views/WorkloadLogsView.tsx
+++ b/src/components/features/dashboard/views/WorkloadLogsView.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { DeploymentLogViewer } from "../../logs/DeploymentLogViewer";
+import { WorkloadLogViewer } from "../../logs/WorkloadLogViewer";
 import { useTabsStore } from "@/lib/stores/tabs-store";
 
-export function DeploymentLogsView() {
+export function WorkloadLogsView() {
   const t = useTranslations();
   const activeTabId = useTabsStore((s) => s.activeTabId);
   const tabs = useTabsStore((s) => s.tabs);
   const activeTab = tabs.find((tab) => tab.id === activeTabId);
   const metadata = activeTab?.metadata;
 
-  if (!metadata?.namespace || !metadata?.deploymentName) {
+  // deploymentName is the pre-#212 metadata key; tabs persisted by an older
+  // version still carry it.
+  const workloadName = metadata?.workloadName ?? metadata?.deploymentName;
+
+  if (!metadata?.namespace || !workloadName) {
     return (
       <div className="flex h-full items-center justify-center text-muted-foreground">
         {t("empty.noDeploymentSelected")}
@@ -22,10 +26,11 @@ export function DeploymentLogsView() {
   return (
     <div className="flex h-full flex-col">
       <div className="flex-1 overflow-hidden min-h-0">
-        <DeploymentLogViewer
+        <WorkloadLogViewer
           key={activeTab?.id}
-          deploymentName={metadata.deploymentName}
+          workloadName={workloadName}
           namespace={metadata.namespace}
+          kind={metadata.workloadKind ?? "deployment"}
           autoStream={metadata.autoStream}
         />
       </div>

--- a/src/components/features/dashboard/views/_createResourceView.tsx
+++ b/src/components/features/dashboard/views/_createResourceView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
-import { Copy, Trash2, Eye } from "lucide-react";
+import { Copy, Trash2, Eye, FileText } from "lucide-react";
 import { toast } from "sonner";
 import { ResourceList } from "../../resources/ResourceList";
 import {
@@ -15,6 +15,8 @@ import {
 } from "../../resources/columns";
 import { useResourceDetail } from "../context";
 import { useRefreshOnDelete } from "@/lib/hooks/useRefreshOnDelete";
+import { supportsAggregatedLogs } from "@/lib/hooks/useWorkloadLogs";
+import { useOpenWorkloadLogsTab } from "@/lib/hooks/useOpenWorkloadLogsTab";
 
 // Base resource type - all K8s resources have these
 interface BaseResource {
@@ -96,6 +98,7 @@ export function createResourceView<T extends BaseResource>(
 
   return function ResourceView() {
     const t = useTranslations();
+    const openWorkloadLogsTab = useOpenWorkloadLogsTab();
     const { data, isLoading, error, refresh, retry } = hook({
       autoRefresh: true,
       refreshInterval: 30000,
@@ -132,6 +135,16 @@ export function createResourceView<T extends BaseResource>(
           ),
         },
       ];
+
+      // Aggregated logs across the workload's pods
+      if (supportsAggregatedLogs(resourceType) && resource.namespace) {
+        items.push({
+          label: t("logs.viewLogs"),
+          icon: <FileText className="size-4" />,
+          onClick: () =>
+            openWorkloadLogsTab(resourceType, resource.name, resource.namespace!),
+        });
+      }
 
       // Add custom menu items if provided
       if (additionalMenuItems) {

--- a/src/components/features/dashboard/views/workloads/DeploymentsView.tsx
+++ b/src/components/features/dashboard/views/workloads/DeploymentsView.tsx
@@ -17,7 +17,7 @@ import {
   type ContextMenuItemDef,
 } from "../../../resources/columns";
 import { useResourceDetail } from "../../context";
-import { useTabsStore } from "@/lib/stores/tabs-store";
+import { useOpenWorkloadLogsTab } from "@/lib/hooks/useOpenWorkloadLogsTab";
 import type { DeploymentInfo } from "@/lib/types";
 
 export function DeploymentsView() {
@@ -27,7 +27,7 @@ export function DeploymentsView() {
     refreshInterval: 30000,
   });
   const { openResourceDetail, handleDeleteFromContext, handleScaleFromContext } = useResourceDetail();
-  const openOrActivateTab = useTabsStore((s) => s.openOrActivateTab);
+  const openWorkloadLogsTab = useOpenWorkloadLogsTab();
   const [sortKey, setSortKey] = useState<string | null>("created_at");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const currentCluster = useClusterStore((s) => s.currentCluster);
@@ -50,17 +50,7 @@ export function DeploymentsView() {
     {
       label: t("logs.viewLogs"),
       icon: <FileText className="size-4" />,
-      onClick: () => {
-        const result = openOrActivateTab(
-          "deployment-logs",
-          `Logs: ${dep.name} (${dep.namespace})`,
-          { namespace: dep.namespace, deploymentName: dep.name },
-          (tab) => tab.type === "deployment-logs" &&
-            tab.metadata?.deploymentName === dep.name &&
-            tab.metadata?.namespace === dep.namespace,
-        );
-        if (result === null) toast.warning(t("tabs.limitToast"));
-      },
+      onClick: () => openWorkloadLogsTab("deployment", dep.name, dep.namespace),
     },
     {
       label: "Scale",

--- a/src/components/features/logs/WorkloadLogViewer.tsx
+++ b/src/components/features/logs/WorkloadLogViewer.tsx
@@ -2,7 +2,11 @@
 
 import { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { AlertCircle, Layers, Maximize2 } from "lucide-react";
-import { useDeploymentLogs } from "@/lib/hooks/useDeploymentLogs";
+import {
+  useWorkloadLogs,
+  WORKLOAD_KIND_LABELS,
+  type WorkloadLogKind,
+} from "@/lib/hooks/useWorkloadLogs";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -14,23 +18,26 @@ import type { TimestampMode } from "./types";
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
-interface DeploymentLogViewerProps {
-  deploymentName: string;
+interface WorkloadLogViewerProps {
+  workloadName: string;
   namespace: string;
+  /** Workload type whose pods are aggregated; defaults to Deployment */
+  kind?: WorkloadLogKind;
   onOpenInTab?: (isCurrentlyStreaming: boolean) => void;
   autoStream?: boolean;
 }
 
 /**
- * Log viewer that aggregates logs from all pods in a deployment.
+ * Log viewer that aggregates logs from all pods in a workload.
  * Each log line is prefixed with pod name and color-coded per pod.
  */
-export function DeploymentLogViewer({
-  deploymentName,
+export function WorkloadLogViewer({
+  workloadName,
   namespace,
+  kind = "deployment",
   onOpenInTab,
   autoStream,
-}: DeploymentLogViewerProps) {
+}: WorkloadLogViewerProps) {
   const t = useTranslations();
 
   const {
@@ -46,7 +53,7 @@ export function DeploymentLogViewer({
     startStream,
     stopStream,
     clearLogs,
-  } = useDeploymentLogs(deploymentName, namespace);
+  } = useWorkloadLogs(workloadName, namespace, kind);
 
   // Display options state
   const [lineWrap, setLineWrap] = useState(true);
@@ -78,7 +85,7 @@ export function DeploymentLogViewer({
 
   useEffect(() => {
     resetFilters();
-  }, [namespace, deploymentName, resetFilters]);
+  }, [namespace, workloadName, kind, resetFilters]);
 
   // Auto-start streaming when opened from side panel with active stream
   const autoStreamTriggered = useRef(false);
@@ -101,7 +108,7 @@ export function DeploymentLogViewer({
   // Export and AI analysis operate on the pod-filtered set, so an active pod
   // filter narrows both — the visible logs are the ones that get exported.
   const { isDownloading, downloadLogs } = useLogDownload({
-    sourceName: deploymentName,
+    sourceName: workloadName,
     container: null,
     logs: podFilteredLogs,
     filteredLogs,
@@ -111,10 +118,10 @@ export function DeploymentLogViewer({
 
   const { isAICliAvailable, analyzeWithAI, sendSelectionToAI } = useLogAnalysis({
     namespace,
-    sourceName: deploymentName,
+    sourceName: workloadName,
     container: null,
     logs: filteredLogs,
-    workloadKind: "Deployment",
+    workloadKind: WORKLOAD_KIND_LABELS[kind],
     t,
   });
 
@@ -132,7 +139,7 @@ export function DeploymentLogViewer({
         <div className="flex items-center gap-3 min-w-0">
           <h3 className="font-medium truncate">
             <Layers className="inline size-4 mr-1.5 -mt-0.5" />
-            {t("logs.title")}: {deploymentName}
+            {t("logs.title")}: {workloadName}
           </h3>
           <Badge variant="secondary">{namespace}</Badge>
           {isStreaming && (

--- a/src/components/features/logs/components/LogContent.tsx
+++ b/src/components/features/logs/components/LogContent.tsx
@@ -5,7 +5,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { Loader2, Copy, Check, Sparkles, SearchX } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { LogEntry } from "@/lib/types";
-import type { PodColorEntry } from "@/lib/hooks/useDeploymentLogs";
+import type { PodColorEntry } from "@/lib/hooks/useWorkloadLogs";
 import { LogLine } from "./LogLine";
 
 interface LogContentProps {

--- a/src/components/features/logs/components/__tests__/LogContent.test.tsx
+++ b/src/components/features/logs/components/__tests__/LogContent.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { LogContent } from "../LogContent";
-import type { PodColorEntry } from "@/lib/hooks/useDeploymentLogs";
+import type { PodColorEntry } from "@/lib/hooks/useWorkloadLogs";
 import type { LogEntry } from "@/lib/types";
 
 const makeLogs = (count: number, pod = "test-pod"): LogEntry[] =>

--- a/src/components/features/resources/ResourceDetail.tsx
+++ b/src/components/features/resources/ResourceDetail.tsx
@@ -22,7 +22,8 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { LogViewer } from "../logs/LogViewer";
-import { DeploymentLogViewer } from "../logs/DeploymentLogViewer";
+import { WorkloadLogViewer } from "../logs/WorkloadLogViewer";
+import { supportsAggregatedLogs } from "@/lib/hooks/useWorkloadLogs";
 import { useTabsStore } from "@/lib/stores/tabs-store";
 import { OverviewTab } from "./components/OverviewTab";
 import { YamlTab, type YamlTabHandle } from "./components/YamlTab";
@@ -167,14 +168,20 @@ export function ResourceDetail({
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const handleOpenDeploymentLogsTab = useCallback((isCurrentlyStreaming: boolean) => {
-    if (!resource?.namespace) return;
+  const handleOpenWorkloadLogsTab = useCallback((isCurrentlyStreaming: boolean) => {
+    if (!resource?.namespace || !supportsAggregatedLogs(resourceType)) return;
     const result = openOrActivateTab(
       "deployment-logs",
       `Logs: ${resource.name} (${resource.namespace})`,
-      { namespace: resource.namespace, deploymentName: resource.name, autoStream: isCurrentlyStreaming },
+      {
+        namespace: resource.namespace,
+        workloadName: resource.name,
+        workloadKind: resourceType,
+        autoStream: isCurrentlyStreaming,
+      },
       (tab) => tab.type === "deployment-logs" &&
-        tab.metadata?.deploymentName === resource.name &&
+        tab.metadata?.workloadName === resource.name &&
+        tab.metadata?.workloadKind === resourceType &&
         tab.metadata?.namespace === resource.namespace,
     );
     if (result === null) {
@@ -182,7 +189,7 @@ export function ResourceDetail({
       return;
     }
     onClose();
-  }, [openOrActivateTab, resource?.name, resource?.namespace, t, onClose]);
+  }, [openOrActivateTab, resource?.name, resource?.namespace, resourceType, t, onClose]);
 
   const handleOpenPodLogsTab = useCallback(() => {
     if (!resource?.namespace) return;
@@ -301,7 +308,7 @@ export function ResourceDetail({
               <FileJson className="size-4" />
               {t("resourceDetail.yaml")}
             </TabsTrigger>
-            {(resourceType === "pod" || resourceType === "deployment") && resource.namespace && (
+            {(resourceType === "pod" || supportsAggregatedLogs(resourceType)) && resource.namespace && (
               <TabsTrigger value="logs" className="gap-2">
                 <FileText className="size-4" />
                 {t("resourceDetail.logs")}
@@ -382,12 +389,13 @@ export function ResourceDetail({
           </TabsContent>
         )}
 
-        {resourceType === "deployment" && resource.namespace && (
+        {supportsAggregatedLogs(resourceType) && resource.namespace && (
           <TabsContent value="logs" className="flex-1 overflow-hidden m-0">
-            <DeploymentLogViewer
-              deploymentName={resource.name}
+            <WorkloadLogViewer
+              workloadName={resource.name}
               namespace={resource.namespace}
-              onOpenInTab={handleOpenDeploymentLogsTab}
+              kind={resourceType}
+              onOpenInTab={handleOpenWorkloadLogsTab}
             />
           </TabsContent>
         )}

--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -1,15 +1,23 @@
 import { renderHook, act } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
-import { useDeploymentLogs } from "../useDeploymentLogs";
+import { useWorkloadLogs, supportsAggregatedLogs } from "../useWorkloadLogs";
 
 const mockListPods = jest.fn();
 const mockListDeployments = jest.fn();
+const mockListStatefulsets = jest.fn();
+const mockListDaemonsets = jest.fn();
+const mockListReplicasets = jest.fn();
+const mockListJobs = jest.fn();
 const mockWatchPods = jest.fn();
 const mockStopWatch = jest.fn();
 
 jest.mock("../../tauri/commands", () => ({
   listPods: (...args: unknown[]) => mockListPods(...args),
   listDeployments: (...args: unknown[]) => mockListDeployments(...args),
+  listStatefulsets: (...args: unknown[]) => mockListStatefulsets(...args),
+  listDaemonsets: (...args: unknown[]) => mockListDaemonsets(...args),
+  listReplicasets: (...args: unknown[]) => mockListReplicasets(...args),
+  listJobs: (...args: unknown[]) => mockListJobs(...args),
   streamPodLogs: jest.fn(),
   stopLogStream: jest.fn().mockResolvedValue(undefined),
   watchPods: (...args: unknown[]) => mockWatchPods(...args),
@@ -18,7 +26,7 @@ jest.mock("../../tauri/commands", () => ({
 
 const mockListen = listen as jest.Mock;
 
-describe("useDeploymentLogs unmount during watch setup", () => {
+describe("useWorkloadLogs unmount during watch setup", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockListDeployments.mockResolvedValue([]);
@@ -36,7 +44,7 @@ describe("useDeploymentLogs unmount during watch setup", () => {
       () => new Promise((resolve) => { resolveListen = resolve; })
     );
 
-    const { unmount } = renderHook(() => useDeploymentLogs("demo-web", "default"));
+    const { unmount } = renderHook(() => useWorkloadLogs("demo-web", "default"));
     await act(async () => {});
 
     unmount();
@@ -59,7 +67,7 @@ describe("useDeploymentLogs unmount during watch setup", () => {
       () => new Promise<void>((resolve) => { resolveWatch = resolve; })
     );
 
-    const { unmount } = renderHook(() => useDeploymentLogs("demo-web", "default"));
+    const { unmount } = renderHook(() => useWorkloadLogs("demo-web", "default"));
     await act(async () => {});
     expect(mockWatchPods).toHaveBeenCalledTimes(1);
 
@@ -73,12 +81,12 @@ describe("useDeploymentLogs unmount during watch setup", () => {
 
     expect(mockStopWatch).toHaveBeenCalledTimes(1);
     expect(mockStopWatch).toHaveBeenCalledWith(
-      expect.stringContaining("deploy-pods-default-demo-web")
+      expect.stringContaining("workload-pods-deployment-default-demo-web")
     );
   });
 });
 
-describe("useDeploymentLogs seq stamping", () => {
+describe("useWorkloadLogs seq stamping", () => {
   const podEntry = {
     name: "demo-web-7d4b8c-abcde",
     namespace: "default",
@@ -107,7 +115,7 @@ describe("useDeploymentLogs seq stamping", () => {
       return Promise.resolve(jest.fn());
     });
 
-    const { result } = renderHook(() => useDeploymentLogs("demo-web", "default"));
+    const { result } = renderHook(() => useWorkloadLogs("demo-web", "default"));
     await act(async () => {});
 
     await act(async () => {
@@ -150,5 +158,105 @@ describe("useDeploymentLogs seq stamping", () => {
     const bySeq = [...result.current.logs].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
     expect(bySeq.map((l) => l.message)).toEqual(["first", "second", "third"]);
     expect(result.current.logs.map((l) => l.message)).toEqual(["second", "first", "third"]);
+  });
+});
+
+describe("useWorkloadLogs pod resolution per workload kind", () => {
+  const listerFor = {
+    deployment: mockListDeployments,
+    statefulset: mockListStatefulsets,
+    daemonset: mockListDaemonsets,
+    replicaset: mockListReplicasets,
+    job: mockListJobs,
+  } as const;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListPods.mockResolvedValue([]);
+    mockWatchPods.mockResolvedValue(undefined);
+    mockStopWatch.mockResolvedValue(undefined);
+    mockListen.mockResolvedValue(jest.fn());
+    for (const lister of Object.values(listerFor)) {
+      lister.mockResolvedValue([]);
+    }
+  });
+
+  it.each([
+    ["deployment", "demo-web", { app: "demo-web" }],
+    ["statefulset", "demo-db", { app: "demo-db" }],
+    ["daemonset", "demo-log-collector", { app: "demo-log-collector" }],
+    ["replicaset", "demo-web-7d4b8c", { "pod-template-hash": "7d4b8c" }],
+    ["job", "demo-migration", { "batch.kubernetes.io/controller-uid": "abc-123" }],
+  ] as const)(
+    "resolves %s pods through its own lister and selector",
+    async (kind, name, selector) => {
+      listerFor[kind].mockResolvedValue([{ name, namespace: "default", selector }]);
+
+      renderHook(() => useWorkloadLogs(name, "default", kind));
+      await act(async () => {});
+
+      expect(listerFor[kind]).toHaveBeenCalledWith({ namespace: "default" });
+      // Every other lister must stay untouched
+      for (const [otherKind, lister] of Object.entries(listerFor)) {
+        if (otherKind !== kind) expect(lister).not.toHaveBeenCalled();
+      }
+
+      const expectedLabelSelector = Object.entries(selector)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",");
+      expect(mockListPods).toHaveBeenCalledWith({
+        namespace: "default",
+        label_selector: expectedLabelSelector,
+      });
+    }
+  );
+
+  it("reports a kind-specific error when the workload is missing", async () => {
+    mockListStatefulsets.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useWorkloadLogs("demo-db", "default", "statefulset"));
+    await act(async () => {});
+
+    expect(result.current.error?.message).toContain("StatefulSet demo-db not found");
+    expect(mockListPods).not.toHaveBeenCalled();
+  });
+
+  it("skips the pod query when the selector is empty", async () => {
+    mockListJobs.mockResolvedValue([
+      { name: "demo-migration", namespace: "default", selector: {} },
+    ]);
+
+    const { result } = renderHook(() =>
+      useWorkloadLogs("demo-migration", "default", "job")
+    );
+    await act(async () => {});
+
+    expect(mockListPods).not.toHaveBeenCalled();
+    expect(result.current.pods).toEqual([]);
+  });
+
+  it("defaults to deployment when no kind is given", async () => {
+    mockListDeployments.mockResolvedValue([
+      { name: "demo-web", namespace: "default", selector: { app: "demo-web" } },
+    ]);
+
+    renderHook(() => useWorkloadLogs("demo-web", "default"));
+    await act(async () => {});
+
+    expect(mockListDeployments).toHaveBeenCalled();
+  });
+});
+
+describe("supportsAggregatedLogs", () => {
+  it.each(["deployment", "statefulset", "daemonset", "replicaset", "job"])(
+    "accepts %s",
+    (kind) => {
+      expect(supportsAggregatedLogs(kind)).toBe(true);
+    }
+  );
+
+  // CronJobs own Jobs, not pods, so they need a second resolution hop.
+  it.each(["cronjob", "pod", "service", "configmap"])("rejects %s", (kind) => {
+    expect(supportsAggregatedLogs(kind)).toBe(false);
   });
 });

--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -29,7 +29,9 @@ const mockListen = listen as jest.Mock;
 describe("useWorkloadLogs unmount during watch setup", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockListDeployments.mockResolvedValue([]);
+    mockListDeployments.mockResolvedValue([
+      { name: "demo-web", namespace: "default", selector_query: "app=demo-web" },
+    ]);
     mockListPods.mockResolvedValue([]);
     mockWatchPods.mockResolvedValue(undefined);
     mockStopWatch.mockResolvedValue(undefined);
@@ -97,7 +99,7 @@ describe("useWorkloadLogs seq stamping", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockListDeployments.mockResolvedValue([
-      { name: "demo-web", namespace: "default", selector: { app: "demo-web" } },
+      { name: "demo-web", namespace: "default", selector_query: "app=demo-web" },
     ]);
     mockListPods.mockResolvedValue([podEntry]);
     mockWatchPods.mockResolvedValue(undefined);
@@ -182,15 +184,17 @@ describe("useWorkloadLogs pod resolution per workload kind", () => {
   });
 
   it.each([
-    ["deployment", "demo-web", { app: "demo-web" }],
-    ["statefulset", "demo-db", { app: "demo-db" }],
-    ["daemonset", "demo-log-collector", { app: "demo-log-collector" }],
-    ["replicaset", "demo-web-7d4b8c", { "pod-template-hash": "7d4b8c" }],
-    ["job", "demo-migration", { "batch.kubernetes.io/controller-uid": "abc-123" }],
+    ["deployment", "demo-web", "app=demo-web"],
+    ["statefulset", "demo-db", "app=demo-db"],
+    ["daemonset", "demo-log-collector", "app=demo-log-collector"],
+    ["replicaset", "demo-web-7d4b8c", "pod-template-hash=7d4b8c"],
+    ["job", "demo-migration", "batch.kubernetes.io/controller-uid=abc-123"],
   ] as const)(
     "resolves %s pods through its own lister and selector",
-    async (kind, name, selector) => {
-      listerFor[kind].mockResolvedValue([{ name, namespace: "default", selector }]);
+    async (kind, name, selectorQuery) => {
+      listerFor[kind].mockResolvedValue([
+        { name, namespace: "default", selector_query: selectorQuery },
+      ]);
 
       renderHook(() => useWorkloadLogs(name, "default", kind));
       await act(async () => {});
@@ -201,13 +205,15 @@ describe("useWorkloadLogs pod resolution per workload kind", () => {
         if (otherKind !== kind) expect(lister).not.toHaveBeenCalled();
       }
 
-      const expectedLabelSelector = Object.entries(selector)
-        .map(([k, v]) => `${k}=${v}`)
-        .join(",");
       expect(mockListPods).toHaveBeenCalledWith({
         namespace: "default",
-        label_selector: expectedLabelSelector,
+        label_selector: selectorQuery,
       });
+      expect(mockWatchPods).toHaveBeenCalledWith(
+        expect.stringContaining(`workload-pods-${kind}-default-${name}`),
+        "default",
+        selectorQuery
+      );
     }
   );
 
@@ -223,7 +229,7 @@ describe("useWorkloadLogs pod resolution per workload kind", () => {
 
   it("skips the pod query when the selector is empty", async () => {
     mockListJobs.mockResolvedValue([
-      { name: "demo-migration", namespace: "default", selector: {} },
+      { name: "demo-migration", namespace: "default", selector_query: "" },
     ]);
 
     const { result } = renderHook(() =>
@@ -237,7 +243,7 @@ describe("useWorkloadLogs pod resolution per workload kind", () => {
 
   it("defaults to deployment when no kind is given", async () => {
     mockListDeployments.mockResolvedValue([
-      { name: "demo-web", namespace: "default", selector: { app: "demo-web" } },
+      { name: "demo-web", namespace: "default", selector_query: "app=demo-web" },
     ]);
 
     renderHook(() => useWorkloadLogs("demo-web", "default"));

--- a/src/lib/hooks/useOpenWorkloadLogsTab.ts
+++ b/src/lib/hooks/useOpenWorkloadLogsTab.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import { useTabsStore } from "@/lib/stores/tabs-store";
+import type { WorkloadLogKind } from "./useWorkloadLogs";
+
+/**
+ * Opens (or focuses) the aggregated log tab for a workload.
+ *
+ * The tab type stays "deployment-logs" for every workload kind — it is
+ * persisted in restored tabs, so renaming it would strand existing sessions.
+ * The actual kind travels in the tab metadata.
+ */
+export function useOpenWorkloadLogsTab() {
+  const t = useTranslations();
+  const openOrActivateTab = useTabsStore((s) => s.openOrActivateTab);
+
+  return useCallback(
+    (
+      kind: WorkloadLogKind,
+      name: string,
+      namespace: string,
+      opts?: { autoStream?: boolean },
+    ) => {
+      const result = openOrActivateTab(
+        "deployment-logs",
+        `Logs: ${name} (${namespace})`,
+        { namespace, workloadName: name, workloadKind: kind, autoStream: opts?.autoStream },
+        (tab) =>
+          tab.type === "deployment-logs" &&
+          tab.metadata?.workloadName === name &&
+          tab.metadata?.workloadKind === kind &&
+          tab.metadata?.namespace === namespace,
+      );
+      if (result === null) {
+        toast.warning(t("tabs.limitToast"));
+        return false;
+      }
+      return true;
+    },
+    [openOrActivateTab, t],
+  );
+}

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -5,6 +5,10 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   listPods,
   listDeployments,
+  listStatefulsets,
+  listDaemonsets,
+  listReplicasets,
+  listJobs,
   streamPodLogs,
   stopLogStream,
   watchPods,
@@ -38,7 +42,51 @@ export interface PodColorEntry {
   bg: string;
 }
 
-export interface UseDeploymentLogsReturn {
+/**
+ * Workload types whose pods can be aggregated into a single log view.
+ *
+ * CronJobs are absent on purpose: they own no pods directly, only Jobs, so
+ * they would need a second resolution hop through their children.
+ */
+export const AGGREGATED_LOG_WORKLOADS = [
+  "deployment",
+  "statefulset",
+  "daemonset",
+  "replicaset",
+  "job",
+] as const;
+
+export type WorkloadLogKind = (typeof AGGREGATED_LOG_WORKLOADS)[number];
+
+export function supportsAggregatedLogs(resourceType: string): resourceType is WorkloadLogKind {
+  return (AGGREGATED_LOG_WORKLOADS as readonly string[]).includes(resourceType);
+}
+
+/** Human-readable kind, used in AI prompts and view titles */
+export const WORKLOAD_KIND_LABELS: Record<WorkloadLogKind, string> = {
+  deployment: "Deployment",
+  statefulset: "StatefulSet",
+  daemonset: "DaemonSet",
+  replicaset: "ReplicaSet",
+  job: "Job",
+};
+
+/**
+ * Every supported workload exposes spec.selector.matchLabels as `selector`,
+ * so resolving its pods only differs by which lister to call.
+ */
+const WORKLOAD_LISTERS: Record<
+  WorkloadLogKind,
+  (namespace: string) => Promise<Array<{ name: string; selector: Record<string, string> }>>
+> = {
+  deployment: (namespace) => listDeployments({ namespace }),
+  statefulset: (namespace) => listStatefulsets({ namespace }),
+  daemonset: (namespace) => listDaemonsets({ namespace }),
+  replicaset: (namespace) => listReplicasets({ namespace }),
+  job: (namespace) => listJobs({ namespace }),
+};
+
+export interface UseWorkloadLogsReturn {
   logs: LogEntry[];
   pods: PodInfo[];
   podColorMap: Map<string, PodColorEntry>;
@@ -55,13 +103,14 @@ export interface UseDeploymentLogsReturn {
 }
 
 /**
- * Hook that aggregates logs from all pods belonging to a deployment.
+ * Hook that aggregates logs from all pods belonging to a workload.
  * Uses the Kubernetes watch API to keep the pod list in sync in real-time.
  */
-export function useDeploymentLogs(
-  deploymentName: string,
+export function useWorkloadLogs(
+  workloadName: string,
   namespace: string,
-): UseDeploymentLogsReturn {
+  kind: WorkloadLogKind = "deployment",
+): UseWorkloadLogsReturn {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [pods, setPods] = useState<PodInfo[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -159,7 +208,7 @@ export function useDeploymentLogs(
     }, 150);
   }, [flushPending]);
 
-  /** Check if a pod matches the deployment's selector */
+  /** Check if a pod matches the workload's selector */
   const podMatchesSelector = useCallback((pod: PodInfo): boolean => {
     const selector = selectorRef.current;
     if (!selector || Object.keys(selector).length === 0) return false;
@@ -168,21 +217,23 @@ export function useDeploymentLogs(
     );
   }, []);
 
-  // Fetch deployment selector + initial pod list
+  // Fetch workload selector + initial pod list
   const fetchPods = useCallback(async () => {
     try {
-      const deployments = await listDeployments({ namespace });
-      const deployment = deployments.find((d) => d.name === deploymentName);
-      if (!deployment) {
+      const workloads = await WORKLOAD_LISTERS[kind](namespace);
+      const workload = workloads.find((w) => w.name === workloadName);
+      if (!workload) {
         if (mountedRef.current) {
-          setError(toKubeliError(`Deployment ${deploymentName} not found`));
+          setError(
+            toKubeliError(`${WORKLOAD_KIND_LABELS[kind]} ${workloadName} not found`)
+          );
         }
         return [];
       }
 
-      selectorRef.current = deployment.selector;
+      selectorRef.current = workload.selector;
 
-      const labelSelector = Object.entries(deployment.selector)
+      const labelSelector = Object.entries(workload.selector)
         .map(([k, v]) => `${k}=${v}`)
         .join(",");
 
@@ -205,7 +256,7 @@ export function useDeploymentLogs(
       }
       return [];
     }
-  }, [namespace, deploymentName]);
+  }, [namespace, workloadName, kind]);
 
   const stopAllStreams = useCallback(async () => {
     const streamIds = [...activeStreamIds.current];
@@ -253,7 +304,7 @@ export function useDeploymentLogs(
 
         for (const pod of currentPods) {
           if (!mountedRef.current) break;
-          const streamId = `deploy-logs-${namespace}-${deploymentName}-${pod.name}-${Date.now()}`;
+          const streamId = `workload-logs-${kind}-${namespace}-${workloadName}-${pod.name}-${Date.now()}`;
           streamIds.push(streamId);
 
           const eventName = `log-stream-${streamId}`;
@@ -324,7 +375,7 @@ export function useDeploymentLogs(
         }
       }
     },
-    [isStreaming, stopAllStreams, fetchPods, namespace, deploymentName, scheduleFlush, flushPending]
+    [isStreaming, stopAllStreams, fetchPods, namespace, workloadName, kind, scheduleFlush, flushPending]
   );
 
   const clearLogs = useCallback(() => {
@@ -346,7 +397,7 @@ export function useDeploymentLogs(
     mountedRef.current = true;
     fetchPods();
 
-    const watchId = `deploy-pods-${namespace}-${deploymentName}-${Date.now()}`;
+    const watchId = `workload-pods-${kind}-${namespace}-${workloadName}-${Date.now()}`;
     let watchUnlisten: UnlistenFn | null = null;
     let cancelled = false;
 
@@ -446,7 +497,7 @@ export function useDeploymentLogs(
         clearTimeout(flushTimerRef.current);
       }
     };
-  }, [fetchPods, namespace, deploymentName, podMatchesSelector]);
+  }, [fetchPods, namespace, workloadName, kind, podMatchesSelector]);
 
   return {
     logs,

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -72,12 +72,12 @@ export const WORKLOAD_KIND_LABELS: Record<WorkloadLogKind, string> = {
 };
 
 /**
- * Every supported workload exposes spec.selector.matchLabels as `selector`,
- * so resolving its pods only differs by which lister to call.
+ * Every supported workload exposes its complete Kubernetes label selector as
+ * `selector_query`, so resolving its pods only differs by which lister to call.
  */
 const WORKLOAD_LISTERS: Record<
   WorkloadLogKind,
-  (namespace: string) => Promise<Array<{ name: string; selector: Record<string, string> }>>
+  (namespace: string) => Promise<Array<{ name: string; selector_query: string }>>
 > = {
   deployment: (namespace) => listDeployments({ namespace }),
   statefulset: (namespace) => listStatefulsets({ namespace }),
@@ -123,7 +123,7 @@ export function useWorkloadLogs(
   const pendingLogsRef = useRef<LogEntry[]>([]);
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
-  const selectorRef = useRef<Record<string, string>>({});
+  const selectorQueryRef = useRef("");
   // Stable color assignment - remembers colors for pods that have disappeared
   const colorAssignmentsRef = useRef(new Map<string, PodColorEntry>());
   const nextColorIndexRef = useRef(0);
@@ -208,15 +208,6 @@ export function useWorkloadLogs(
     }, 150);
   }, [flushPending]);
 
-  /** Check if a pod matches the workload's selector */
-  const podMatchesSelector = useCallback((pod: PodInfo): boolean => {
-    const selector = selectorRef.current;
-    if (!selector || Object.keys(selector).length === 0) return false;
-    return Object.entries(selector).every(
-      ([k, v]) => pod.labels && pod.labels[k] === v
-    );
-  }, []);
-
   // Fetch workload selector + initial pod list
   const fetchPods = useCallback(async () => {
     try {
@@ -231,11 +222,8 @@ export function useWorkloadLogs(
         return [];
       }
 
-      selectorRef.current = workload.selector;
-
-      const labelSelector = Object.entries(workload.selector)
-        .map(([k, v]) => `${k}=${v}`)
-        .join(",");
+      const labelSelector = workload.selector_query;
+      selectorQueryRef.current = labelSelector;
 
       if (!labelSelector) {
         if (mountedRef.current) setPods([]);
@@ -395,14 +383,15 @@ export function useWorkloadLogs(
   // Initial fetch + pod watch for real-time badge updates
   useEffect(() => {
     mountedRef.current = true;
-    fetchPods();
-
     const watchId = `workload-pods-${kind}-${namespace}-${workloadName}-${Date.now()}`;
     let watchUnlisten: UnlistenFn | null = null;
     let cancelled = false;
 
     const setupWatch = async () => {
       try {
+        await fetchPods();
+        if (cancelled || !selectorQueryRef.current) return;
+
         // Listen for pod watch events
         const unlisten = await listen<WatchEvent<PodInfo>>(
           `pods-watch-${watchId}`,
@@ -414,7 +403,6 @@ export function useWorkloadLogs(
               switch (watchEvent.type) {
                 case "Added": {
                   const pod = watchEvent.data as PodInfo;
-                  if (!podMatchesSelector(pod)) return prev;
                   if (pod.phase !== "Running" && pod.phase !== "Pending") return prev;
                   // Don't add duplicates
                   if (prev.some((p) => p.uid === pod.uid)) {
@@ -424,10 +412,6 @@ export function useWorkloadLogs(
                 }
                 case "Modified": {
                   const pod = watchEvent.data as PodInfo;
-                  if (!podMatchesSelector(pod)) {
-                    // No longer matches selector - remove
-                    return prev.filter((p) => p.uid !== pod.uid);
-                  }
                   if (pod.phase !== "Running" && pod.phase !== "Pending") {
                     // No longer active - remove
                     return prev.filter((p) => p.uid !== pod.uid);
@@ -445,7 +429,7 @@ export function useWorkloadLogs(
                 case "Restarted": {
                   const allPods = watchEvent.data as PodInfo[];
                   return allPods.filter(
-                    (p) => podMatchesSelector(p) && (p.phase === "Running" || p.phase === "Pending")
+                    (p) => p.phase === "Running" || p.phase === "Pending"
                   );
                 }
                 default:
@@ -463,7 +447,7 @@ export function useWorkloadLogs(
         watchUnlisten = unlisten;
 
         // Start the watch
-        await watchPods(watchId, namespace);
+        await watchPods(watchId, namespace, selectorQueryRef.current);
 
         // Cleanup ran while watchPods() was pending - its stopWatch was a
         // no-op back then, so stop the watch here
@@ -497,7 +481,7 @@ export function useWorkloadLogs(
         clearTimeout(flushTimerRef.current);
       }
     };
-  }, [fetchPods, namespace, workloadName, kind, podMatchesSelector]);
+  }, [fetchPods, namespace, workloadName, kind]);
 
   return {
     logs,

--- a/src/lib/stores/tabs-store.ts
+++ b/src/lib/stores/tabs-store.ts
@@ -1,11 +1,18 @@
 import { create } from "zustand";
 import type { ResourceType } from "@/components/layout/sidebar/Sidebar";
+import type { WorkloadLogKind } from "@/lib/hooks/useWorkloadLogs";
 import { useLogStore } from "./log-store";
 
 export interface TabMetadata {
   namespace?: string;
   podName?: string;
+  /**
+   * @deprecated Use workloadName. Kept so tabs persisted by older versions
+   * keep resolving after an update.
+   */
   deploymentName?: string;
+  workloadName?: string;
+  workloadKind?: WorkloadLogKind;
   autoStream?: boolean;
 }
 

--- a/src/lib/tauri/commands/watch.ts
+++ b/src/lib/tauri/commands/watch.ts
@@ -1,8 +1,16 @@
 import { invoke } from "./core";
 
 // Watch commands
-export async function watchPods(watchId: string, namespace?: string): Promise<void> {
-  return invoke("watch_pods", { watchId, namespace });
+export async function watchPods(
+  watchId: string,
+  namespace?: string,
+  labelSelector?: string
+): Promise<void> {
+  return invoke("watch_pods", {
+    watchId,
+    namespace,
+    ...(labelSelector ? { labelSelector } : {}),
+  });
 }
 
 export async function watchNamespaces(watchId: string): Promise<void> {

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -349,6 +349,8 @@ export interface DeploymentInfo {
   created_at: string | null;
   labels: Record<string, string>;
   selector: Record<string, string>;
+  /** Full selector, including matchExpressions, in Kubernetes query syntax */
+  selector_query: string;
 }
 
 export interface ServiceInfo {
@@ -606,6 +608,8 @@ export interface ReplicaSetInfo {
   created_at: string | null;
   labels: Record<string, string>;
   selector: Record<string, string>;
+  /** Full selector, including matchExpressions, in Kubernetes query syntax */
+  selector_query: string;
 }
 
 // DaemonSet info
@@ -624,6 +628,8 @@ export interface DaemonSetInfo {
   node_selector: Record<string, string>;
   /** Pod selector from spec.selector — resolves the DaemonSet's pods */
   selector: Record<string, string>;
+  /** Full selector, including matchExpressions, in Kubernetes query syntax */
+  selector_query: string;
 }
 
 // StatefulSet info
@@ -640,6 +646,8 @@ export interface StatefulSetInfo {
   labels: Record<string, string>;
   /** Pod selector from spec.selector — resolves the StatefulSet's pods */
   selector: Record<string, string>;
+  /** Full selector, including matchExpressions, in Kubernetes query syntax */
+  selector_query: string;
 }
 
 // Job info
@@ -663,6 +671,8 @@ export interface JobInfo {
    * controller-generated `batch.kubernetes.io/controller-uid` label.
    */
   selector: Record<string, string>;
+  /** Full selector, including matchExpressions, in Kubernetes query syntax */
+  selector_query: string;
 }
 
 // CronJob info

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -622,6 +622,8 @@ export interface DaemonSetInfo {
   created_at: string | null;
   labels: Record<string, string>;
   node_selector: Record<string, string>;
+  /** Pod selector from spec.selector — resolves the DaemonSet's pods */
+  selector: Record<string, string>;
 }
 
 // StatefulSet info
@@ -636,6 +638,8 @@ export interface StatefulSetInfo {
   service_name: string | null;
   created_at: string | null;
   labels: Record<string, string>;
+  /** Pod selector from spec.selector — resolves the StatefulSet's pods */
+  selector: Record<string, string>;
 }
 
 // Job info
@@ -654,6 +658,11 @@ export interface JobInfo {
   created_at: string | null;
   labels: Record<string, string>;
   status: string;
+  /**
+   * Pod selector from spec.selector — resolves the Job's pods. Normally the
+   * controller-generated `batch.kubernetes.io/controller-uid` label.
+   */
+  selector: Record<string, string>;
 }
 
 // CronJob info


### PR DESCRIPTION
Closes #212

> Stacked on #408 (which is stacked on #407). Review those first — base retargets automatically as each merges.

Aggregated log viewing was Deployment-only for a structural reason: `DeploymentInfo` was the only workload struct carrying `spec.selector.matchLabels`. Without a selector there is no way to resolve a workload's pods, so the feature could not simply be pointed at other kinds.

## Backend

`StatefulSetInfo`, `DaemonSetInfo` and `JobInfo` gain a `selector` field, mirroring what Deployment and ReplicaSet already had. No new command was needed — `list_pods` already accepts a label selector, so pod resolution stays frontend-side exactly as before.

For Jobs this is normally the controller-generated `batch.kubernetes.io/controller-uid` label, which is more reliable than matching on `job-name`.

## Frontend

`useDeploymentLogs` → `useWorkloadLogs`, taking a `kind` that selects the lister. Everything else in the hook — the pod watch, the 150 ms merge-sort flush, stable pod colors, filtering — was already kind-agnostic and is untouched. `DeploymentLogViewer` → `WorkloadLogViewer`, passing the kind through to the AI prompt title from #408.

The Logs tab in the resource detail and a "View Logs" context menu action now appear for every supported workload. The context menu entry lives in `_createResourceView`, so StatefulSets, DaemonSets, ReplicaSets and Jobs all get it from one place rather than four copies.

**CronJobs are deliberately excluded.** They own Jobs, not pods, so they would need a second resolution hop through their children — worth its own issue if wanted.

## Compatibility

- Stream and watch IDs now carry the kind. A Deployment and a StatefulSet of the same name in one namespace previously produced colliding IDs.
- Tab metadata gains `workloadName`/`workloadKind`; the old `deploymentName` key is read as a fallback so tabs persisted by an older version keep resolving after an update.
- The `"deployment-logs"` tab type string is unchanged for the same reason — it is persisted in restored tabs, so renaming it would strand existing sessions.

## Tests

- Per-kind pod resolution: each of the five kinds calls its own lister with the right label selector, and no other lister is touched.
- Kind-specific "not found" error, empty-selector short-circuit, and the deployment default.
- `supportsAggregatedLogs` accepts the five workloads and rejects CronJob/Pod/Service/ConfigMap.

`make check`, `make lint`, `make vet`, `cargo clippy -- -D warnings`, 737 frontend tests and 299 Rust tests pass.