### PR TITLE
feat: show container list in workload overview

### DIFF
--- a/src/components/features/resources/components/OverviewTab.tsx
+++ b/src/components/features/resources/components/OverviewTab.tsx
@@ -9,6 +9,7 @@ import { useLocale } from "@/components/providers/I18nProvider";
 import { MetadataItem } from "./MetadataItem";
 import { SecretDataSection } from "./SecretDataSection";
 import { ContainerStatusSection } from "./ContainerStatusSection";
+import { TemplateContainersSection } from "./TemplateContainersSection";
 import { PodMetricsSection } from "./PodMetricsSection";
 import { AnnotationsSection } from "./AnnotationsSection";
 import { OwnerReferencesSection } from "./OwnerReferencesSection";
@@ -22,6 +23,20 @@ function formatDate(dateString: string, locale: string): string {
   const resolvedLocale = locale === "system" ? undefined : locale;
   return date.toLocaleString(resolvedLocale);
 }
+
+/**
+ * Workloads whose YAML carries a pod template at spec.template.
+ *
+ * CronJobs are absent on purpose: theirs sits one level deeper, under
+ * spec.jobTemplate.spec.template.
+ */
+const WORKLOADS_WITH_POD_TEMPLATE = new Set([
+  "deployment",
+  "statefulset",
+  "daemonset",
+  "replicaset",
+  "job",
+]);
 
 interface OverviewTabProps {
   resource: ResourceData;
@@ -168,6 +183,11 @@ export function OverviewTab({ resource, resourceType, onNavigateToOwner }: Overv
             containers={containers}
             namespace={resource.namespace ?? ""}
           />
+        )}
+
+        {/* Pod template containers (for workloads that own pods) */}
+        {WORKLOADS_WITH_POD_TEMPLATE.has(resourceType) && (
+          <TemplateContainersSection yaml={resource.yaml} />
         )}
 
         {/* Labels Section */}

