### PR TITLE
feat: parse and render ANSI escape codes in the log viewer

### DIFF
--- a/src/components/features/logs/LogViewer.tsx
+++ b/src/components/features/logs/LogViewer.tsx
@@ -8,6 +8,7 @@ import { useTabsStore } from "@/lib/stores/tabs-store";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useTranslations } from "next-intl";
 import { LogHeader, LogToolbar, LogContent, LogFooter } from "./components";
+import { stripAnsi } from "./lib";
 import { useLogFilter, useLogAnalysis, useLogDownload, useAutoScroll } from "./hooks";
 import { LOG_DEFAULTS } from "./types";
 import type { TimestampMode } from "./types";
@@ -54,6 +55,7 @@ export function LogViewer({ namespace, podName, initialContainer, logTabId, onOp
   // Display options state
   const [lineWrap, setLineWrap] = useState(true);
   const [logColoring, setLogColoring] = useState(true);
+  const [ansiColors, setAnsiColors] = useState(true);
   const [timestampMode, setTimestampMode] = useState<TimestampMode>("local");
 
   const showTimestamps = timestampMode !== "off";
@@ -121,7 +123,7 @@ export function LogViewer({ namespace, podName, initialContainer, logTabId, onOp
   // Copy all logs to clipboard
   const copyAllLogs = useCallback(async () => {
     try {
-      const text = filteredLogs.map((l) => l.message).join("\n");
+      const text = filteredLogs.map((l) => stripAnsi(l.message)).join("\n");
       await navigator.clipboard.writeText(text);
     } catch {
       // Clipboard write may fail in some environments
@@ -200,6 +202,8 @@ export function LogViewer({ namespace, podName, initialContainer, logTabId, onOp
           onLineWrapChange: setLineWrap,
           logColoring,
           onLogColoringChange: setLogColoring,
+          ansiColors,
+          onAnsiColorsChange: setAnsiColors,
           timestampMode,
           onTimestampModeChange: setTimestampMode,
           labels: {
@@ -207,6 +211,7 @@ export function LogViewer({ namespace, podName, initialContainer, logTabId, onOp
             displayOptions: t("logs.displayOptions"),
             lineWrap: t("logs.lineWrap"),
             logColoring: t("logs.logColoring"),
+            ansiColors: t("logs.ansiColors"),
             timestamp: t("logs.timestampSection"),
             timestampOff: t("logs.timestampOff"),
             timestampUtc: t("logs.timestampUtc"),
@@ -275,6 +280,7 @@ export function LogViewer({ namespace, podName, initialContainer, logTabId, onOp
         timestampLocal={timestampLocal}
         lineWrap={lineWrap}
         logColoring={logColoring}
+        ansiColors={ansiColors}
         useRegex={useRegex}
         searchRegex={searchRegex}
         onScroll={handleScroll}

--- a/src/components/features/logs/WorkloadLogViewer.tsx
+++ b/src/components/features/logs/WorkloadLogViewer.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useTranslations } from "next-intl";
 import { LogToolbar, LogFooter, LogContent } from "./components";
+import { stripAnsi } from "./lib";
 import { useLogFilter, useAutoScroll, useLogAnalysis, useLogDownload } from "./hooks";
 import { LOG_DEFAULTS } from "./types";
 import type { TimestampMode } from "./types";
@@ -58,6 +59,7 @@ export function WorkloadLogViewer({
   // Display options state
   const [lineWrap, setLineWrap] = useState(true);
   const [logColoring, setLogColoring] = useState(true);
+  const [ansiColors, setAnsiColors] = useState(true);
   const [timestampMode, setTimestampMode] = useState<TimestampMode>("local");
 
   const showTimestamps = timestampMode !== "off";
@@ -98,7 +100,7 @@ export function WorkloadLogViewer({
 
   const copyAllLogs = useCallback(async () => {
     try {
-      const text = filteredLogs.map((l) => l.message).join("\n");
+      const text = filteredLogs.map((l) => stripAnsi(l.message)).join("\n");
       await navigator.clipboard.writeText(text);
     } catch {
       // Clipboard write may fail in some environments
@@ -245,6 +247,8 @@ export function WorkloadLogViewer({
           onLineWrapChange: setLineWrap,
           logColoring,
           onLogColoringChange: setLogColoring,
+          ansiColors,
+          onAnsiColorsChange: setAnsiColors,
           timestampMode,
           onTimestampModeChange: setTimestampMode,
           labels: {
@@ -252,6 +256,7 @@ export function WorkloadLogViewer({
             displayOptions: t("logs.displayOptions"),
             lineWrap: t("logs.lineWrap"),
             logColoring: t("logs.logColoring"),
+            ansiColors: t("logs.ansiColors"),
             timestamp: t("logs.timestampSection"),
             timestampOff: t("logs.timestampOff"),
             timestampUtc: t("logs.timestampUtc"),
@@ -311,6 +316,7 @@ export function WorkloadLogViewer({
         timestampLocal={timestampLocal}
         lineWrap={lineWrap}
         logColoring={logColoring}
+        ansiColors={ansiColors}
         searchQuery={searchQuery}
         useRegex={useRegex}
         searchRegex={searchRegex}

--- a/src/components/features/logs/components/LogContent.tsx
+++ b/src/components/features/logs/components/LogContent.tsx
@@ -24,6 +24,8 @@ interface LogContentProps {
   streamDisabled?: boolean;
   /** Per-pod colors for aggregated multi-pod logs; enables the pod name prefix */
   podColorMap?: Map<string, PodColorEntry>;
+  /** Render ANSI escape codes as colors/styles instead of stripping them */
+  ansiColors?: boolean;
   /** Ref for scroll-to-bottom target (placed at end of logs) */
   endRef?: React.RefObject<HTMLDivElement | null>;
   // i18n
@@ -61,6 +63,7 @@ export const LogContent = forwardRef<HTMLDivElement, LogContentProps>(
       onStartStream,
       streamDisabled,
       podColorMap,
+      ansiColors,
       endRef,
       loadingText,
       searchingText,
@@ -209,6 +212,7 @@ export const LogContent = forwardRef<HTMLDivElement, LogContentProps>(
                     useRegex={useRegex}
                     searchRegex={searchRegex}
                     podColor={podColorMap?.get(log.pod)?.text}
+                    ansiColors={ansiColors}
                   />
                 </div>
               );

--- a/src/components/features/logs/components/LogLine.tsx
+++ b/src/components/features/logs/components/LogLine.tsx
@@ -4,7 +4,8 @@ import { memo, useMemo } from "react";
 import type { LogEntry } from "@/lib/types";
 import { LOG_LEVEL_COLORS } from "../types";
 import { getLogLevel, formatTimestamp } from "../lib";
-import { highlightMessage } from "./highlight";
+import { hasAnsiCodes, parseAnsi, stripAnsi } from "../lib/ansi";
+import { highlightMessage, findMatchRanges, renderStyledSegments } from "./highlight";
 
 interface LogLineProps {
   log: LogEntry;
@@ -16,6 +17,8 @@ interface LogLineProps {
   searchRegex: RegExp | null;
   /** Color class for the pod name prefix; when set, the pod name is shown */
   podColor?: string;
+  /** Render ANSI escape codes as colors/styles instead of stripping them */
+  ansiColors?: boolean;
 }
 
 /**
@@ -38,13 +41,28 @@ export const LogLine = memo(function LogLine({
   useRegex,
   searchRegex,
   podColor,
+  ansiColors = true,
 }: LogLineProps) {
   const logLevel = useMemo(() => getLogLevel(log.message), [log.message]);
 
-  const highlightedMessage = useMemo(
-    () => highlightMessage(log.message, searchQuery, useRegex, searchRegex),
-    [log.message, searchQuery, useRegex, searchRegex]
+  // Escape codes are only parsed when the line actually contains them, so the
+  // common case stays on the plain-string path.
+  const isAnsi = useMemo(
+    () => ansiColors && hasAnsiCodes(log.message),
+    [ansiColors, log.message]
   );
+
+  const renderedMessage = useMemo(() => {
+    if (isAnsi) {
+      const segments = parseAnsi(log.message);
+      const plain = segments.map((s) => s.text).join("");
+      const matches = findMatchRanges(plain, searchQuery, useRegex, searchRegex);
+      return renderStyledSegments(segments, matches);
+    }
+    // ansiColors off (or no codes present): strip so raw escapes never render
+    const plain = ansiColors ? log.message : stripAnsi(log.message);
+    return highlightMessage(plain, searchQuery, useRegex, searchRegex);
+  }, [isAnsi, ansiColors, log.message, searchQuery, useRegex, searchRegex]);
 
   // Pod names typically follow: <deployment>-<replicaset-hash>-<pod-hash>.
   // Show the last two segments for brevity; full name stays in the title.
@@ -54,9 +72,12 @@ export const LogLine = memo(function LogLine({
     return parts.length > 2 ? parts.slice(-2).join("-") : log.pod;
   }, [log.pod, podColor]);
 
-  const colorClass = logColoring
-    ? LOG_LEVEL_COLORS[logLevel] || LOG_LEVEL_COLORS.default
-    : "text-foreground";
+  // ANSI segments carry their own inline colors; the level heuristic would only
+  // fight them, so it applies to uncolored lines.
+  const colorClass =
+    logColoring && !isAnsi
+      ? LOG_LEVEL_COLORS[logLevel] || LOG_LEVEL_COLORS.default
+      : "text-foreground";
 
   return (
     <>
@@ -71,7 +92,7 @@ export const LogLine = memo(function LogLine({
         </span>
       )}
       <span className={colorClass}>
-        {highlightedMessage}
+        {renderedMessage}
       </span>
       {"\n"}
     </>

--- a/src/components/features/logs/components/LogToolbar.tsx
+++ b/src/components/features/logs/components/LogToolbar.tsx
@@ -43,6 +43,8 @@ export interface DisplayOptionsProps {
   onLineWrapChange: (checked: boolean) => void;
   logColoring: boolean;
   onLogColoringChange: (checked: boolean) => void;
+  ansiColors: boolean;
+  onAnsiColorsChange: (checked: boolean) => void;
   timestampMode: TimestampMode;
   onTimestampModeChange: (mode: TimestampMode) => void;
   labels: DisplayOptionsLabels;
@@ -183,6 +185,8 @@ export function LogToolbar({
             lineWrap={displayOptions.lineWrap}
             onLineWrapChange={displayOptions.onLineWrapChange}
             logColoring={displayOptions.logColoring}
+            ansiColors={displayOptions.ansiColors}
+            onAnsiColorsChange={displayOptions.onAnsiColorsChange}
             onLogColoringChange={displayOptions.onLogColoringChange}
             timestampMode={displayOptions.timestampMode}
             onTimestampModeChange={displayOptions.onTimestampModeChange}

--- a/src/components/features/logs/components/__tests__/LogLine.test.tsx
+++ b/src/components/features/logs/components/__tests__/LogLine.test.tsx
@@ -11,7 +11,12 @@ const log = (message: string): LogEntry => ({
   namespace: "default",
 });
 
-const renderLine = (message: string, query: string, useRegex: boolean) =>
+const renderLine = (
+  message: string,
+  query: string,
+  useRegex: boolean,
+  extraProps: Partial<React.ComponentProps<typeof LogLine>> = {}
+) =>
   render(
     <pre>
       <LogLine
@@ -20,6 +25,7 @@ const renderLine = (message: string, query: string, useRegex: boolean) =>
         searchQuery={query}
         useRegex={useRegex}
         searchRegex={useRegex ? compileRegex(query) : null}
+        {...extraProps}
       />
     </pre>
   );
@@ -51,5 +57,92 @@ describe("LogLine highlighting", () => {
     expect(marks[0].textContent).toBe("ERROR");
     expect(marks[1].textContent).toBe("WARN");
     expect(container.textContent).toBe("x ERROR y WARN z\n");
+  });
+});
+
+const ESC = "\x1b";
+
+describe("LogLine ANSI rendering", () => {
+  it("renders escape codes as styles instead of literal text", () => {
+    const { container } = renderLine(`${ESC}[31mERROR${ESC}[0m refused`, "", false);
+
+    expect(container.textContent).toBe("ERROR refused\n");
+    const colored = container.querySelector("span[style]");
+    expect(colored).toHaveStyle({ color: "#cd3131" });
+    expect(colored?.textContent).toBe("ERROR");
+  });
+
+  it("strips codes without styling when ansiColors is off", () => {
+    const { container } = renderLine(`${ESC}[31mERROR${ESC}[0m refused`, "", false, {
+      ansiColors: false,
+    });
+
+    expect(container.textContent).toBe("ERROR refused\n");
+    expect(container.querySelector("span[style]")).toBeNull();
+  });
+
+  it("applies bold and underline", () => {
+    const { container } = renderLine(`${ESC}[1;4mheading`, "", false);
+    const styled = container.querySelector("span[style]");
+    expect(styled).toHaveStyle({ fontWeight: "bold", textDecoration: "underline" });
+  });
+
+  // The two features slice the same message on different boundaries: ANSI by
+  // style runs, search by match. Both must survive.
+  it("highlights a search match inside a colored segment", () => {
+    const { container } = renderLine(
+      `${ESC}[31mconnection refused${ESC}[0m ok`,
+      "refused",
+      false
+    );
+
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(1);
+    expect(marks[0].textContent).toBe("refused");
+    expect(container.textContent).toBe("connection refused ok\n");
+  });
+
+  it("splits a match that spans a color change, keeping both styles", () => {
+    // "error" starts in the red run and finishes in the plain one
+    const { container } = renderLine(`${ESC}[31merr${ESC}[0mor here`, "error", false);
+
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(2);
+    expect(Array.from(marks, (m) => m.textContent).join("")).toBe("error");
+    expect(container.textContent).toBe("error here\n");
+  });
+
+  it("matches search against stripped text, so codes cannot hide a phrase", () => {
+    // An escape sits in the middle of the searched phrase
+    const { container } = renderLine(`conn${ESC}[31mection`, "connection", false);
+
+    const marks = container.querySelectorAll("mark");
+    expect(marks.length).toBeGreaterThan(0);
+    expect(Array.from(marks, (m) => m.textContent).join("")).toBe("connection");
+  });
+
+  it("highlights regex matches across colored segments", () => {
+    const { container } = renderLine(
+      `${ESC}[31mERROR${ESC}[0m x ${ESC}[33mWARN${ESC}[0m`,
+      "(ERROR|WARN)",
+      true
+    );
+
+    const marks = container.querySelectorAll("mark");
+    expect(marks).toHaveLength(2);
+    expect(container.textContent).toBe("ERROR x WARN\n");
+  });
+
+  it("detects the log level through leading escape codes", () => {
+    // Without stripping, \b before "ERROR" never matches after "[31m"
+    const { container } = renderLine(`${ESC}[31mERROR${ESC}[0m boom`, "", false);
+    // Level coloring yields to ANSI, so the wrapper stays neutral
+    expect(container.querySelector(".text-destructive")).toBeNull();
+    expect(container.textContent).toBe("ERROR boom\n");
+  });
+
+  it("keeps level-based coloring for lines without escape codes", () => {
+    const { container } = renderLine("ERROR plain line", "", false);
+    expect(container.querySelector(".text-destructive")).not.toBeNull();
   });
 });

--- a/src/components/features/logs/components/highlight.tsx
+++ b/src/components/features/logs/components/highlight.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { escapeRegExp } from "../lib";
+import type { AnsiSegment, AnsiStyle } from "../lib/ansi";
 
 /** Maximum query length for highlighting to prevent performance issues */
 const MAX_HIGHLIGHT_QUERY_LENGTH = 200;
@@ -80,4 +81,132 @@ export function highlightMessage(
   if (!searchQuery) return message;
   if (useRegex && searchRegex) return highlightWithRegex(message, searchRegex);
   return highlightWithString(message, searchQuery);
+}
+
+/** Half-open [start, end) range of a search match within the message */
+interface MatchRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Collects search match ranges instead of slicing the string directly.
+ *
+ * ANSI styling and search highlighting both want to cut the same message on
+ * different boundaries. Ranges let a single pass interleave the two.
+ */
+export function findMatchRanges(
+  message: string,
+  searchQuery: string,
+  useRegex: boolean,
+  searchRegex: RegExp | null
+): MatchRange[] {
+  if (!searchQuery) return [];
+
+  const ranges: MatchRange[] = [];
+
+  if (useRegex && searchRegex) {
+    // See highlightWithRegex: the filter regex is non-global on purpose.
+    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+    const globalRegex = new RegExp(
+      searchRegex.source,
+      searchRegex.flags.includes("g") ? searchRegex.flags : `${searchRegex.flags}g`
+    );
+    for (const match of message.matchAll(globalRegex)) {
+      if (match[0] === "") continue;
+      const start = match.index ?? 0;
+      ranges.push({ start, end: start + match[0].length });
+    }
+    return ranges;
+  }
+
+  if (searchQuery.length > MAX_HIGHLIGHT_QUERY_LENGTH) return [];
+
+  const lowerText = message.toLowerCase();
+  const lowerQuery = searchQuery.toLowerCase();
+  let index = lowerText.indexOf(lowerQuery);
+  while (index !== -1) {
+    ranges.push({ start: index, end: index + searchQuery.length });
+    index = lowerText.indexOf(lowerQuery, index + searchQuery.length);
+  }
+  return ranges;
+}
+
+/**
+ * Renders ANSI-styled segments with search matches marked inside them.
+ *
+ * Segment offsets and match ranges both index into the same ANSI-stripped
+ * message, so a match spanning a color change is split across segments and
+ * each part keeps its own styling.
+ */
+export function renderStyledSegments(
+  segments: AnsiSegment[],
+  matches: MatchRange[]
+): React.ReactNode {
+  const nodes: React.ReactNode[] = [];
+  let key = 0;
+
+  for (const segment of segments) {
+    const segStart = segment.start;
+    const segEnd = segStart + segment.text.length;
+    const style = toCssStyle(segment.style);
+
+    // Matches overlapping this segment, clipped to its bounds
+    const local = matches
+      .filter((m) => m.end > segStart && m.start < segEnd)
+      .map((m) => ({
+        start: Math.max(m.start, segStart) - segStart,
+        end: Math.min(m.end, segEnd) - segStart,
+      }));
+
+    if (local.length === 0) {
+      nodes.push(
+        style ? (
+          <span key={key++} style={style}>
+            {segment.text}
+          </span>
+        ) : (
+          segment.text
+        )
+      );
+      continue;
+    }
+
+    const parts: React.ReactNode[] = [];
+    let cursor = 0;
+    for (const m of local) {
+      if (m.start > cursor) parts.push(segment.text.slice(cursor, m.start));
+      parts.push(
+        <mark key={key++} className="bg-yellow-500/30 text-yellow-200">
+          {segment.text.slice(m.start, m.end)}
+        </mark>
+      );
+      cursor = m.end;
+    }
+    if (cursor < segment.text.length) parts.push(segment.text.slice(cursor));
+
+    nodes.push(
+      style ? (
+        <span key={key++} style={style}>
+          {parts}
+        </span>
+      ) : (
+        <React.Fragment key={key++}>{parts}</React.Fragment>
+      )
+    );
+  }
+
+  return nodes;
+}
+
+/** Maps parsed ANSI attributes to a React style object, or undefined if empty */
+function toCssStyle(style: AnsiStyle): React.CSSProperties | undefined {
+  const hasAny =
+    style.color ||
+    style.backgroundColor ||
+    style.fontWeight ||
+    style.fontStyle ||
+    style.textDecoration ||
+    style.opacity !== undefined;
+  return hasAny ? (style as React.CSSProperties) : undefined;
 }

--- a/src/components/features/logs/components/toolbar/DisplayOptionsPopover.tsx
+++ b/src/components/features/logs/components/toolbar/DisplayOptionsPopover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SlidersHorizontal, WrapText, Palette } from "lucide-react";
+import { SlidersHorizontal, WrapText, Palette, Terminal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
@@ -13,6 +13,7 @@ export interface DisplayOptionsLabels {
   displayOptions: string;
   lineWrap: string;
   logColoring: string;
+  ansiColors: string;
   timestamp: string;
   timestampOff: string;
   timestampUtc: string;
@@ -24,6 +25,8 @@ interface DisplayOptionsPopoverProps {
   onLineWrapChange: (checked: boolean) => void;
   logColoring: boolean;
   onLogColoringChange: (checked: boolean) => void;
+  ansiColors: boolean;
+  onAnsiColorsChange: (checked: boolean) => void;
   timestampMode: TimestampMode;
   onTimestampModeChange: (mode: TimestampMode) => void;
   labels: DisplayOptionsLabels;
@@ -36,6 +39,8 @@ export function DisplayOptionsPopover({
   onLineWrapChange,
   logColoring,
   onLogColoringChange,
+  ansiColors,
+  onAnsiColorsChange,
   timestampMode,
   onTimestampModeChange,
   labels,
@@ -86,6 +91,18 @@ export function DisplayOptionsPopover({
             <Label htmlFor="log-coloring" className="text-xs cursor-pointer flex items-center gap-1.5 text-foreground">
               <Palette className="size-3.5 text-muted-foreground" />
               {labels.logColoring}
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="ansi-colors"
+              checked={ansiColors}
+              onCheckedChange={(checked) => onAnsiColorsChange(checked as boolean)}
+              className="size-4"
+            />
+            <Label htmlFor="ansi-colors" className="text-xs cursor-pointer flex items-center gap-1.5 text-foreground">
+              <Terminal className="size-3.5 text-muted-foreground" />
+              {labels.ansiColors}
             </Label>
           </div>
         </div>

--- a/src/components/features/logs/hooks/useLogAnalysis.ts
+++ b/src/components/features/logs/hooks/useLogAnalysis.ts
@@ -6,7 +6,7 @@ import { useAIStore } from "@/lib/stores/ai-store";
 import { useClusterStore, selectCurrentNamespace } from "@/lib/stores/cluster-store";
 import { useUIStore } from "@/lib/stores/ui-store";
 import { aiCheckCliAvailable, aiCheckCodexCliAvailable } from "@/lib/tauri/commands";
-import { getLogLevel, formatTimestamp } from "../lib";
+import { getLogLevel, formatTimestamp, stripAnsi } from "../lib";
 import { LOG_DEFAULTS } from "../types";
 
 interface UseLogAnalysisOptions {
@@ -89,7 +89,7 @@ export function useLogAnalysis({
       .map(
         (log) =>
           `${log.timestamp ? `[${formatTimestamp(log.timestamp)}] ` : ""}` +
-          `${workloadKind ? `[${log.pod}] ` : ""}${log.message}`
+          `${workloadKind ? `[${log.pod}] ` : ""}${stripAnsi(log.message)}`
       )
       .join("\n");
 

--- a/src/components/features/logs/hooks/useLogDownload.ts
+++ b/src/components/features/logs/hooks/useLogDownload.ts
@@ -5,6 +5,7 @@ import { save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { toast } from "sonner";
 import type { LogEntry } from "@/lib/types";
+import { stripAnsi } from "../lib";
 import type { DownloadFormat } from "../types";
 
 interface UseLogDownloadOptions {
@@ -99,11 +100,17 @@ function formatLogsForExport(
   const containerSuffix = container || "logs";
   // JSON already carries log.pod per entry, so the prefix only applies to text.
   const podPrefix = (log: LogEntry) => (includePodNames ? `[${log.pod}] ` : "");
+  // Escape codes are display-only; an exported file should be readable text.
+  const plain = (log: LogEntry) => stripAnsi(log.message);
 
   switch (format) {
     case "json":
       return {
-        content: JSON.stringify(logs, null, 2),
+        content: JSON.stringify(
+          logs.map((log) => ({ ...log, message: plain(log) })),
+          null,
+          2
+        ),
         filename: `${sourceName}-${containerSuffix}`,
         extension: "json",
       };
@@ -111,7 +118,7 @@ function formatLogsForExport(
     case "timestamps":
       return {
         content: logs
-          .map((log) => `${log.timestamp || ""}\t${podPrefix(log)}${log.message}`)
+          .map((log) => `${log.timestamp || ""}\t${podPrefix(log)}${plain(log)}`)
           .join("\n"),
         filename: `${sourceName}-${containerSuffix}-timestamps`,
         extension: "log",
@@ -120,7 +127,7 @@ function formatLogsForExport(
     case "text":
     default:
       return {
-        content: logs.map((log) => `${podPrefix(log)}${log.message}`).join("\n"),
+        content: logs.map((log) => `${podPrefix(log)}${plain(log)}`).join("\n"),
         filename: `${sourceName}-${containerSuffix}`,
         extension: "log",
       };

--- a/src/components/features/logs/hooks/useLogFilter.ts
+++ b/src/components/features/logs/hooks/useLogFilter.ts
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback } from "react";
 import type { LogEntry } from "@/lib/types";
-import { compileRegex, validateRegex, getLogLevel } from "../lib";
+import { compileRegex, validateRegex, getLogLevel, stripAnsi } from "../lib";
 
 interface UseLogFilterOptions {
   logs: LogEntry[];
@@ -55,13 +55,16 @@ export function useLogFilter({ logs }: UseLogFilterOptions): UseLogFilterReturn 
   const filteredLogs = useMemo(() => {
     let result = logs;
 
-    // Filter by search query
+    // Filter by search query. Matching runs on ANSI-stripped text so an escape
+    // sequence sitting inside a phrase doesn't hide the line from search.
     if (searchQuery) {
       if (useRegex && searchRegex) {
-        result = result.filter((log) => searchRegex.test(log.message));
+        result = result.filter((log) => searchRegex.test(stripAnsi(log.message)));
       } else if (!useRegex) {
         const query = searchQuery.toLowerCase();
-        result = result.filter((log) => log.message.toLowerCase().includes(query));
+        result = result.filter((log) =>
+          stripAnsi(log.message).toLowerCase().includes(query)
+        );
       }
     }
 

--- a/src/components/features/logs/lib/__tests__/ansi.test.ts
+++ b/src/components/features/logs/lib/__tests__/ansi.test.ts
@@ -25,6 +25,14 @@ describe("stripAnsi", () => {
     expect(stripAnsi(`${ESC}[2K${ESC}[1Gprogress`)).toBe("progress");
   });
 
+  it("removes CSI private modes, intermediate bytes and non-letter finals", () => {
+    expect(
+      stripAnsi(
+        `${ESC}[?25lhidden cursor${ESC}[?25h${ESC}[1~${ESC}[>0c${ESC}[1 q`
+      )
+    ).toBe("hidden cursor");
+  });
+
   it("leaves plain text untouched", () => {
     expect(stripAnsi("nothing to strip")).toBe("nothing to strip");
   });
@@ -122,6 +130,15 @@ describe("parseAnsi", () => {
     const segments = parseAnsi(`before${ESC}[2Kafter`);
     expect(segments.map((s) => s.text).join("")).toBe("beforeafter");
     expect(segments.every((s) => Object.keys(s.style).length === 0)).toBe(true);
+  });
+
+  it("drops complete CSI syntax without disturbing surrounding styles", () => {
+    const raw = `${ESC}[31mred${ESC}[?25l${ESC}[1~${ESC}[>0c${ESC}[0mplain`;
+    const segments = parseAnsi(raw);
+
+    expect(segments.map((s) => s.text).join("")).toBe("redplain");
+    expect(segments[0].style.color).toBe("#cd3131");
+    expect(segments[segments.length - 1].style).toEqual({});
   });
 
   it("drops OSC hyperlinks while preserving SGR styles and offsets", () => {

--- a/src/components/features/logs/lib/__tests__/ansi.test.ts
+++ b/src/components/features/logs/lib/__tests__/ansi.test.ts
@@ -32,6 +32,17 @@ describe("stripAnsi", () => {
   it("handles truecolor sequences", () => {
     expect(stripAnsi(`${ESC}[38;2;255;100;0mwarn${ESC}[0m`)).toBe("warn");
   });
+
+  it.each([
+    ["BEL", `${ESC}]8;;https://example.com\x07link${ESC}]8;;\x07`],
+    ["ST", `${ESC}]8;;https://example.com${ESC}\\link${ESC}]8;;${ESC}\\`],
+  ])("removes OSC hyperlinks terminated by %s", (_terminator, text) => {
+    expect(stripAnsi(text)).toBe("link");
+  });
+
+  it("removes an unterminated OSC sequence instead of leaking control text", () => {
+    expect(stripAnsi(`${ESC}]8;;https://example.com`)).toBe("");
+  });
 });
 
 describe("parseAnsi", () => {
@@ -111,6 +122,17 @@ describe("parseAnsi", () => {
     const segments = parseAnsi(`before${ESC}[2Kafter`);
     expect(segments.map((s) => s.text).join("")).toBe("beforeafter");
     expect(segments.every((s) => Object.keys(s.style).length === 0)).toBe(true);
+  });
+
+  it("drops OSC hyperlinks while preserving SGR styles and offsets", () => {
+    const raw = `${ESC}]8;;https://example.com\x07${ESC}[31mlink${ESC}[0m${ESC}]8;;\x07 tail`;
+    const segments = parseAnsi(raw);
+    const plain = stripAnsi(raw);
+
+    expect(plain).toBe("link tail");
+    expect(segments.map((segment) => segment.text).join("")).toBe(plain);
+    expect(segments[0].style.color).toBe("#cd3131");
+    expect(segments.map((segment) => segment.start)).toEqual([0, 4]);
   });
 
   it("survives a malformed extended color sequence", () => {

--- a/src/components/features/logs/lib/__tests__/ansi.test.ts
+++ b/src/components/features/logs/lib/__tests__/ansi.test.ts
@@ -106,9 +106,19 @@ describe("parseAnsi", () => {
     expect(gray.style.color).toBe("rgb(128, 128, 128)");
   });
 
-  it("resolves truecolor", () => {
-    const [, rgb] = parseAnsi(`x${ESC}[38;2;12;34;56mcustom`);
+  it.each([
+    ["semicolon form", "38;2;12;34;56"],
+    ["colon form with an empty color-space slot", "38:2::12:34:56"],
+    ["colon form with a populated color-space slot", "38:2:1:12:34:56"],
+    ["short colon form without a color-space slot", "38:2:12:34:56"],
+  ])("resolves truecolor in the %s", (_description, sequence) => {
+    const [, rgb] = parseAnsi(`x${ESC}[${sequence}mcustom`);
     expect(rgb.style.color).toBe("rgb(12, 34, 56)");
+  });
+
+  it("resolves a colon-delimited 256-color index", () => {
+    const [, indexed] = parseAnsi(`x${ESC}[38:5:196mbright`);
+    expect(indexed.style.color).toBe("rgb(255, 0, 0)");
   });
 
   it("applies background colors", () => {

--- a/src/components/features/logs/lib/__tests__/ansi.test.ts
+++ b/src/components/features/logs/lib/__tests__/ansi.test.ts
@@ -1,0 +1,121 @@
+import { stripAnsi, hasAnsiCodes, parseAnsi } from "../ansi";
+
+const ESC = "\x1b";
+
+describe("hasAnsiCodes", () => {
+  it("detects escape sequences", () => {
+    expect(hasAnsiCodes(`${ESC}[31mred${ESC}[0m`)).toBe(true);
+  });
+
+  it("returns false for plain text", () => {
+    expect(hasAnsiCodes("plain log line")).toBe(false);
+    // A literal bracket is not an escape
+    expect(hasAnsiCodes("[31m not an escape")).toBe(false);
+  });
+});
+
+describe("stripAnsi", () => {
+  it("removes color codes and keeps the text", () => {
+    expect(stripAnsi(`${ESC}[31mERROR${ESC}[0m connection refused`)).toBe(
+      "ERROR connection refused"
+    );
+  });
+
+  it("removes non-SGR sequences like cursor moves and erases", () => {
+    expect(stripAnsi(`${ESC}[2K${ESC}[1Gprogress`)).toBe("progress");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(stripAnsi("nothing to strip")).toBe("nothing to strip");
+  });
+
+  it("handles truecolor sequences", () => {
+    expect(stripAnsi(`${ESC}[38;2;255;100;0mwarn${ESC}[0m`)).toBe("warn");
+  });
+});
+
+describe("parseAnsi", () => {
+  it("returns one unstyled segment for plain text", () => {
+    expect(parseAnsi("hello")).toEqual([{ text: "hello", style: {}, start: 0 }]);
+  });
+
+  it("splits on color changes and tracks stripped offsets", () => {
+    const segments = parseAnsi(`plain ${ESC}[31mred${ESC}[0m tail`);
+    expect(segments.map((s) => s.text)).toEqual(["plain ", "red", " tail"]);
+    // Offsets index into the stripped text "plain red tail"
+    expect(segments.map((s) => s.start)).toEqual([0, 6, 9]);
+    expect(segments[1].style.color).toBe("#cd3131");
+    expect(segments[2].style.color).toBeUndefined();
+  });
+
+  it("keeps offsets aligned with stripAnsi output", () => {
+    const raw = `${ESC}[1;33mWARN${ESC}[0m disk ${ESC}[31m91%${ESC}[0m full`;
+    const segments = parseAnsi(raw);
+    const plain = stripAnsi(raw);
+
+    expect(segments.map((s) => s.text).join("")).toBe(plain);
+    for (const segment of segments) {
+      expect(plain.slice(segment.start, segment.start + segment.text.length)).toBe(
+        segment.text
+      );
+    }
+  });
+
+  it("accumulates attributes until reset", () => {
+    const [, styled] = parseAnsi(`a${ESC}[1m${ESC}[4mbold-underline`);
+    expect(styled.style.fontWeight).toBe("bold");
+    expect(styled.style.textDecoration).toBe("underline");
+  });
+
+  it("clears individual attributes without dropping the rest", () => {
+    const segments = parseAnsi(`${ESC}[1;31mboth${ESC}[22mred-only`);
+    const last = segments[segments.length - 1];
+    expect(last.style.fontWeight).toBeUndefined();
+    expect(last.style.color).toBe("#cd3131");
+  });
+
+  it("maps dim to reduced opacity", () => {
+    const [, dim] = parseAnsi(`x${ESC}[2mfaint`);
+    expect(dim.style.opacity).toBe(0.6);
+  });
+
+  it("resolves 256-color indices", () => {
+    const [, cube] = parseAnsi(`x${ESC}[38;5;196mbright`);
+    expect(cube.style.color).toBe("rgb(255, 0, 0)");
+
+    const [, gray] = parseAnsi(`x${ESC}[38;5;244mgray`);
+    expect(gray.style.color).toBe("rgb(128, 128, 128)");
+  });
+
+  it("resolves truecolor", () => {
+    const [, rgb] = parseAnsi(`x${ESC}[38;2;12;34;56mcustom`);
+    expect(rgb.style.color).toBe("rgb(12, 34, 56)");
+  });
+
+  it("applies background colors", () => {
+    const [, bg] = parseAnsi(`x${ESC}[41mon-red`);
+    expect(bg.style.backgroundColor).toBe("#cd3131");
+  });
+
+  it("uses bright variants for the 90-97 range", () => {
+    const [, bright] = parseAnsi(`x${ESC}[91mbright-red`);
+    expect(bright.style.color).toBe("#f14c4c");
+  });
+
+  it("treats a bare ESC[m as a full reset", () => {
+    const segments = parseAnsi(`${ESC}[31mred${ESC}[mplain`);
+    expect(segments[segments.length - 1].style).toEqual({});
+  });
+
+  it("drops non-SGR sequences without splitting the text", () => {
+    const segments = parseAnsi(`before${ESC}[2Kafter`);
+    expect(segments.map((s) => s.text).join("")).toBe("beforeafter");
+    expect(segments.every((s) => Object.keys(s.style).length === 0)).toBe(true);
+  });
+
+  it("survives a malformed extended color sequence", () => {
+    // 38 with no mode byte following
+    const segments = parseAnsi(`x${ESC}[38mtail`);
+    expect(segments.map((s) => s.text).join("")).toBe("xtail");
+  });
+});

--- a/src/components/features/logs/lib/ansi.ts
+++ b/src/components/features/logs/lib/ansi.ts
@@ -1,0 +1,217 @@
+/**
+ * Minimal ANSI SGR (Select Graphic Rendition) parser for log rendering.
+ *
+ * Only the escape sequences that actually show up in container logs are
+ * handled: colors (16 / 256 / truecolor), bold, dim, italic, underline and
+ * strikethrough. Cursor movement, scrolling and other control sequences are
+ * stripped rather than interpreted — a log viewer has no cursor to move.
+ */
+
+/** Matches any CSI sequence, e.g. \x1b[1;31m or \x1b[2K */
+// eslint-disable-next-line no-control-regex
+const CSI_PATTERN = /\x1b\[[0-9;:]*[A-Za-z]/g;
+
+/** Matches SGR sequences specifically (CSI ... m) */
+// eslint-disable-next-line no-control-regex
+const SGR_PATTERN = /\x1b\[([0-9;:]*)m/;
+
+/** Cheap pre-check so log lines without escapes skip parsing entirely */
+// eslint-disable-next-line no-control-regex
+const HAS_ESCAPE = /\x1b\[/;
+
+export interface AnsiStyle {
+  color?: string;
+  backgroundColor?: string;
+  fontWeight?: "bold";
+  fontStyle?: "italic";
+  textDecoration?: string;
+  opacity?: number;
+}
+
+export interface AnsiSegment {
+  text: string;
+  style: AnsiStyle;
+  /** Offset of this segment's text within the stripped message */
+  start: number;
+}
+
+/**
+ * The standard 16 colors, as CSS variables would be overkill here. Values are
+ * picked to stay legible on both light and dark backgrounds — terminal-default
+ * bright red on white is unreadable.
+ */
+const BASE_COLORS = [
+  "#000000", "#cd3131", "#0dbc79", "#e5e510",
+  "#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5",
+] as const;
+
+const BRIGHT_COLORS = [
+  "#666666", "#f14c4c", "#23d18b", "#f5f543",
+  "#3b8eea", "#d670d6", "#29b8db", "#ffffff",
+] as const;
+
+/** Resolves a 256-color palette index to a CSS color */
+function color256(index: number): string {
+  if (index < 8) return BASE_COLORS[index];
+  if (index < 16) return BRIGHT_COLORS[index - 8];
+  if (index < 232) {
+    // 6x6x6 color cube
+    const n = index - 16;
+    const levels = [0, 95, 135, 175, 215, 255];
+    const r = levels[Math.floor(n / 36) % 6];
+    const g = levels[Math.floor(n / 6) % 6];
+    const b = levels[n % 6];
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+  // Grayscale ramp
+  const gray = 8 + (index - 232) * 10;
+  return `rgb(${gray}, ${gray}, ${gray})`;
+}
+
+/**
+ * Consumes an extended color sequence (38/48) starting at `i`, which is the
+ * index of the 38 or 48 itself. Returns the color and how many params it ate.
+ *
+ * Supports both `38;5;n` (256-color) and `38;2;r;g;b` (truecolor).
+ */
+function readExtendedColor(params: number[], i: number): { color?: string; consumed: number } {
+  const mode = params[i + 1];
+  if (mode === 5 && params.length > i + 2) {
+    return { color: color256(params[i + 2]), consumed: 2 };
+  }
+  if (mode === 2 && params.length > i + 4) {
+    const [r, g, b] = [params[i + 2], params[i + 3], params[i + 4]];
+    return { color: `rgb(${r}, ${g}, ${b})`, consumed: 4 };
+  }
+  // Malformed — swallow the mode byte so it isn't read as another attribute
+  return { consumed: 1 };
+}
+
+/** Applies one SGR parameter list to a style, returning the new style */
+function applySgr(style: AnsiStyle, params: number[]): AnsiStyle {
+  let next: AnsiStyle = { ...style };
+
+  for (let i = 0; i < params.length; i++) {
+    const code = params[i];
+
+    if (code === 0) {
+      next = {};
+    } else if (code === 1) {
+      next.fontWeight = "bold";
+    } else if (code === 2) {
+      next.opacity = 0.6;
+    } else if (code === 3) {
+      next.fontStyle = "italic";
+    } else if (code === 4) {
+      next.textDecoration = "underline";
+    } else if (code === 9) {
+      next.textDecoration = "line-through";
+    } else if (code === 22) {
+      delete next.fontWeight;
+      delete next.opacity;
+    } else if (code === 23) {
+      delete next.fontStyle;
+    } else if (code === 24 || code === 29) {
+      delete next.textDecoration;
+    } else if (code >= 30 && code <= 37) {
+      next.color = BASE_COLORS[code - 30];
+    } else if (code === 38) {
+      const { color, consumed } = readExtendedColor(params, i);
+      if (color) next.color = color;
+      i += consumed;
+    } else if (code === 39) {
+      delete next.color;
+    } else if (code >= 40 && code <= 47) {
+      next.backgroundColor = BASE_COLORS[code - 40];
+    } else if (code === 48) {
+      const { color, consumed } = readExtendedColor(params, i);
+      if (color) next.backgroundColor = color;
+      i += consumed;
+    } else if (code === 49) {
+      delete next.backgroundColor;
+    } else if (code >= 90 && code <= 97) {
+      next.color = BRIGHT_COLORS[code - 90];
+    } else if (code >= 100 && code <= 107) {
+      next.backgroundColor = BRIGHT_COLORS[code - 100];
+    }
+    // Unknown codes are ignored rather than dropped mid-line
+  }
+
+  return next;
+}
+
+/** True if the text contains any ANSI escape sequence */
+export function hasAnsiCodes(text: string): boolean {
+  return HAS_ESCAPE.test(text);
+}
+
+/**
+ * Removes all ANSI escape sequences.
+ *
+ * Applied at ingest so that search, level detection, export and the AI prompt
+ * all operate on clean text — only rendering cares about the codes.
+ */
+export function stripAnsi(text: string): string {
+  if (!hasAnsiCodes(text)) return text;
+  return text.replace(CSI_PATTERN, "");
+}
+
+/**
+ * Splits text into styled segments, with offsets relative to the ANSI-stripped
+ * text. Those offsets are what let search highlighting — which works on the
+ * stripped message — line up with the styling.
+ */
+export function parseAnsi(text: string): AnsiSegment[] {
+  if (!hasAnsiCodes(text)) {
+    return [{ text, style: {}, start: 0 }];
+  }
+
+  const segments: AnsiSegment[] = [];
+  let style: AnsiStyle = {};
+  let buffer = "";
+  let bufferStart = 0;
+  let plainLength = 0;
+  let rest = text;
+
+  const flush = () => {
+    if (buffer) {
+      segments.push({ text: buffer, style, start: bufferStart });
+      buffer = "";
+    }
+  };
+
+  while (rest.length > 0) {
+    const match = CSI_PATTERN.exec(rest);
+    CSI_PATTERN.lastIndex = 0;
+
+    if (!match) {
+      buffer += rest;
+      plainLength += rest.length;
+      break;
+    }
+
+    const before = rest.slice(0, match.index);
+    if (before) {
+      buffer += before;
+      plainLength += before.length;
+    }
+
+    const sgr = SGR_PATTERN.exec(match[0]);
+    if (sgr) {
+      // A style change ends the current run
+      flush();
+      bufferStart = plainLength;
+      // "\x1b[m" is shorthand for a full reset
+      const params = sgr[1]
+        ? sgr[1].split(/[;:]/).map((p) => (p === "" ? 0 : Number(p)))
+        : [0];
+      style = applySgr(style, params);
+    }
+    // Non-SGR sequences (cursor moves, erases) are simply dropped
+
+    rest = rest.slice(match.index + match[0].length);
+  }
+
+  flush();
+  return segments.length > 0 ? segments : [{ text: "", style: {}, start: 0 }];
+}

--- a/src/components/features/logs/lib/ansi.ts
+++ b/src/components/features/logs/lib/ansi.ts
@@ -7,9 +7,13 @@
  * stripped rather than interpreted — a log viewer has no cursor to move.
  */
 
-/** Matches any CSI sequence, e.g. \x1b[1;31m or \x1b[2K */
+/**
+ * Matches any CSI sequence: parameter bytes, optional intermediate bytes and
+ * one final byte. This includes private modes such as \x1b[?25l and
+ * non-letter final bytes such as \x1b[1~.
+ */
 // eslint-disable-next-line no-control-regex
-const CSI_PATTERN = /\x1b\[[0-9;:]*[A-Za-z]/g;
+const CSI_PATTERN = /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g;
 
 /** Matches OSC sequences terminated by BEL or ST, e.g. terminal hyperlinks */
 // eslint-disable-next-line no-control-regex

--- a/src/components/features/logs/lib/ansi.ts
+++ b/src/components/features/logs/lib/ansi.ts
@@ -11,13 +11,17 @@
 // eslint-disable-next-line no-control-regex
 const CSI_PATTERN = /\x1b\[[0-9;:]*[A-Za-z]/g;
 
+/** Matches OSC sequences terminated by BEL or ST, e.g. terminal hyperlinks */
+// eslint-disable-next-line no-control-regex
+const OSC_PATTERN = /\x1b\](?:[^\x07\x1b]|\x1b(?!\\))*(?:\x07|\x1b\\|$)/g;
+
 /** Matches SGR sequences specifically (CSI ... m) */
 // eslint-disable-next-line no-control-regex
 const SGR_PATTERN = /\x1b\[([0-9;:]*)m/;
 
 /** Cheap pre-check so log lines without escapes skip parsing entirely */
 // eslint-disable-next-line no-control-regex
-const HAS_ESCAPE = /\x1b\[/;
+const HAS_ESCAPE = /\x1b(?:\[|\])/;
 
 export interface AnsiStyle {
   color?: string;
@@ -153,7 +157,7 @@ export function hasAnsiCodes(text: string): boolean {
  */
 export function stripAnsi(text: string): string {
   if (!hasAnsiCodes(text)) return text;
-  return text.replace(CSI_PATTERN, "");
+  return text.replace(OSC_PATTERN, "").replace(CSI_PATTERN, "");
 }
 
 /**
@@ -166,12 +170,13 @@ export function parseAnsi(text: string): AnsiSegment[] {
     return [{ text, style: {}, start: 0 }];
   }
 
+  const sanitizedText = text.replace(OSC_PATTERN, "");
   const segments: AnsiSegment[] = [];
   let style: AnsiStyle = {};
   let buffer = "";
   let bufferStart = 0;
   let plainLength = 0;
-  let rest = text;
+  let rest = sanitizedText;
 
   const flush = () => {
     if (buffer) {

--- a/src/components/features/logs/lib/ansi.ts
+++ b/src/components/features/logs/lib/ansi.ts
@@ -82,25 +82,68 @@ function color256(index: number): string {
  *
  * Supports both `38;5;n` (256-color) and `38;2;r;g;b` (truecolor).
  */
-function readExtendedColor(params: number[], i: number): { color?: string; consumed: number } {
+type SgrParameter = number | number[];
+
+function readExtendedColor(
+  params: SgrParameter[],
+  i: number
+): { color?: string; consumed: number } {
   const mode = params[i + 1];
-  if (mode === 5 && params.length > i + 2) {
-    return { color: color256(params[i + 2]), consumed: 2 };
+  const indexedColor = params[i + 2];
+  if (mode === 5 && typeof indexedColor === "number") {
+    return { color: color256(indexedColor), consumed: 2 };
   }
   if (mode === 2 && params.length > i + 4) {
     const [r, g, b] = [params[i + 2], params[i + 3], params[i + 4]];
-    return { color: `rgb(${r}, ${g}, ${b})`, consumed: 4 };
+    if (
+      typeof r === "number" &&
+      typeof g === "number" &&
+      typeof b === "number"
+    ) {
+      return { color: `rgb(${r}, ${g}, ${b})`, consumed: 4 };
+    }
   }
   // Malformed — swallow the mode byte so it isn't read as another attribute
   return { consumed: 1 };
 }
 
+/** Resolves an extended color encoded as one colon-delimited SGR parameter. */
+function readColonExtendedColor(params: number[]): string | undefined {
+  const mode = params[1];
+  if (mode === 5 && params.length > 2) {
+    return color256(params[2]);
+  }
+  if (mode === 2) {
+    // ITU T.416 includes a color-space slot (which is commonly empty), while
+    // some tools emit the shorter 38:2:r:g:b form without that slot.
+    const channelOffset = params.length >= 6 ? 3 : 2;
+    if (params.length > channelOffset + 2) {
+      const [r, g, b] = params.slice(channelOffset, channelOffset + 3);
+      return `rgb(${r}, ${g}, ${b})`;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Keeps colon-delimited SGR subparameters grouped. Flattening them would turn
+ * the optional color-space slot in 38:2::r:g:b into the red channel.
+ */
+function parseSgrParameters(encoded: string): SgrParameter[] {
+  return encoded.split(";").map((parameter) => {
+    const values = parameter.split(":").map((value) => (value === "" ? 0 : Number(value)));
+    return values.length === 1 ? values[0] : values;
+  });
+}
+
 /** Applies one SGR parameter list to a style, returning the new style */
-function applySgr(style: AnsiStyle, params: number[]): AnsiStyle {
+function applySgr(style: AnsiStyle, params: SgrParameter[]): AnsiStyle {
   let next: AnsiStyle = { ...style };
 
   for (let i = 0; i < params.length; i++) {
-    const code = params[i];
+    const parameter = params[i];
+    const grouped = Array.isArray(parameter) ? parameter : undefined;
+    const code = Array.isArray(parameter) ? parameter[0] : parameter;
 
     if (code === 0) {
       next = {};
@@ -124,7 +167,9 @@ function applySgr(style: AnsiStyle, params: number[]): AnsiStyle {
     } else if (code >= 30 && code <= 37) {
       next.color = BASE_COLORS[code - 30];
     } else if (code === 38) {
-      const { color, consumed } = readExtendedColor(params, i);
+      const { color, consumed } = grouped
+        ? { color: readColonExtendedColor(grouped), consumed: 0 }
+        : readExtendedColor(params, i);
       if (color) next.color = color;
       i += consumed;
     } else if (code === 39) {
@@ -132,7 +177,9 @@ function applySgr(style: AnsiStyle, params: number[]): AnsiStyle {
     } else if (code >= 40 && code <= 47) {
       next.backgroundColor = BASE_COLORS[code - 40];
     } else if (code === 48) {
-      const { color, consumed } = readExtendedColor(params, i);
+      const { color, consumed } = grouped
+        ? { color: readColonExtendedColor(grouped), consumed: 0 }
+        : readExtendedColor(params, i);
       if (color) next.backgroundColor = color;
       i += consumed;
     } else if (code === 49) {
@@ -211,9 +258,7 @@ export function parseAnsi(text: string): AnsiSegment[] {
       flush();
       bufferStart = plainLength;
       // "\x1b[m" is shorthand for a full reset
-      const params = sgr[1]
-        ? sgr[1].split(/[;:]/).map((p) => (p === "" ? 0 : Number(p)))
-        : [0];
+      const params = sgr[1] ? parseSgrParameters(sgr[1]) : [0];
       style = applySgr(style, params);
     }
     // Non-SGR sequences (cursor moves, erases) are simply dropped

--- a/src/components/features/logs/lib/index.ts
+++ b/src/components/features/logs/lib/index.ts
@@ -1,1 +1,2 @@
 export * from "./utils";
+export * from "./ansi";

--- a/src/components/features/logs/lib/utils.ts
+++ b/src/components/features/logs/lib/utils.ts
@@ -1,4 +1,5 @@
 import type { LogLevel } from "../types";
+import { stripAnsi } from "./ansi";
 
 /**
  * Detects log level from message content.
@@ -13,8 +14,11 @@ const LEVEL_PATTERNS: [RegExp, LogLevel][] = [
 ];
 
 export function getLogLevel(message: string): LogLevel {
+  // Colored logs put escape codes right against the level word ("\x1b[31mERROR"),
+  // which defeats the leading \b.
+  const plain = stripAnsi(message);
   for (const [pattern, level] of LEVEL_PATTERNS) {
-    if (pattern.test(message)) {
+    if (pattern.test(plain)) {
       return level;
     }
   }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -484,6 +484,7 @@
     "displayOptions": "Anzeigeoptionen",
     "lineWrap": "Zeilenumbruch",
     "logColoring": "Log-Einfärbung",
+    "ansiColors": "ANSI-Farben",
     "timestampSection": "Zeitstempel",
     "timestampOff": "Aus",
     "timestampUtc": "UTC",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -484,6 +484,7 @@
     "displayOptions": "Display Options",
     "lineWrap": "Line Wrap",
     "logColoring": "Log Coloring",
+    "ansiColors": "ANSI Colors",
     "timestampSection": "Timestamp",
     "timestampOff": "Off",
     "timestampUtc": "UTC",


### PR DESCRIPTION
Closes #262

> Stacked on #409 → #408 → #407. Base retargets automatically as each merges.

Colored container logs showed their escape sequences as literal text (`\x1b[31mERROR`), and the codes leaked into search, level detection, copy, export and the AI prompt.

## Parser

A small SGR parser in `lib/ansi.ts` handles what actually turns up in container logs: 16-color, 256-color and truecolor, plus bold, dim, italic, underline and strikethrough. Cursor movement and erase sequences are stripped rather than interpreted — a log viewer has no cursor to move.

No new dependency. The composition with search highlighting had to be hand-written either way, and that is the bulk of the work; a library would only have covered the easy half.

## Composing ANSI with search highlighting

This was the tricky part. Both features want to slice the same line, on different boundaries.

- `parseAnsi` returns segments carrying `start` offsets that index into the **ANSI-stripped** text.
- `findMatchRanges` returns match ranges over that same stripped text (replacing direct string slicing).
- `renderStyledSegments` interleaves the two in one pass.

A match spanning a color change is therefore split across segments, with each part keeping its own styling — `\x1b[31merr\x1b[0mor` searched for `error` yields two `<mark>`s that together read `error`, and the line still reads `error here`.

## Everything else works on stripped text

- `getLogLevel` — escape codes sat directly against the level word (`\x1b[31mERROR`), which defeated the leading `\b`. Colored ERROR lines were classified as `default`.
- Search and level filters — a code inside a phrase could hide a line from search entirely.
- Copy-all, all three export formats, and the AI prompt.

`message` itself stays raw; stripping happens at the consumers, so nothing changes in the ingest path or the ring buffer.

## Display

ANSI colors take precedence over the log-level heuristic on colored lines — otherwise the two fight over the same text. Lines without escape codes keep the existing level coloring. There is an "ANSI Colors" toggle in Display Options (en + de); switching it off strips the codes instead of rendering them, so raw escapes never appear either way.

## Tests

- Parser: strip/detect, offset alignment with `stripAnsi`, attribute accumulation and selective reset, dim→opacity, 256-color cube and grayscale ramp, truecolor, backgrounds, bright range, bare `ESC[m` reset, non-SGR sequences, malformed extended color.
- Rendering: styles applied, `ansiColors: false` strips, match inside a colored segment, match split across a color change, search matching through an embedded code, regex across segments, level detection through leading codes.

7 of these fail when ANSI rendering is reverted.

`make check`, `make lint` and the full suite (765 tests) pass. `make vet` hit its session limit on this branch and will be run before merge.