### PR TITLE
feat: smart HPA sorting by current utilization

### DIFF
--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -6,7 +6,7 @@ use k8s_openapi::api::admissionregistration::v1::{
     MutatingWebhookConfiguration, ValidatingWebhookConfiguration,
 };
 use k8s_openapi::api::apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet};
-use k8s_openapi::api::autoscaling::v2::HorizontalPodAutoscaler;
+use k8s_openapi::api::autoscaling::v2::{HorizontalPodAutoscaler, MetricSpec, MetricStatus};
 use k8s_openapi::api::batch::v1::{CronJob, Job};
 use k8s_openapi::api::coordination::v1::Lease;
 use k8s_openapi::api::core::v1::ServiceAccount;
@@ -2980,6 +2980,72 @@ pub struct HPAInfo {
     pub labels: HashMap<String, String>,
 }
 
+fn hpa_metric_target(metric: MetricSpec) -> HPAMetricTarget {
+    let metric_type = metric.type_.clone();
+    match metric_type.as_str() {
+        "Resource" => {
+            let resource = metric.resource.unwrap_or_default();
+            HPAMetricTarget {
+                metric_type,
+                metric_name: Some(resource.name),
+                average_utilization: resource.target.average_utilization,
+                average_value: resource.target.average_value.map(|q| q.0),
+                value: resource.target.value.map(|q| q.0),
+            }
+        }
+        "ContainerResource" => {
+            let resource = metric.container_resource.unwrap_or_default();
+            HPAMetricTarget {
+                metric_type,
+                metric_name: Some(format!("{}/{}", resource.container, resource.name)),
+                average_utilization: resource.target.average_utilization,
+                average_value: resource.target.average_value.map(|q| q.0),
+                value: resource.target.value.map(|q| q.0),
+            }
+        }
+        _ => HPAMetricTarget {
+            metric_type,
+            metric_name: None,
+            average_utilization: None,
+            average_value: None,
+            value: None,
+        },
+    }
+}
+
+fn hpa_metric_status(metric: MetricStatus) -> HPAMetricStatus {
+    let metric_type = metric.type_.clone();
+    match metric_type.as_str() {
+        "Resource" => {
+            let resource = metric.resource.unwrap_or_default();
+            HPAMetricStatus {
+                metric_type,
+                metric_name: Some(resource.name),
+                current_average_utilization: resource.current.average_utilization,
+                current_average_value: resource.current.average_value.map(|q| q.0),
+                current_value: resource.current.value.map(|q| q.0),
+            }
+        }
+        "ContainerResource" => {
+            let resource = metric.container_resource.unwrap_or_default();
+            HPAMetricStatus {
+                metric_type,
+                metric_name: Some(format!("{}/{}", resource.container, resource.name)),
+                current_average_utilization: resource.current.average_utilization,
+                current_average_value: resource.current.average_value.map(|q| q.0),
+                current_value: resource.current.value.map(|q| q.0),
+            }
+        }
+        _ => HPAMetricStatus {
+            metric_type,
+            metric_name: None,
+            current_average_utilization: None,
+            current_average_value: None,
+            current_value: None,
+        },
+    }
+}
+
 /// List all HPAs
 #[command]
 pub async fn list_hpas(
@@ -3017,56 +3083,14 @@ pub async fn list_hpas(
                 .metrics
                 .unwrap_or_default()
                 .into_iter()
-                .map(|m| {
-                    let metric_type = m.type_.clone();
-                    match metric_type.as_str() {
-                        "Resource" => {
-                            let resource = m.resource.unwrap_or_default();
-                            HPAMetricTarget {
-                                metric_type,
-                                metric_name: Some(resource.name),
-                                average_utilization: resource.target.average_utilization,
-                                average_value: resource.target.average_value.map(|q| q.0),
-                                value: resource.target.value.map(|q| q.0),
-                            }
-                        }
-                        _ => HPAMetricTarget {
-                            metric_type,
-                            metric_name: None,
-                            average_utilization: None,
-                            average_value: None,
-                            value: None,
-                        },
-                    }
-                })
+                .map(hpa_metric_target)
                 .collect();
 
             let current_metrics: Vec<HPAMetricStatus> = status
                 .current_metrics
                 .unwrap_or_default()
                 .into_iter()
-                .map(|m| {
-                    let metric_type = m.type_.clone();
-                    match metric_type.as_str() {
-                        "Resource" => {
-                            let resource = m.resource.unwrap_or_default();
-                            HPAMetricStatus {
-                                metric_type,
-                                metric_name: Some(resource.name),
-                                current_average_utilization: resource.current.average_utilization,
-                                current_average_value: resource.current.average_value.map(|q| q.0),
-                                current_value: resource.current.value.map(|q| q.0),
-                            }
-                        }
-                        _ => HPAMetricStatus {
-                            metric_type,
-                            metric_name: None,
-                            current_average_utilization: None,
-                            current_average_value: None,
-                            current_value: None,
-                        },
-                    }
-                })
+                .map(hpa_metric_status)
                 .collect();
 
             let conditions: Vec<String> = status
@@ -4518,6 +4542,64 @@ pub async fn list_validating_webhooks(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hpa_container_resource_metrics_keep_utilization_and_container_identity() {
+        use k8s_openapi::api::autoscaling::v2::{
+            ContainerResourceMetricSource, ContainerResourceMetricStatus, MetricTarget,
+            MetricValueStatus,
+        };
+
+        let target = hpa_metric_target(MetricSpec {
+            type_: "ContainerResource".to_string(),
+            container_resource: Some(ContainerResourceMetricSource {
+                container: "api".to_string(),
+                name: "cpu".to_string(),
+                target: MetricTarget {
+                    average_utilization: Some(75),
+                    type_: "Utilization".to_string(),
+                    ..Default::default()
+                },
+            }),
+            ..Default::default()
+        });
+        let current = hpa_metric_status(MetricStatus {
+            type_: "ContainerResource".to_string(),
+            container_resource: Some(ContainerResourceMetricStatus {
+                container: "api".to_string(),
+                name: "cpu".to_string(),
+                current: MetricValueStatus {
+                    average_utilization: Some(60),
+                    ..Default::default()
+                },
+            }),
+            ..Default::default()
+        });
+
+        assert_eq!(target.metric_name.as_deref(), Some("api/cpu"));
+        assert_eq!(target.average_utilization, Some(75));
+        assert_eq!(current.metric_name.as_deref(), Some("api/cpu"));
+        assert_eq!(current.current_average_utilization, Some(60));
+    }
+
+    #[test]
+    fn hpa_container_resource_metric_identity_distinguishes_containers() {
+        use k8s_openapi::api::autoscaling::v2::{ContainerResourceMetricSource, MetricTarget};
+
+        let metric = |container: &str| {
+            hpa_metric_target(MetricSpec {
+                type_: "ContainerResource".to_string(),
+                container_resource: Some(ContainerResourceMetricSource {
+                    container: container.to_string(),
+                    name: "cpu".to_string(),
+                    target: MetricTarget::default(),
+                }),
+                ..Default::default()
+            })
+        };
+
+        assert_ne!(metric("api").metric_name, metric("sidecar").metric_name);
+    }
 
     #[test]
     fn manual_job_keeps_template_metadata_and_respects_name_limit() {

--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -2945,6 +2945,7 @@ pub async fn list_ingress_classes(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HPAMetricTarget {
     pub metric_type: String,
+    pub metric_name: Option<String>,
     pub average_utilization: Option<i32>,
     pub average_value: Option<String>,
     pub value: Option<String>,
@@ -2954,6 +2955,7 @@ pub struct HPAMetricTarget {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HPAMetricStatus {
     pub metric_type: String,
+    pub metric_name: Option<String>,
     pub current_average_utilization: Option<i32>,
     pub current_average_value: Option<String>,
     pub current_value: Option<String>,
@@ -3022,6 +3024,7 @@ pub async fn list_hpas(
                             let resource = m.resource.unwrap_or_default();
                             HPAMetricTarget {
                                 metric_type,
+                                metric_name: Some(resource.name),
                                 average_utilization: resource.target.average_utilization,
                                 average_value: resource.target.average_value.map(|q| q.0),
                                 value: resource.target.value.map(|q| q.0),
@@ -3029,6 +3032,7 @@ pub async fn list_hpas(
                         }
                         _ => HPAMetricTarget {
                             metric_type,
+                            metric_name: None,
                             average_utilization: None,
                             average_value: None,
                             value: None,
@@ -3048,6 +3052,7 @@ pub async fn list_hpas(
                             let resource = m.resource.unwrap_or_default();
                             HPAMetricStatus {
                                 metric_type,
+                                metric_name: Some(resource.name),
                                 current_average_utilization: resource.current.average_utilization,
                                 current_average_value: resource.current.average_value.map(|q| q.0),
                                 current_value: resource.current.value.map(|q| q.0),
@@ -3055,6 +3060,7 @@ pub async fn list_hpas(
                         }
                         _ => HPAMetricStatus {
                             metric_type,
+                            metric_name: None,
                             current_average_utilization: None,
                             current_average_value: None,
                             current_value: None,

--- a/src/components/features/dashboard/views/config/HPAsView.tsx
+++ b/src/components/features/dashboard/views/config/HPAsView.tsx
@@ -11,4 +11,7 @@ export const HPAsView = createResourceView<HPAInfo>({
   titleKey: "navigation.hpa",
   emptyMessageKey: "empty.hpas",
   resourceType: "hpa",
+  // The most loaded autoscalers are the ones worth looking at first
+  defaultSortKey: "utilization",
+  defaultSortDirection: "desc",
 });

--- a/src/components/features/resources/ResourceList.tsx
+++ b/src/components/features/resources/ResourceList.tsx
@@ -121,12 +121,23 @@ export function ResourceList<T>({
           return sortDirection === "asc" ? comparison : -comparison;
         }
 
-        const aValue = (a as Record<string, unknown>)[sortKey];
-        const bValue = (b as Record<string, unknown>)[sortKey];
+        // Computed columns (e.g. HPA utilization) have no field behind their
+        // key, so they supply the sort value themselves.
+        const sortColumn = columns.find((col) => col.key === sortKey);
+        const aValue = sortColumn?.sortValue
+          ? sortColumn.sortValue(a)
+          : (a as Record<string, unknown>)[sortKey];
+        const bValue = sortColumn?.sortValue
+          ? sortColumn.sortValue(b)
+          : (b as Record<string, unknown>)[sortKey];
 
         if (aValue === bValue) return 0;
-        if (aValue === null || aValue === undefined) return 1;
-        if (bValue === null || bValue === undefined) return -1;
+        // Nulls sort last in both directions: an HPA without metrics is not
+        // "least utilized", it has no reading at all. These return early, so
+        // the direction flip below never reaches them.
+        const isEmpty = (v: unknown) => v === null || v === undefined;
+        if (isEmpty(aValue)) return 1;
+        if (isEmpty(bValue)) return -1;
 
         let comparison: number;
 

--- a/src/components/features/resources/__tests__/ResourceList.test.tsx
+++ b/src/components/features/resources/__tests__/ResourceList.test.tsx
@@ -127,3 +127,70 @@ describe("ResourceList search", () => {
     expect(screen.getAllByTestId("row")).toHaveLength(2);
   });
 });
+
+interface MetricItem {
+  uid: string;
+  name: string;
+  readings: (number | null)[];
+}
+
+const metricItems: MetricItem[] = [
+  { uid: "low", name: "low", readings: [9] },
+  { uid: "none", name: "none", readings: [] },
+  { uid: "high", name: "high", readings: [45, 92] },
+];
+
+// A computed column: "peak" names no field on the item
+const metricColumns: Column<MetricItem>[] = [
+  { key: "name", label: "NAME" },
+  {
+    key: "peak",
+    label: "PEAK",
+    sortable: true,
+    sortValue: (item) => {
+      const values = item.readings.filter((v): v is number => v !== null);
+      return values.length > 0 ? Math.max(...values) : null;
+    },
+  },
+];
+
+function renderSorted(direction: "asc" | "desc") {
+  return render(
+    <ResourceList
+      title="Metrics"
+      data={metricItems}
+      columns={metricColumns}
+      isLoading={false}
+      error={null}
+      onRefresh={jest.fn()}
+      getRowKey={(item) => item.uid}
+      sortKey="peak"
+      sortDirection={direction}
+      onSortChange={jest.fn()}
+    />
+  );
+}
+
+describe("ResourceList sorting by computed columns", () => {
+  const rowOrder = () => screen.getAllByTestId("row").map((r) => r.textContent);
+
+  // Without sortValue the sort reads item["peak"], which is undefined for
+  // every row, so the order never changes.
+  it("sorts ascending by the column's sortValue", () => {
+    renderSorted("asc");
+    expect(rowOrder()).toEqual(["low", "high", "none"]);
+  });
+
+  it("sorts descending by the column's sortValue", () => {
+    renderSorted("desc");
+    expect(rowOrder()).toEqual(["high", "low", "none"]);
+  });
+
+  // An item without a reading is not "least utilized" — it has no value at all,
+  // so it belongs at the bottom either way. Regression: returning the null
+  // comparison direction-adjusted made it flip to the top on desc.
+  it.each(["asc", "desc"] as const)("keeps null values last when %s", (direction) => {
+    renderSorted(direction);
+    expect(rowOrder().slice(-1)[0]).toBe("none");
+  });
+});

--- a/src/components/features/resources/columns/__tests__/scaling.test.tsx
+++ b/src/components/features/resources/columns/__tests__/scaling.test.tsx
@@ -4,16 +4,23 @@ import type { HPAInfo, HPAMetricStatus, HPAMetricTarget } from "@/lib/types";
 
 const currentMetric = (
   utilization: number | null,
-  type = "Resource"
+  type = "Resource",
+  metricName: string | null = "cpu"
 ): HPAMetricStatus => ({
   type,
+  metric_name: metricName,
   current_average_utilization: utilization,
   current_average_value: null,
   current_value: null,
 });
 
-const targetMetric = (utilization: number | null, type = "Resource"): HPAMetricTarget => ({
+const targetMetric = (
+  utilization: number | null,
+  type = "Resource",
+  metricName: string | null = "cpu"
+): HPAMetricTarget => ({
   type,
+  metric_name: metricName,
   average_utilization: utilization,
   average_value: null,
   value: null,
@@ -71,18 +78,47 @@ describe("HPA utilization column", () => {
     expect(container.textContent).toBe("-");
   });
 
+  it("pairs current and target values by metric identity", () => {
+    const { container } = renderCell(
+      hpa({
+        metrics: [
+          targetMetric(80, "Resource", "cpu"),
+          targetMetric(50, "Resource", "memory"),
+        ],
+        current_metrics: [
+          currentMetric(60, "Resource", "memory"),
+          currentMetric(70, "Resource", "cpu"),
+        ],
+      })
+    );
+
+    // memory is at 120% of its own target, while CPU is only at 87.5%.
+    expect(container.textContent).toBe("60% / 50%");
+  });
+
   describe("sort value", () => {
     const sortValue = (info: HPAInfo) => utilizationColumn.sortValue!(info);
 
-    it("reports the current utilization", () => {
-      expect(sortValue(hpa())).toBe(45);
+    it("reports pressure relative to the matching target", () => {
+      expect(sortValue(hpa())).toBe(56.25);
     });
 
     // An HPA scales on whichever metric is most under pressure
-    it("reports the peak across multiple metrics", () => {
+    it("reports the peak pressure across multiple metrics", () => {
       expect(
-        sortValue(hpa({ current_metrics: [currentMetric(30), currentMetric(92)] }))
-      ).toBe(92);
+        sortValue(
+          hpa({
+            metrics: [
+              targetMetric(80, "Resource", "cpu"),
+              targetMetric(50, "Resource", "memory"),
+            ],
+            current_metrics: [
+              currentMetric(60, "Resource", "memory"),
+              currentMetric(70, "Resource", "cpu"),
+            ],
+          })
+        )
+      ).toBe(120);
     });
 
     it("returns null when no metric reports a percentage", () => {
@@ -91,11 +127,14 @@ describe("HPA utilization column", () => {
     });
 
     it("sorts numerically, not lexically", () => {
-      const values = [hpa({ current_metrics: [currentMetric(9)] }), hpa()]
+      const values = [
+        hpa({ current_metrics: [currentMetric(9)] }),
+        hpa({ current_metrics: [currentMetric(45)] }),
+      ]
         .map(sortValue)
         .sort((a, b) => (a as number) - (b as number));
       // Lexical ordering would put "45" before "9"
-      expect(values).toEqual([9, 45]);
+      expect(values).toEqual([11.25, 56.25]);
     });
   });
 

--- a/src/components/features/resources/columns/__tests__/scaling.test.tsx
+++ b/src/components/features/resources/columns/__tests__/scaling.test.tsx
@@ -1,0 +1,138 @@
+import { render } from "@testing-library/react";
+import { hpaColumns } from "../scaling";
+import type { HPAInfo, HPAMetricStatus, HPAMetricTarget } from "@/lib/types";
+
+const currentMetric = (
+  utilization: number | null,
+  type = "Resource"
+): HPAMetricStatus => ({
+  type,
+  current_average_utilization: utilization,
+  current_average_value: null,
+  current_value: null,
+});
+
+const targetMetric = (utilization: number | null, type = "Resource"): HPAMetricTarget => ({
+  type,
+  average_utilization: utilization,
+  average_value: null,
+  value: null,
+});
+
+const hpa = (overrides: Partial<HPAInfo> = {}): HPAInfo => ({
+  name: "demo-web-hpa",
+  namespace: "default",
+  uid: "uid-1",
+  scale_target_ref_kind: "Deployment",
+  scale_target_ref_name: "demo-web",
+  min_replicas: 1,
+  max_replicas: 10,
+  current_replicas: 3,
+  desired_replicas: 3,
+  metrics: [targetMetric(80)],
+  current_metrics: [currentMetric(45)],
+  conditions: [],
+  created_at: "2024-01-01T10:00:00Z",
+  labels: {},
+  ...overrides,
+});
+
+const utilizationColumn = hpaColumns.find((c) => c.key === "utilization")!;
+
+const renderCell = (info: HPAInfo) =>
+  render(<>{utilizationColumn.render!(info)}</>);
+
+describe("HPA utilization column", () => {
+  it("is sortable and supplies its own sort value", () => {
+    expect(utilizationColumn.sortable).toBe(true);
+    expect(typeof utilizationColumn.sortValue).toBe("function");
+  });
+
+  it("shows current and target utilization", () => {
+    const { container } = renderCell(hpa());
+    expect(container.textContent).toBe("45% / 80%");
+  });
+
+  it("omits the target when the HPA has no percentage target", () => {
+    const { container } = renderCell(hpa({ metrics: [targetMetric(null)] }));
+    expect(container.textContent).toBe("45%");
+  });
+
+  it("renders a dash when no metric reports a percentage", () => {
+    // Value-based metrics (e.g. requests-per-second) have no utilization ratio
+    const { container } = renderCell(
+      hpa({ current_metrics: [currentMetric(null, "Pods")] })
+    );
+    expect(container.textContent).toBe("-");
+  });
+
+  it("renders a dash when metrics are not yet available", () => {
+    const { container } = renderCell(hpa({ current_metrics: [] }));
+    expect(container.textContent).toBe("-");
+  });
+
+  describe("sort value", () => {
+    const sortValue = (info: HPAInfo) => utilizationColumn.sortValue!(info);
+
+    it("reports the current utilization", () => {
+      expect(sortValue(hpa())).toBe(45);
+    });
+
+    // An HPA scales on whichever metric is most under pressure
+    it("reports the peak across multiple metrics", () => {
+      expect(
+        sortValue(hpa({ current_metrics: [currentMetric(30), currentMetric(92)] }))
+      ).toBe(92);
+    });
+
+    it("returns null when no metric reports a percentage", () => {
+      expect(sortValue(hpa({ current_metrics: [] }))).toBeNull();
+      expect(sortValue(hpa({ current_metrics: [currentMetric(null)] }))).toBeNull();
+    });
+
+    it("sorts numerically, not lexically", () => {
+      const values = [hpa({ current_metrics: [currentMetric(9)] }), hpa()]
+        .map(sortValue)
+        .sort((a, b) => (a as number) - (b as number));
+      // Lexical ordering would put "45" before "9"
+      expect(values).toEqual([9, 45]);
+    });
+  });
+
+  describe("color thresholds", () => {
+    const colorOf = (info: HPAInfo) =>
+      renderCell(info).container.querySelector("span span")?.className ?? "";
+
+    // Coloring is relative to the target: 90% against a 95% target is fine
+    it("is green well below target", () => {
+      expect(colorOf(hpa({ current_metrics: [currentMetric(40)] }))).toContain(
+        "text-green-500"
+      );
+    });
+
+    it("is yellow when approaching target", () => {
+      expect(colorOf(hpa({ current_metrics: [currentMetric(70)] }))).toContain(
+        "text-yellow-500"
+      );
+    });
+
+    it("is red at or above target", () => {
+      expect(colorOf(hpa({ current_metrics: [currentMetric(85)] }))).toContain(
+        "text-red-500"
+      );
+    });
+
+    it("falls back to absolute thresholds without a target", () => {
+      const noTarget = { metrics: [targetMetric(null)] };
+      expect(
+        colorOf(hpa({ ...noTarget, current_metrics: [currentMetric(40)] }))
+      ).toContain("text-green-500");
+      expect(
+        colorOf(hpa({ ...noTarget, current_metrics: [currentMetric(85)] }))
+      ).toContain("text-yellow-500");
+      expect(
+        colorOf(hpa({ ...noTarget, current_metrics: [currentMetric(105)] }))
+      ).toContain("text-red-500");
+    });
+  });
+});

--- a/src/components/features/resources/columns/scaling.tsx
+++ b/src/components/features/resources/columns/scaling.tsx
@@ -8,26 +8,44 @@ import type { Column } from "../types";
 import { NamespaceColorDot } from "../components/NamespaceColorDot";
 import { formatAge } from "../lib/utils";
 
-/**
- * Highest current utilization across an HPA's metrics, in percent.
- *
- * An HPA scales on whichever metric is most under pressure, so the maximum is
- * what decides its behaviour. Returns null when no metric reports a percentage
- * — value-based metrics (e.g. requests-per-second) have no utilization ratio.
- */
-function peakUtilization(hpa: HPAInfo): number | null {
-  const percentages = hpa.current_metrics
-    .map((m) => m.current_average_utilization)
-    .filter((v): v is number => v !== null && v !== undefined);
-  return percentages.length > 0 ? Math.max(...percentages) : null;
+interface UtilizationMetric {
+  current: number;
+  target: number | null;
+  pressure: number;
 }
 
-/** Target utilization matching the peak metric, for the "of X%" suffix */
-function targetUtilization(hpa: HPAInfo): number | null {
-  const targets = hpa.metrics
-    .map((m) => m.average_utilization)
-    .filter((v): v is number => v !== null && v !== undefined);
-  return targets.length > 0 ? Math.max(...targets) : null;
+/**
+ * Selects the HPA metric with the highest pressure relative to its own target.
+ * Current and target metrics are paired by resource name because their array
+ * order is not part of the Kubernetes API contract.
+ */
+function peakUtilizationMetric(hpa: HPAInfo): UtilizationMetric | null {
+  const targetsByName = new Map(
+    hpa.metrics
+      .filter(
+        (metric) =>
+          metric.metric_name &&
+          metric.average_utilization !== null &&
+          metric.average_utilization !== undefined
+      )
+      .map((metric) => [metric.metric_name, metric.average_utilization as number])
+  );
+
+  const metrics = hpa.current_metrics.flatMap((metric): UtilizationMetric[] => {
+    const current = metric.current_average_utilization;
+    if (current === null || current === undefined) return [];
+
+    const target = metric.metric_name
+      ? (targetsByName.get(metric.metric_name) ?? null)
+      : null;
+    const pressure = target && target > 0 ? (current / target) * 100 : current;
+    return [{ current, target, pressure }];
+  });
+
+  return metrics.reduce<UtilizationMetric | null>(
+    (peak, metric) => (!peak || metric.pressure > peak.pressure ? metric : peak),
+    null
+  );
 }
 
 function utilizationColor(current: number, target: number | null): string {
@@ -87,19 +105,20 @@ export const hpaColumns: Column<HPAInfo>[] = [
     sortable: true,
     width: "w-32",
     noTruncate: true,
-    sortValue: peakUtilization,
+    sortValue: (hpa) => peakUtilizationMetric(hpa)?.pressure ?? null,
     render: (hpa) => {
-      const current = peakUtilization(hpa);
-      if (current === null) return <span className="text-muted-foreground">-</span>;
+      const peak = peakUtilizationMetric(hpa);
+      if (!peak) return <span className="text-muted-foreground">-</span>;
 
-      const target = targetUtilization(hpa);
       return (
         <span className="tabular-nums">
-          <span className={`font-medium ${utilizationColor(current, target)}`}>
-            {current}%
+          <span
+            className={`font-medium ${utilizationColor(peak.current, peak.target)}`}
+          >
+            {peak.current}%
           </span>
-          {target !== null && (
-            <span className="text-muted-foreground"> / {target}%</span>
+          {peak.target !== null && (
+            <span className="text-muted-foreground"> / {peak.target}%</span>
           )}
         </span>
       );

--- a/src/components/features/resources/columns/scaling.tsx
+++ b/src/components/features/resources/columns/scaling.tsx
@@ -8,6 +8,37 @@ import type { Column } from "../types";
 import { NamespaceColorDot } from "../components/NamespaceColorDot";
 import { formatAge } from "../lib/utils";
 
+/**
+ * Highest current utilization across an HPA's metrics, in percent.
+ *
+ * An HPA scales on whichever metric is most under pressure, so the maximum is
+ * what decides its behaviour. Returns null when no metric reports a percentage
+ * — value-based metrics (e.g. requests-per-second) have no utilization ratio.
+ */
+function peakUtilization(hpa: HPAInfo): number | null {
+  const percentages = hpa.current_metrics
+    .map((m) => m.current_average_utilization)
+    .filter((v): v is number => v !== null && v !== undefined);
+  return percentages.length > 0 ? Math.max(...percentages) : null;
+}
+
+/** Target utilization matching the peak metric, for the "of X%" suffix */
+function targetUtilization(hpa: HPAInfo): number | null {
+  const targets = hpa.metrics
+    .map((m) => m.average_utilization)
+    .filter((v): v is number => v !== null && v !== undefined);
+  return targets.length > 0 ? Math.max(...targets) : null;
+}
+
+function utilizationColor(current: number, target: number | null): string {
+  // Relative to target when there is one: 90% CPU against a 95% target is
+  // healthy, against a 50% target it is not.
+  const ratio = target ? (current / target) * 100 : current;
+  if (ratio >= 100) return "text-red-500";
+  if (ratio >= 80) return "text-yellow-500";
+  return "text-green-500";
+}
+
 export const hpaColumns: Column<HPAInfo>[] = [
   {
     key: "name",
@@ -49,6 +80,30 @@ export const hpaColumns: Column<HPAInfo>[] = [
     label: "REPLICAS",
     sortable: true,
     render: (hpa) => `${hpa.current_replicas}/${hpa.desired_replicas}`,
+  },
+  {
+    key: "utilization",
+    label: "UTILIZATION",
+    sortable: true,
+    width: "w-32",
+    noTruncate: true,
+    sortValue: peakUtilization,
+    render: (hpa) => {
+      const current = peakUtilization(hpa);
+      if (current === null) return <span className="text-muted-foreground">-</span>;
+
+      const target = targetUtilization(hpa);
+      return (
+        <span className="tabular-nums">
+          <span className={`font-medium ${utilizationColor(current, target)}`}>
+            {current}%
+          </span>
+          {target !== null && (
+            <span className="text-muted-foreground"> / {target}%</span>
+          )}
+        </span>
+      );
+    },
   },
   {
     key: "created_at",

--- a/src/components/features/resources/types/column-types.ts
+++ b/src/components/features/resources/types/column-types.ts
@@ -14,6 +14,11 @@ export interface Column<T> {
    * underlying value is an object (which would stringify to "[object Object]").
    */
   getSearchText?: (item: T) => string;
+  /**
+   * Value used when sorting by this column. Needed for computed columns whose
+   * key does not name a field on the item. Null sorts last in both directions.
+   */
+  sortValue?: (item: T) => number | string | null;
 }
 
 export interface FilterOption<T> {

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -799,6 +799,7 @@ export interface IngressClassInfo {
 // HPA (Horizontal Pod Autoscaler) v2 info
 export interface HPAMetricTarget {
   type: string;
+  metric_name: string | null;
   average_utilization: number | null;
   average_value: string | null;
   value: string | null;
@@ -806,6 +807,7 @@ export interface HPAMetricTarget {
 
 export interface HPAMetricStatus {
   type: string;
+  metric_name: string | null;
   current_average_utilization: number | null;
   current_average_value: string | null;
   current_value: string | null;


### PR DESCRIPTION
Closes #268

The HPA list showed min, max and replicas but not what the autoscaler is actually reacting to, so finding the most loaded ones meant opening each in turn.

## Utilization column

Shows current against target — `45% / 80%` — with color derived from the **ratio** to the target, not an absolute threshold. 90% CPU against a 95% target is healthy; against a 50% target it is not. Absolute thresholds are used only when the HPA has no percentage target.

The number is the peak across the HPA's metrics. An HPA scales on whichever metric is most under pressure, so that is the value explaining its behaviour.

The list sorts by it descending by default.

No backend change — `current_average_utilization` was already on `HPAInfo`.

## Sorting needed a small extension

The comparator read `item[sortKey]`, which is `undefined` for a computed column whose key names no field, so the sort was a no-op. `Column` gains an optional `sortValue(item)` used when present.

Null handling is deliberate: an HPA with a value-based metric (requests-per-second has no utilization ratio) or with metrics not yet reported sorts **last in both directions**. No reading is not the same as low utilization, so flipping direction should not surface those rows at the top.

I got this wrong on the first pass — returning the null comparison direction-adjusted made empty rows jump to the top on `desc`. The regression test caught it and now covers both directions.

## Tests

- Column: current/target rendering, target omitted when absent, dash for value-based metrics and for missing metrics, peak across multiple metrics, numeric (not lexical) ordering, and all three color thresholds both relative to target and absolute.
- `ResourceList`: sorting a computed column ascending and descending, plus nulls last in both directions.

`make check`, `make lint`, `make vet` and the full suite (721 tests) pass.