--- a/src/components/features/resources/components/TemplateContainersSection.tsx
+++ b/src/components/features/resources/components/TemplateContainersSection.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMemo } from "react";
+import { Box } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { useTranslations } from "next-intl";
+import { parseTemplateContainers } from "../lib/utils";
+
+interface TemplateContainersSectionProps {
+  /** Resource YAML; the pod template is read from spec.template.spec */
+  yaml: string | undefined;
+}
+
+/**
+ * Containers declared in a workload's pod template.
+ *
+ * Distinct from ContainerStatusSection, which reports the live state of a
+ * running pod. A template has no instance, so there is nothing to say beyond
+ * name and image.
+ */
+export function TemplateContainersSection({ yaml }: TemplateContainersSectionProps) {
+  const t = useTranslations();
+  const containers = useMemo(() => parseTemplateContainers(yaml), [yaml]);
+
+  if (containers.length === 0) return null;
+
+  return (
+    <section>
+      <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
+        <Box className="size-4" />
+        {t("podDetail.containers")}
+        <Badge variant="secondary" className="text-xs px-1.5 py-0.5">
+          {containers.length}
+        </Badge>
+      </h3>
+      <div className="space-y-2">
+        {containers.map((container) => (
+          <div
+            key={`${container.init ? "init" : "main"}-${container.name}`}
+            className="rounded-lg border bg-card px-3 py-2"
+          >
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-sm">{container.name}</span>
+              {container.init && (
+                <Badge variant="outline" className="text-xs px-1.5 py-0 text-muted-foreground">
+                  {t("podDetail.initContainer")}
+                </Badge>
+              )}
+            </div>
+            <div className="text-xs text-muted-foreground font-mono break-all mt-0.5">
+              {container.image || "-"}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/resources/components/__tests__/TemplateContainersSection.test.tsx
+++ b/src/components/features/resources/components/__tests__/TemplateContainersSection.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { TemplateContainersSection } from "../TemplateContainersSection";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const yamlWith = (body: string) => `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+${body}
+`;
+
+describe("TemplateContainersSection", () => {
+  it("lists each container with its image", () => {
+    render(
+      <TemplateContainersSection
+        yaml={yamlWith(`      containers:
+        - name: web
+          image: nginx:1.25
+        - name: sidecar
+          image: envoyproxy/envoy:v1.28`)}
+      />
+    );
+
+    expect(screen.getByText("web")).toBeInTheDocument();
+    expect(screen.getByText("nginx:1.25")).toBeInTheDocument();
+    expect(screen.getByText("sidecar")).toBeInTheDocument();
+    expect(screen.getByText("envoyproxy/envoy:v1.28")).toBeInTheDocument();
+  });
+
+  it("marks init containers and lists them first", () => {
+    const { container } = render(
+      <TemplateContainersSection
+        yaml={yamlWith(`      initContainers:
+        - name: migrate
+          image: busybox:1.36
+      containers:
+        - name: web
+          image: nginx:1.25`)}
+      />
+    );
+
+    const names = Array.from(
+      container.querySelectorAll("span.font-medium.text-sm"),
+      (el) => el.textContent
+    );
+    expect(names).toEqual(["migrate", "web"]);
+    // Only the init container carries the badge
+    expect(screen.getAllByText("podDetail.initContainer")).toHaveLength(1);
+  });
+
+  it("shows the container count", () => {
+    render(
+      <TemplateContainersSection
+        yaml={yamlWith(`      containers:
+        - name: a
+          image: alpine:3.19
+        - name: b
+          image: alpine:3.19`)}
+      />
+    );
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("renders nothing without a pod template", () => {
+    const { container } = render(
+      <TemplateContainersSection yaml={"kind: Service\nspec:\n  ports:\n    - port: 80"} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the YAML has not loaded yet", () => {
+    const { container } = render(<TemplateContainersSection yaml={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a dash for a container without an image", () => {
+    render(
+      <TemplateContainersSection
+        yaml={yamlWith(`      containers:
+        - name: no-image`)}
+      />
+    );
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+});

--- a/src/components/features/resources/lib/__tests__/parseTemplateContainers.test.ts
+++ b/src/components/features/resources/lib/__tests__/parseTemplateContainers.test.ts
@@ -1,0 +1,128 @@
+import { parseTemplateContainers } from "../utils";
+
+const deploymentYaml = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-web
+spec:
+  replicas: 3
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.36
+      containers:
+        - name: web
+          image: nginx:1.25
+          ports:
+            - containerPort: 80
+        - name: sidecar
+          image: envoyproxy/envoy:v1.28
+`;
+
+describe("parseTemplateContainers", () => {
+  it("reads containers from the pod template", () => {
+    expect(parseTemplateContainers(deploymentYaml)).toEqual([
+      { name: "wait-for-db", image: "busybox:1.36", init: true },
+      { name: "web", image: "nginx:1.25", init: false },
+      { name: "sidecar", image: "envoyproxy/envoy:v1.28", init: false },
+    ]);
+  });
+
+  // Init containers run before the others, so they are listed first
+  it("puts init containers ahead of regular ones", () => {
+    const result = parseTemplateContainers(deploymentYaml);
+    expect(result[0].init).toBe(true);
+    expect(result.slice(1).every((c) => !c.init)).toBe(true);
+  });
+
+  it("handles a template without init containers", () => {
+    const yaml = `
+spec:
+  template:
+    spec:
+      containers:
+        - name: only
+          image: alpine:3.19
+`;
+    expect(parseTemplateContainers(yaml)).toEqual([
+      { name: "only", image: "alpine:3.19", init: false },
+    ]);
+  });
+
+  it("returns empty for undefined or empty input", () => {
+    expect(parseTemplateContainers(undefined)).toEqual([]);
+    expect(parseTemplateContainers("")).toEqual([]);
+  });
+
+  it("returns empty when there is no pod template", () => {
+    // A Service has no spec.template
+    const yaml = `
+kind: Service
+spec:
+  ports:
+    - port: 80
+`;
+    expect(parseTemplateContainers(yaml)).toEqual([]);
+  });
+
+  // CronJobs nest their template under spec.jobTemplate, so they must not
+  // accidentally resolve through this path
+  it("does not reach into a CronJob's nested template", () => {
+    const yaml = `
+kind: CronJob
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: cleanup
+              image: busybox:1.36
+`;
+    expect(parseTemplateContainers(yaml)).toEqual([]);
+  });
+
+  it("survives malformed YAML", () => {
+    expect(parseTemplateContainers("spec:\n  template:\n   - broken: [")).toEqual([]);
+  });
+
+  it("skips entries without a name", () => {
+    const yaml = `
+spec:
+  template:
+    spec:
+      containers:
+        - image: nginx:1.25
+        - name: valid
+          image: alpine:3.19
+`;
+    expect(parseTemplateContainers(yaml)).toEqual([
+      { name: "valid", image: "alpine:3.19", init: false },
+    ]);
+  });
+
+  it("tolerates a container without an image", () => {
+    const yaml = `
+spec:
+  template:
+    spec:
+      containers:
+        - name: no-image
+`;
+    expect(parseTemplateContainers(yaml)).toEqual([
+      { name: "no-image", image: "", init: false },
+    ]);
+  });
+
+  it("ignores a containers field that is not a list", () => {
+    const yaml = `
+spec:
+  template:
+    spec:
+      containers: not-a-list
+`;
+    expect(parseTemplateContainers(yaml)).toEqual([]);
+  });
+});

--- a/src/components/features/resources/lib/utils.ts
+++ b/src/components/features/resources/lib/utils.ts
@@ -1,3 +1,5 @@
+import { parse as parseYaml } from "yaml";
+
 /** Format a timestamp into a human-readable relative age string */
 export function formatAge(timestamp: string): string {
   const date = new Date(timestamp);
@@ -111,5 +113,50 @@ export function decodeBase64(value: string): string {
     return atob(value);
   } catch {
     return value;
+  }
+}
+
+/** A container as declared in a workload's pod template */
+export interface TemplateContainer {
+  name: string;
+  image: string;
+  /** True for entries from initContainers */
+  init: boolean;
+}
+
+/**
+ * Reads the containers of a workload's pod template out of its YAML.
+ *
+ * The detail view already loads the full YAML, so the containers are on hand
+ * without extending the list payload for every workload in the cluster.
+ * Init containers come first — that is the order they run in.
+ */
+export function parseTemplateContainers(yaml: string | undefined): TemplateContainer[] {
+  if (!yaml) return [];
+
+  try {
+    const doc = parseYaml(yaml) as
+      | { spec?: { template?: { spec?: Record<string, unknown> } } }
+      | null;
+    const podSpec = doc?.spec?.template?.spec;
+    if (!podSpec) return [];
+
+    const collect = (key: string, init: boolean): TemplateContainer[] => {
+      const list = podSpec[key];
+      if (!Array.isArray(list)) return [];
+      return list
+        .filter((c): c is Record<string, unknown> => !!c && typeof c === "object")
+        .map((c) => ({
+          name: typeof c.name === "string" ? c.name : "",
+          image: typeof c.image === "string" ? c.image : "",
+          init,
+        }))
+        .filter((c) => c.name !== "");
+    };
+
+    return [...collect("initContainers", true), ...collect("containers", false)];
+  } catch {
+    // Malformed YAML is the editor's problem to report, not this section's
+    return [];
   }
 }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1017,6 +1017,7 @@
   },
   "podDetail": {
     "initContainers": "Init-Container",
+    "initContainer": "Init",
     "containers": "Container",
     "lastTermination": "Letzte Beendigung",
     "exitCode": "Exit-Code",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1017,6 +1017,7 @@
   },
   "podDetail": {
     "initContainers": "Init Containers",
+    "initContainer": "Init",
     "containers": "Containers",
     "lastTermination": "Last Termination",
     "exitCode": "Exit Code",


### PR DESCRIPTION
Closes #261

Deployment, StatefulSet, DaemonSet, ReplicaSet and Job detail views showed no containers or image names. Only Pods did, via `ContainerStatusSection`.

## Deviation from the issue

The issue proposed extending `DeploymentInfo` / `StatefulSetInfo` / `DaemonSetInfo` with a `containers` field. I started down that path, then backed it out: the detail view **already loads the full YAML**, so the pod template is on hand without adding a field to the list payload for every workload in the cluster. `yaml` is already a dependency.

Net effect — no backend change, no new Tauri command, no extra data on the list path.

## Separate component on purpose

`TemplateContainersSection` is not `ContainerStatusSection` with a flag. The latter reports the live state of a running pod: readiness, restart counts, last termination reason and exit code, env-var reveal. A pod *template* has no running instance, so none of that exists. Name, image and an init badge is the whole story.

CronJobs are excluded — their template sits one level deeper, under `spec.jobTemplate.spec.template`, and a test pins that they do not accidentally resolve through this path.

## Tests

- Parser: template extraction, init-containers-first ordering, no-init case, absent template, CronJob's nested template, malformed YAML, entries missing a name, containers missing an image, and a non-list `containers` field.
- Section: names and images rendered, init badge on the right entry only, count badge, and the three empty cases.

`make check`, `make lint`, `make vet` and the full suite (720 tests) pass.