### PR TITLE
feat: add configurable metrics refresh interval with disable option

### DIFF
--- a/src/components/features/dashboard/components/MetricsRefreshButton.tsx
+++ b/src/components/features/dashboard/components/MetricsRefreshButton.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useTranslations } from "next-intl";
+import { useUIStore } from "@/lib/stores/ui-store";
+
+interface MetricsRefreshButtonProps {
+  onRefresh: () => void;
+  isLoading?: boolean;
+}
+
+/**
+ * Manual metrics refresh.
+ *
+ * Always available, not just when polling is off — a user watching a rollout
+ * wants the current numbers now, regardless of when the next poll lands.
+ */
+export function MetricsRefreshButton({ onRefresh, isLoading }: MetricsRefreshButtonProps) {
+  const t = useTranslations();
+  const intervalSeconds = useUIStore((s) => s.settings.metricsRefreshInterval);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={onRefresh}
+          disabled={isLoading}
+          aria-label={t("metrics.refresh")}
+        >
+          <RefreshCw className={`size-3.5 ${isLoading ? "animate-spin" : ""}`} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {intervalSeconds > 0
+          ? t("metrics.refreshWithInterval", { seconds: intervalSeconds })
+          : t("metrics.refreshAutoDisabled")}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/features/dashboard/views/ClusterOverview.tsx
+++ b/src/components/features/dashboard/views/ClusterOverview.tsx
@@ -72,14 +72,17 @@ export function ClusterOverview() {
       </div>
 
       {/* Metrics Section */}
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-muted-foreground">
+          {t("metrics.title")}
+        </h2>
+        <MetricsRefreshButton
+          onRefresh={refreshMetrics}
+          isLoading={metricsLoading}
+        />
+      </div>
+
       {metricsAvailable && metrics && (
-        <>
-        <div className="mb-2 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-muted-foreground">
-            {t("metrics.title")}
-          </h2>
-          <MetricsRefreshButton onRefresh={refreshMetrics} isLoading={metricsLoading} />
-        </div>
         <div className="mb-6 @2xl:mb-8 grid grid-cols-1 @xl:grid-cols-2 gap-4 @2xl:gap-6">
           <Card>
             <CardHeader className="pb-2">
@@ -115,7 +118,6 @@ export function ClusterOverview() {
             </CardContent>
           </Card>
         </div>
-        </>
       )}
 
       {!metricsAvailable && !metricsLoading && (

--- a/src/components/features/dashboard/views/ClusterOverview.tsx
+++ b/src/components/features/dashboard/views/ClusterOverview.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/hooks/useK8sResources";
 import { getEffectivePodStatus } from "../../resources/columns";
 import { useClusterMetrics } from "@/lib/hooks/useMetrics";
+import { MetricsRefreshButton } from "../components/MetricsRefreshButton";
 import { SummaryCard } from "../components/SummaryCard";
 import { StatusRow } from "../components/StatusRow";
 import { MetricsProgressBar } from "../components/MetricsProgressBar";
@@ -23,10 +24,12 @@ export function ClusterOverview() {
   const { data: deployments } = useDeployments();
   const { data: services } = useServices();
   const { data: nodes } = useNodes();
-  const { summary: metrics, metricsAvailable, isLoading: metricsLoading } = useClusterMetrics({
-    autoRefresh: true,
-    refreshInterval: 15000,
-  });
+  const {
+    summary: metrics,
+    metricsAvailable,
+    isLoading: metricsLoading,
+    refresh: refreshMetrics,
+  } = useClusterMetrics({ autoRefresh: true });
 
   const runningPods = pods.filter((p) => getEffectivePodStatus(p) === "Running").length;
   const pendingPods = pods.filter((p) => p.phase === "Pending").length;
@@ -70,6 +73,13 @@ export function ClusterOverview() {
 
       {/* Metrics Section */}
       {metricsAvailable && metrics && (
+        <>
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            {t("metrics.title")}
+          </h2>
+          <MetricsRefreshButton onRefresh={refreshMetrics} isLoading={metricsLoading} />
+        </div>
         <div className="mb-6 @2xl:mb-8 grid grid-cols-1 @xl:grid-cols-2 gap-4 @2xl:gap-6">
           <Card>
             <CardHeader className="pb-2">
@@ -105,6 +115,7 @@ export function ClusterOverview() {
             </CardContent>
           </Card>
         </div>
+        </>
       )}
 
       {!metricsAvailable && !metricsLoading && (

--- a/src/components/features/dashboard/views/__tests__/ClusterOverview.test.tsx
+++ b/src/components/features/dashboard/views/__tests__/ClusterOverview.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ClusterOverview } from "../ClusterOverview";
+import { useClusterMetrics } from "@/lib/hooks/useMetrics";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("@/lib/hooks/useK8sResources", () => ({
+  usePods: () => ({ data: [] }),
+  useDeployments: () => ({ data: [] }),
+  useServices: () => ({ data: [] }),
+  useNodes: () => ({ data: [] }),
+}));
+
+jest.mock("@/lib/hooks/useMetrics", () => ({
+  useClusterMetrics: jest.fn(),
+}));
+
+const mockUseClusterMetrics = useClusterMetrics as jest.MockedFunction<
+  typeof useClusterMetrics
+>;
+
+describe("ClusterOverview metrics refresh", () => {
+  it("keeps manual refresh available after metrics loading fails", () => {
+    const refresh = jest.fn();
+    mockUseClusterMetrics.mockReturnValue({
+      summary: null,
+      metricsAvailable: false,
+      isLoading: false,
+      error: "Metrics server not available",
+      refresh,
+    });
+
+    render(<ClusterOverview />);
+
+    expect(screen.getByText("metrics.metricsNotAvailable")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "metrics.refresh" }));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/features/dashboard/views/workloads/PodsView.tsx
+++ b/src/components/features/dashboard/views/workloads/PodsView.tsx
@@ -49,7 +49,6 @@ export function PodsView() {
   const { data: services } = useServices({ autoRefresh: true, refreshInterval: 30000 });
   const { data: podMetricsData, isLoading: metricsLoading } = usePodMetrics(undefined, {
     autoRefresh: true,
-    refreshInterval: 10000,
     initialRefreshInterval: 3000,
   });
 

--- a/src/components/features/dashboard/views/workloads/PodsView.tsx
+++ b/src/components/features/dashboard/views/workloads/PodsView.tsx
@@ -47,10 +47,17 @@ export function PodsView() {
     refreshInterval: 10000,
   });
   const { data: services } = useServices({ autoRefresh: true, refreshInterval: 30000 });
-  const { data: podMetricsData, isLoading: metricsLoading } = usePodMetrics(undefined, {
+  const {
+    data: podMetricsData,
+    isLoading: metricsLoading,
+    refresh: refreshMetrics,
+  } = usePodMetrics(undefined, {
     autoRefresh: true,
     initialRefreshInterval: 3000,
   });
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([refresh(), refreshMetrics()]);
+  }, [refresh, refreshMetrics]);
 
   // Build a lookup map for pod metrics AND seed sparkline history.
   // Seeding inside useMemo (not useEffect) ensures history is populated
@@ -486,7 +493,7 @@ export function PodsView() {
       columns={columnsWithActions}
       isLoading={isLoading}
       error={error}
-      onRefresh={refresh}
+      onRefresh={handleRefresh}
       onRetry={retry}
       isWatching={isWatching}
       onStartWatch={startWatch}

--- a/src/components/features/dashboard/views/workloads/__tests__/PodsView.test.tsx
+++ b/src/components/features/dashboard/views/workloads/__tests__/PodsView.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PodsView } from "../PodsView";
+import { usePods, useServices } from "@/lib/hooks/useK8sResources";
+import { usePodMetrics } from "@/lib/hooks/useMetrics";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("@/lib/hooks/useK8sResources", () => ({
+  usePods: jest.fn(),
+  useServices: jest.fn(),
+}));
+
+jest.mock("@/lib/hooks/useMetrics", () => ({
+  usePodMetrics: jest.fn(),
+}));
+
+jest.mock("@/components/features/resources/ResourceList", () => ({
+  ResourceList: ({ onRefresh }: { onRefresh: () => Promise<void> }) => (
+    <button onClick={() => void onRefresh()}>refresh pods</button>
+  ),
+}));
+
+jest.mock("@/components/features/resources/columns", () => ({
+  getPodColumnsWithMetrics: () => [],
+  translateColumns: (columns: unknown[]) => columns,
+  getEffectivePodStatus: () => "Running",
+}));
+
+jest.mock("@/lib/hooks/usePortForward", () => ({
+  usePortForward: () => ({
+    forwards: [],
+    requestForward: jest.fn(),
+    stopForward: jest.fn(),
+  }),
+}));
+
+jest.mock("@/components/features/terminal", () => ({
+  useTerminalTabs: () => ({ addTab: jest.fn() }),
+}));
+
+jest.mock("@/components/features/dashboard/context", () => ({
+  useResourceDetail: () => ({
+    openResourceDetail: jest.fn(),
+    handleDeleteFromContext: jest.fn(),
+    closeResourceDetail: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/hooks/useRefreshOnDelete", () => ({
+  useRefreshOnDelete: jest.fn(),
+}));
+
+jest.mock("@/lib/stores/cluster-store", () => ({
+  useClusterStore: (selector: (state: unknown) => unknown) =>
+    selector({ currentCluster: { context: "test" } }),
+}));
+
+jest.mock("@/lib/stores/favorites-store", () => ({
+  useFavoritesStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      addFavorite: jest.fn(),
+      removeFavorite: jest.fn(),
+      isFavorite: jest.fn(() => false),
+    }),
+}));
+
+jest.mock("@/lib/stores/ui-store", () => ({
+  useUIStore: (selector: (state: unknown) => unknown) =>
+    selector({ pendingPodLogs: null, setPendingPodLogs: jest.fn() }),
+}));
+
+jest.mock("@/lib/stores/tabs-store", () => ({
+  useTabsStore: (selector: (state: unknown) => unknown) =>
+    selector({ openOrActivateTab: jest.fn() }),
+}));
+
+jest.mock("@/lib/hooks/useMetricsHistory", () => ({
+  seedHistoryFromBulkMetrics: jest.fn(),
+}));
+
+const mockUsePods = usePods as jest.MockedFunction<typeof usePods>;
+const mockUseServices = useServices as jest.MockedFunction<typeof useServices>;
+const mockUsePodMetrics = usePodMetrics as jest.MockedFunction<
+  typeof usePodMetrics
+>;
+
+describe("PodsView refresh", () => {
+  it("refreshes pod data and metrics from the manual refresh action", async () => {
+    const refreshPods = jest.fn().mockResolvedValue(undefined);
+    const refreshMetrics = jest.fn().mockResolvedValue(undefined);
+    mockUsePods.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refresh: refreshPods,
+      retry: jest.fn(),
+      startWatch: jest.fn(),
+      stopWatchFn: jest.fn(),
+      isWatching: false,
+    } as ReturnType<typeof usePods>);
+    mockUseServices.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+      retry: jest.fn(),
+      startWatch: jest.fn(),
+      stopWatchFn: jest.fn(),
+      isWatching: false,
+    });
+    mockUsePodMetrics.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refresh: refreshMetrics,
+    });
+
+    render(<PodsView />);
+    fireEvent.click(screen.getByRole("button", { name: "refresh pods" }));
+
+    await waitFor(() => {
+      expect(refreshPods).toHaveBeenCalledTimes(1);
+      expect(refreshMetrics).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/features/settings/components/GeneralTab.tsx
+++ b/src/components/features/settings/components/GeneralTab.tsx
@@ -61,6 +61,34 @@ export function GeneralTab() {
       <Separator />
 
       <SettingSection
+        title={t("metricsRefreshInterval.title")}
+        description={t("metricsRefreshInterval.description")}
+      >
+        <Select
+          value={settings.metricsRefreshInterval.toString()}
+          onValueChange={(value) =>
+            updateSettings({ metricsRefreshInterval: parseInt(value) })
+          }
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="5">{t("refreshInterval.seconds", { count: 5 })}</SelectItem>
+            <SelectItem value="10">{t("refreshInterval.seconds", { count: 10 })}</SelectItem>
+            <SelectItem value="15">{t("refreshInterval.seconds", { count: 15 })}</SelectItem>
+            <SelectItem value="30">{t("refreshInterval.seconds", { count: 30 })}</SelectItem>
+            <SelectItem value="60">{t("refreshInterval.minute")}</SelectItem>
+            <SelectItem value="300">{t("refreshInterval.minutes", { count: 5 })}</SelectItem>
+            {/* 0 keeps the manual refresh button as the only trigger */}
+            <SelectItem value="0">{t("metricsRefreshInterval.disabled")}</SelectItem>
+          </SelectContent>
+        </Select>
+      </SettingSection>
+
+      <Separator />
+
+      <SettingSection
         title={t("portForwardBrowser.title")}
         description={t("portForwardBrowser.description")}
       >

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -643,6 +643,11 @@
       "description": "Diesen Namespace beim Verbinden mit Clustern vorauswählen",
       "placeholder": "Alle Namespaces"
     },
+    "metricsRefreshInterval": {
+      "title": "Metrik-Aktualisierungsintervall",
+      "description": "Wie oft CPU- und Speicher-Metriken abgerufen werden, unabhängig von Ressourcenlisten",
+      "disabled": "Deaktiviert"
+    },
     "refreshInterval": {
       "title": "Aktualisierungsintervall",
       "description": "Wie oft sollen Ressourcendaten aktualisiert werden (in Sekunden)",
@@ -951,6 +956,9 @@
     "removedMissingResourceDescription": "Die Ressource \"{name}\" existiert nicht mehr."
   },
   "metrics": {
+    "refresh": "Metriken aktualisieren",
+    "refreshWithInterval": "Metriken aktualisieren (automatisch alle {seconds}s)",
+    "refreshAutoDisabled": "Metriken aktualisieren (Auto-Aktualisierung aus)",
     "title": "Metriken",
     "cpu": "CPU",
     "memory": "Arbeitsspeicher",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -643,6 +643,11 @@
       "description": "Pre-select this namespace when connecting to clusters",
       "placeholder": "All namespaces"
     },
+    "metricsRefreshInterval": {
+      "title": "Metrics Refresh Interval",
+      "description": "How often to poll CPU and memory metrics, independently of resource lists",
+      "disabled": "Disabled"
+    },
     "refreshInterval": {
       "title": "Refresh Interval",
       "description": "How often to refresh resource data (in seconds)",
@@ -951,6 +956,9 @@
     "removedMissingResourceDescription": "The resource \"{name}\" no longer exists."
   },
   "metrics": {
+    "refresh": "Refresh metrics",
+    "refreshWithInterval": "Refresh metrics (auto every {seconds}s)",
+    "refreshAutoDisabled": "Refresh metrics (auto-refresh off)",
     "title": "Metrics",
     "cpu": "CPU",
     "memory": "Memory",

--- a/src/lib/hooks/__tests__/useMetricsHistory.test.ts
+++ b/src/lib/hooks/__tests__/useMetricsHistory.test.ts
@@ -12,16 +12,24 @@ const mockClusterState = {
 
 jest.mock("@/lib/stores/cluster-store", () => ({
   useClusterStore: Object.assign(
-    jest.fn(() => ({ isConnected: true })),
+    jest.fn((selector?: (s: typeof mockClusterState) => unknown) =>
+      selector ? selector(mockClusterState) : mockClusterState
+    ),
     { getState: () => mockClusterState }
   ),
 }));
 
+import { renderHook, act } from "@testing-library/react";
+import { useUIStore, defaultSettings } from "@/lib/stores/ui-store";
+import { getPodMetrics } from "@/lib/tauri/commands";
 import {
+  useMetricsHistory,
   getHistorySnapshot,
   seedHistoryFromBulkMetrics,
   clearMetricsHistory,
 } from "../useMetricsHistory";
+
+const mockGetPodMetrics = getPodMetrics as jest.Mock;
 
 function makePodMetrics(name: string, cpu: number, mem: number): PodMetrics {
   return {
@@ -148,6 +156,78 @@ describe("useMetricsHistory module", () => {
       }
 
       expect(getHistorySnapshot("kubeli-demo/web")).toHaveLength(30);
+    });
+  });
+
+  // Regression for the metrics-interval setting: the pod-detail sparkline
+  // polled on its own hardcoded 10s timer, so "Disabled" (0) never stopped it.
+  describe("polling interval setting", () => {
+    const setMetricsInterval = (seconds: number) =>
+      useUIStore.setState({
+        settings: { ...defaultSettings, metricsRefreshInterval: seconds },
+      });
+
+    const advance = async (ms: number) => {
+      await act(async () => {
+        jest.advanceTimersByTime(ms);
+      });
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockGetPodMetrics.mockClear();
+      mockGetPodMetrics.mockResolvedValue([
+        makePodMetrics("web", 100_000_000, 200_000_000),
+      ]);
+    });
+
+    afterEach(() => {
+      useUIStore.setState({ settings: defaultSettings });
+    });
+
+    it("polls at the configured cadence", async () => {
+      setMetricsInterval(5);
+      renderHook(() => useMetricsHistory("web", "kubeli-demo"));
+
+      // Initial mount poll (setTimeout 0)
+      await advance(0);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(1);
+
+      await advance(5_000);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(2);
+
+      await advance(5_000);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(3);
+    });
+
+    it("stops after the mount poll when the interval is disabled", async () => {
+      setMetricsInterval(0);
+      renderHook(() => useMetricsHistory("web", "kubeli-demo"));
+
+      // One current reading beats an empty panel, so the mount poll stays
+      await advance(0);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(1);
+
+      await advance(300_000);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(1);
+    });
+
+    it("applies a changed setting without a remount", async () => {
+      setMetricsInterval(60);
+      renderHook(() => useMetricsHistory("web", "kubeli-demo"));
+
+      await advance(0);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(1);
+
+      await advance(30_000);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        setMetricsInterval(5);
+      });
+
+      await advance(5_000);
+      expect(mockGetPodMetrics).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/lib/hooks/__tests__/useMetricsInterval.test.ts
+++ b/src/lib/hooks/__tests__/useMetricsInterval.test.ts
@@ -1,0 +1,141 @@
+import { renderHook, act } from "@testing-library/react";
+import { useClusterMetrics, useNodeMetrics } from "../useMetrics";
+import { useUIStore, defaultSettings } from "../../stores/ui-store";
+import { getClusterMetricsSummary, getNodeMetrics } from "../../tauri/commands";
+
+jest.mock("../../tauri/commands", () => ({
+  getClusterMetricsSummary: jest.fn(),
+  getNodeMetrics: jest.fn(),
+  getPodMetrics: jest.fn(),
+  getPodMetricsDirect: jest.fn(),
+  checkMetricsServer: jest.fn(),
+}));
+
+jest.mock("../../stores/cluster-store", () => ({
+  useClusterStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ isConnected: true, selectedNamespaces: [] }),
+  selectCurrentNamespace: () => "default",
+}));
+
+const mockClusterSummary = getClusterMetricsSummary as jest.Mock;
+const mockNodeMetrics = getNodeMetrics as jest.Mock;
+
+const setMetricsInterval = (seconds: number) =>
+  useUIStore.setState({
+    settings: { ...defaultSettings, metricsRefreshInterval: seconds },
+  });
+
+describe("metrics polling interval", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockClusterSummary.mockResolvedValue({ metrics_available: true });
+    mockNodeMetrics.mockResolvedValue([]);
+    setMetricsInterval(defaultSettings.metricsRefreshInterval);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    useUIStore.setState({ settings: defaultSettings });
+  });
+
+  const advance = async (ms: number) => {
+    await act(async () => {
+      jest.advanceTimersByTime(ms);
+    });
+  };
+
+  it("polls at the configured interval", async () => {
+    setMetricsInterval(5);
+    renderHook(() => useClusterMetrics({ autoRefresh: true }));
+
+    // Initial fetch on mount
+    await act(async () => {});
+    expect(mockClusterSummary).toHaveBeenCalledTimes(1);
+
+    await advance(5000);
+    expect(mockClusterSummary).toHaveBeenCalledTimes(2);
+
+    await advance(5000);
+    expect(mockClusterSummary).toHaveBeenCalledTimes(3);
+  });
+
+  it("honours a longer interval", async () => {
+    setMetricsInterval(60);
+    renderHook(() => useClusterMetrics({ autoRefresh: true }));
+    await act(async () => {});
+    mockClusterSummary.mockClear();
+
+    await advance(30_000);
+    expect(mockClusterSummary).not.toHaveBeenCalled();
+
+    await advance(30_000);
+    expect(mockClusterSummary).toHaveBeenCalledTimes(1);
+  });
+
+  // 0 means the user turned polling off; only the manual button remains
+  it("stops polling when the interval is set to disabled", async () => {
+    setMetricsInterval(0);
+    const { result } = renderHook(() => useClusterMetrics({ autoRefresh: true }));
+
+    // The mount fetch still runs — an empty panel would be worse than one
+    // stale reading the user can refresh.
+    await act(async () => {});
+    expect(mockClusterSummary).toHaveBeenCalledTimes(1);
+    mockClusterSummary.mockClear();
+
+    await advance(300_000);
+    expect(mockClusterSummary).not.toHaveBeenCalled();
+
+    // Manual refresh still works
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockClusterSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the setting to node metrics too", async () => {
+    setMetricsInterval(5);
+    renderHook(() => useNodeMetrics({ autoRefresh: true }));
+    await act(async () => {});
+    mockNodeMetrics.mockClear();
+
+    await advance(5000);
+    expect(mockNodeMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not poll when autoRefresh is off, whatever the interval", async () => {
+    setMetricsInterval(5);
+    renderHook(() => useClusterMetrics({ autoRefresh: false }));
+    await act(async () => {});
+    mockClusterSummary.mockClear();
+
+    await advance(60_000);
+    expect(mockClusterSummary).not.toHaveBeenCalled();
+  });
+
+  // No caller overrides today, but the escape hatch must keep working
+  it("lets an explicit refreshInterval win over the setting", async () => {
+    setMetricsInterval(60);
+    renderHook(() => useClusterMetrics({ autoRefresh: true, refreshInterval: 2000 }));
+    await act(async () => {});
+    mockClusterSummary.mockClear();
+
+    await advance(2000);
+    expect(mockClusterSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it("picks up a changed setting without a remount", async () => {
+    setMetricsInterval(60);
+    renderHook(() => useClusterMetrics({ autoRefresh: true }));
+    await act(async () => {});
+    mockClusterSummary.mockClear();
+
+    await act(async () => {
+      setMetricsInterval(5);
+    });
+
+    await advance(5000);
+    expect(mockClusterSummary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/hooks/useMetrics.ts
+++ b/src/lib/hooks/useMetrics.ts
@@ -34,7 +34,7 @@ interface UseMetricsOptions {
  * An explicit option wins; otherwise the Settings value applies, where 0 means
  * the user turned automatic polling off and only manual refresh remains.
  */
-function useMetricsInterval(override?: number): number | null {
+export function useMetricsInterval(override?: number): number | null {
   const configuredSeconds = useUIStore((s) => s.settings.metricsRefreshInterval);
   if (override !== undefined) return override;
   return configuredSeconds > 0 ? configuredSeconds * 1000 : null;

--- a/src/lib/hooks/useMetrics.ts
+++ b/src/lib/hooks/useMetrics.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useClusterStore, selectCurrentNamespace } from "../stores/cluster-store";
+import { useUIStore } from "../stores/ui-store";
 import {
   getNodeMetrics,
   getPodMetrics,
@@ -17,9 +18,26 @@ import type {
 
 interface UseMetricsOptions {
   autoRefresh?: boolean;
+  /**
+   * Overrides the user's metrics interval, in ms. No caller sets it today —
+   * they all defer to the Settings value — but it stays available for a view
+   * that genuinely needs its own cadence.
+   */
   refreshInterval?: number;
   /** Faster interval for the first few polls to build sparkline data quickly */
   initialRefreshInterval?: number;
+}
+
+/**
+ * Resolves the effective polling interval in ms, or null when polling is off.
+ *
+ * An explicit option wins; otherwise the Settings value applies, where 0 means
+ * the user turned automatic polling off and only manual refresh remains.
+ */
+function useMetricsInterval(override?: number): number | null {
+  const configuredSeconds = useUIStore((s) => s.settings.metricsRefreshInterval);
+  if (override !== undefined) return override;
+  return configuredSeconds > 0 ? configuredSeconds * 1000 : null;
 }
 
 interface UseClusterMetricsReturn {
@@ -50,6 +68,7 @@ export function useClusterMetrics(options: UseMetricsOptions = {}): UseClusterMe
   const [error, setError] = useState<string | null>(null);
   const [metricsAvailable, setMetricsAvailable] = useState(false);
   const isConnected = useClusterStore((s) => s.isConnected);
+  const intervalMs = useMetricsInterval(options.refreshInterval);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
@@ -78,10 +97,10 @@ export function useClusterMetrics(options: UseMetricsOptions = {}): UseClusterMe
   }, [isConnected, refresh]);
 
   useEffect(() => {
-    if (!options.autoRefresh || !isConnected) return;
-    const interval = setInterval(refresh, options.refreshInterval || 15000);
+    if (!options.autoRefresh || !isConnected || intervalMs === null) return;
+    const interval = setInterval(refresh, intervalMs);
     return () => clearInterval(interval);
-  }, [options.autoRefresh, options.refreshInterval, isConnected, refresh]);
+  }, [options.autoRefresh, intervalMs, isConnected, refresh]);
 
   return {
     summary,
@@ -97,6 +116,7 @@ export function useNodeMetrics(options: UseMetricsOptions = {}): UseNodeMetricsR
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isConnected = useClusterStore((s) => s.isConnected);
+  const intervalMs = useMetricsInterval(options.refreshInterval);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
@@ -119,10 +139,10 @@ export function useNodeMetrics(options: UseMetricsOptions = {}): UseNodeMetricsR
   }, [isConnected, refresh]);
 
   useEffect(() => {
-    if (!options.autoRefresh || !isConnected) return;
-    const interval = setInterval(refresh, options.refreshInterval || 15000);
+    if (!options.autoRefresh || !isConnected || intervalMs === null) return;
+    const interval = setInterval(refresh, intervalMs);
     return () => clearInterval(interval);
-  }, [options.autoRefresh, options.refreshInterval, isConnected, refresh]);
+  }, [options.autoRefresh, intervalMs, isConnected, refresh]);
 
   return {
     data,
@@ -145,6 +165,7 @@ export function usePodMetrics(
   const pollCount = useRef(0);
   /** Track whether kubelet direct endpoint is available */
   const useDirectRef = useRef(true);
+  const intervalMs = useMetricsInterval(options.refreshInterval);
 
   const refresh = useCallback(async () => {
     if (!isConnected) return;
@@ -182,10 +203,10 @@ export function usePodMetrics(
   // Burst-then-normal polling: fast initial polls to build sparkline data
   // quickly with real values, then settle to normal interval.
   useEffect(() => {
-    if (!options.autoRefresh || !isConnected) return;
+    if (!options.autoRefresh || !isConnected || intervalMs === null) return;
 
     const burstMs = options.initialRefreshInterval;
-    const normalMs = options.refreshInterval || 10000;
+    const normalMs = intervalMs;
     const BURST_POLLS = burstMs ? 3 : 0;
     let timer: ReturnType<typeof setTimeout>;
 
@@ -200,7 +221,7 @@ export function usePodMetrics(
 
     scheduleNext();
     return () => clearTimeout(timer);
-  }, [options.autoRefresh, options.refreshInterval, options.initialRefreshInterval, isConnected, refresh]);
+  }, [options.autoRefresh, intervalMs, options.initialRefreshInterval, isConnected, refresh]);
 
   return {
     data,

--- a/src/lib/hooks/useMetricsHistory.ts
+++ b/src/lib/hooks/useMetricsHistory.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useClusterStore } from "../stores/cluster-store";
 import { getPodMetrics } from "../tauri/commands";
+import { useMetricsInterval } from "./useMetrics";
 import type { PodMetrics } from "../types";
 
 /** A single metrics snapshot for a pod */
@@ -12,9 +13,8 @@ export interface MetricsSnapshot {
   memoryBytes: number;
 }
 
-/** Max data points to keep per pod (5 min at 10s interval = 30 points) */
+/** Max data points to keep per pod (7.5 min at the default 15s cadence) */
 const MAX_POINTS = 30;
-const POLL_INTERVAL = 10_000; // 10 seconds
 
 /**
  * In-memory store for metrics history.
@@ -108,6 +108,7 @@ export function useMetricsHistory(
 ): MetricsHistoryResult {
   const isConnected = useClusterStore((s) => s.isConnected);
   const context = useClusterStore((s) => s.currentCluster?.context ?? null);
+  const intervalMs = useMetricsInterval();
   const key = `${namespace}/${podName}`;
   const [history, setHistory] = useState<MetricsSnapshot[]>(() => [...getHistory(key)]);
   const [polled, setPolled] = useState(() => getHistory(key).length > 0);
@@ -142,15 +143,20 @@ export function useMetricsHistory(
     }
   }, [isConnected, podName, namespace, key]);
 
+  // Mount poll, kept separate from the recurring timer: it runs even when
+  // polling is disabled (one current reading beats an empty panel) and must
+  // not re-fire when only the interval setting changes.
   useEffect(() => {
     // Use setTimeout(0) for initial poll to avoid synchronous setState in effect
     const initial = setTimeout(poll, 0);
-    const interval = setInterval(poll, POLL_INTERVAL);
-    return () => {
-      clearTimeout(initial);
-      clearInterval(interval);
-    };
+    return () => clearTimeout(initial);
   }, [poll]);
+
+  useEffect(() => {
+    if (intervalMs === null) return;
+    const interval = setInterval(poll, intervalMs);
+    return () => clearInterval(interval);
+  }, [poll, intervalMs]);
 
   return { history, polled };
 }

--- a/src/lib/stores/ui-store.ts
+++ b/src/lib/stores/ui-store.ts
@@ -26,6 +26,8 @@ export interface AppSettings {
   // General
   defaultNamespace: string;
   refreshInterval: number; // in seconds
+  /** Metrics polling interval in seconds; 0 disables automatic polling */
+  metricsRefreshInterval: number;
 
   // Port Forward
   portForwardOpenBrowser: PortForwardBrowserBehavior;
@@ -66,6 +68,8 @@ export const defaultSettings: AppSettings = {
   locale: defaultLocale,
   defaultNamespace: "",
   refreshInterval: 30,
+  // Matches the previous hardcoded cluster-overview cadence
+  metricsRefreshInterval: 15,
   portForwardOpenBrowser: "ask",
   autoInstallUpdates: false,
   logRetentionLines: 5000,


### PR DESCRIPTION
Closes #267

Metrics polling was hardcoded per view — 15s in the cluster overview, 10s for pod metrics — with no way to slow it down or turn it off. On a large cluster, or over a slow VPN, that is a steady load the user cannot control.

## Setting

`metricsRefreshInterval`: 5s / 10s / 15s / 30s / 1min / 5min / Disabled. Separate from the resource-list interval, since metrics are the more expensive and more frequent of the two. Default 15s — what the cluster overview already did.

## Where the interval is resolved

The hooks read the setting themselves rather than taking it from each call site. That way it reaches every metrics consumer without threading a prop through, and both hardcoded values disappear. An explicit `refreshInterval` option still wins if a view ever needs its own cadence; nothing passes one today.

**Disabled stops the timer but keeps the fetch on mount.** An empty metrics panel is worse than one stale reading the user can refresh on demand.

## Manual refresh

Always visible, not only when polling is off. Someone watching a rollout wants the current numbers now, whatever the timer says. The tooltip states the active cadence, or that auto-refresh is off.

## Tests

Interval honoured (short and long), disabled stops polling while leaving the mount fetch and manual refresh working, the setting applies to node metrics too, `autoRefresh: false` never polls, an explicit override wins, and a changed setting takes effect without a remount.

5 of the 7 fail when the setting wiring is reverted.

`make check`, `make lint`, `make vet` and the full suite (711 tests) pass.