### PR TITLE
fix: resubscribe aggregated log streams after a real drop

### DIFF
--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
 import { useWorkloadLogs, supportsAggregatedLogs } from "../useWorkloadLogs";
 
+const mockStreamPodLogs = jest.fn();
 const mockListPods = jest.fn();
 const mockListDeployments = jest.fn();
 const mockListStatefulsets = jest.fn();
@@ -18,7 +19,7 @@ jest.mock("../../tauri/commands", () => ({
   listDaemonsets: (...args: unknown[]) => mockListDaemonsets(...args),
   listReplicasets: (...args: unknown[]) => mockListReplicasets(...args),
   listJobs: (...args: unknown[]) => mockListJobs(...args),
-  streamPodLogs: jest.fn(),
+  streamPodLogs: (...args: unknown[]) => mockStreamPodLogs(...args),
   stopLogStream: jest.fn().mockResolvedValue(undefined),
   watchPods: (...args: unknown[]) => mockWatchPods(...args),
   stopWatch: (...args: unknown[]) => mockStopWatch(...args),
@@ -160,6 +161,140 @@ describe("useWorkloadLogs seq stamping", () => {
     const bySeq = [...result.current.logs].sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
     expect(bySeq.map((l) => l.message)).toEqual(["first", "second", "third"]);
     expect(result.current.logs.map((l) => l.message)).toEqual(["second", "first", "third"]);
+  });
+});
+
+// Regression: every Ended event was treated as routine pod rotation, so a real
+// network drop silently killed that pod's stream — no lines, no notice.
+describe("useWorkloadLogs stream drop vs pod rotation", () => {
+  const podEntry = {
+    uid: "uid-1",
+    name: "demo-web-7d4b8c-abcde",
+    namespace: "default",
+    phase: "Running",
+    labels: { app: "demo-web" },
+  };
+
+  /** Starts an aggregated stream for one running pod and returns its emitters */
+  async function startStreamingOnePod() {
+    const logListeners: Array<(event: { payload: unknown }) => void> = [];
+    const logUnlistens: jest.Mock[] = [];
+    let watchListener: ((event: { payload: unknown }) => void) | undefined;
+    mockListen.mockImplementation(
+      (eventName: string, handler: (e: { payload: unknown }) => void) => {
+        const unlisten = jest.fn();
+        if (eventName.startsWith("log-stream-")) {
+          logListeners.push(handler);
+          logUnlistens.push(unlisten);
+        }
+        if (eventName.startsWith("pods-watch-")) watchListener = handler;
+        return Promise.resolve(unlisten);
+      }
+    );
+
+    const { result } = renderHook(() => useWorkloadLogs("demo-web", "default"));
+    await act(async () => {});
+    await act(async () => {
+      await result.current.startStream();
+    });
+
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(1);
+    return { result, logListeners, logUnlistens, watchListener: watchListener! };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListDeployments.mockResolvedValue([
+      { name: "demo-web", namespace: "default", selector_query: "app=demo-web" },
+    ]);
+    mockListPods.mockResolvedValue([podEntry]);
+    mockWatchPods.mockResolvedValue(undefined);
+    mockStopWatch.mockResolvedValue(undefined);
+    mockStreamPodLogs.mockResolvedValue(undefined);
+    mockListen.mockResolvedValue(jest.fn());
+  });
+
+  it("resubscribes when a stream drops while the pod is still on the roster", async () => {
+    const { logListeners } = await startStreamingOnePod();
+
+    await act(async () => {
+      logListeners[0]({
+        payload: {
+          type: "Line",
+          data: {
+            message: "hello",
+            timestamp: new Date(Date.now() - 5000).toISOString(),
+            container: "main",
+            pod: podEntry.name,
+            namespace: "default",
+          },
+        },
+      });
+      logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+    });
+
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
+    const [, resumeOptions] = mockStreamPodLogs.mock.calls[1];
+    expect(resumeOptions).toMatchObject({
+      namespace: "default",
+      pod_name: podEntry.name,
+      follow: true,
+    });
+    // Resumes from the last line seen instead of refetching the tail
+    expect(resumeOptions.since_seconds).toBeGreaterThan(0);
+    expect(resumeOptions.tail_lines).toBeUndefined();
+  });
+
+  it("drops the dead stream's listener when resubscribing", async () => {
+    const { logListeners, logUnlistens } = await startStreamingOnePod();
+
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+    });
+
+    expect(logUnlistens[0]).toHaveBeenCalledTimes(1);
+    expect(logUnlistens[1]).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when the pod rotated out of the roster", async () => {
+    const { logListeners, watchListener } = await startStreamingOnePod();
+
+    // Rolling update: the pod leaves the roster, then its stream ends
+    await act(async () => {
+      watchListener({ payload: { type: "Deleted", data: podEntry } });
+    });
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+    });
+
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after one retry instead of looping", async () => {
+    const { logListeners } = await startStreamingOnePod();
+
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+    });
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
+
+    // The resubscribed stream drops too
+    await act(async () => {
+      logListeners[1]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+    });
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
+  });
+
+  // A container that simply exited ends cleanly; retrying would fight the pod's
+  // own lifecycle instead of a network problem.
+  it("does not resubscribe on a clean end of stream", async () => {
+    const { logListeners } = await startStreamingOnePod();
+
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Ended", data: { reason: null } } });
+    });
+
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -257,6 +257,33 @@ describe("useWorkloadLogs stream drop vs pod rotation", () => {
     expect(logUnlistens[1]).not.toHaveBeenCalled();
   });
 
+  // Regression: the backend always emits Ended and then Stopped for the same
+  // stream. Stopped emptied the roster and cleared isStreaming, while the
+  // replacement stream had no Started handler to set it again — so the view
+  // reported "not streaming" while resubscribed lines kept arriving.
+  it("keeps reporting isStreaming after a drop is recovered", async () => {
+    const { result, logListeners } = await startStreamingOnePod();
+
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Started" } });
+    });
+    expect(result.current.isStreaming).toBe(true);
+
+    // Real backend order for a dropped stream
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+      logListeners[0]({ payload: { type: "Stopped", data: {} } });
+    });
+    await waitFor(() => expect(mockStreamPodLogs).toHaveBeenCalledTimes(2));
+
+    // The replacement stream reports Started just like any other
+    await act(async () => {
+      logListeners[1]({ payload: { type: "Started" } });
+    });
+
+    expect(result.current.isStreaming).toBe(true);
+  });
+
   // Regression: stream IDs were Date.now()-only, so a resubscribe landing in
   // the same millisecond reused the dead stream's ID — two live streams then
   // shared one event channel and one stop handle.

--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -332,6 +332,30 @@ describe("useWorkloadLogs stream drop vs pod rotation", () => {
     expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
   });
 
+  // Regression: the retry guard was permanent, so a pod that dropped once was
+  // locked out for the rest of the session — a later, unrelated drop after
+  // hours of healthy streaming got no reconnect at all.
+  it("retries again after a drop that follows a healthy stretch", async () => {
+    const { logListeners } = await startStreamingOnePod();
+
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+    });
+    await waitFor(() => expect(mockStreamPodLogs).toHaveBeenCalledTimes(2));
+
+    // The replacement streams happily well past the loop-guard cooldown
+    const realNow = Date.now;
+    Date.now = () => realNow() + 60_000;
+    try {
+      await act(async () => {
+        logListeners[1]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+      });
+      await waitFor(() => expect(mockStreamPodLogs).toHaveBeenCalledTimes(3));
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   // A container that simply exited ends cleanly; retrying would fight the pod's
   // own lifecycle instead of a network problem.
   it("does not resubscribe on a clean end of stream", async () => {

--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
 import { useWorkloadLogs, supportsAggregatedLogs } from "../useWorkloadLogs";
 
@@ -233,7 +233,8 @@ describe("useWorkloadLogs stream drop vs pod rotation", () => {
       logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
     });
 
-    expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
+    // The resubscribe runs off an async chain, so poll instead of assuming ticks
+    await waitFor(() => expect(mockStreamPodLogs).toHaveBeenCalledTimes(2));
     const [, resumeOptions] = mockStreamPodLogs.mock.calls[1];
     expect(resumeOptions).toMatchObject({
       namespace: "default",
@@ -252,8 +253,24 @@ describe("useWorkloadLogs stream drop vs pod rotation", () => {
       logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
     });
 
-    expect(logUnlistens[0]).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(logUnlistens[0]).toHaveBeenCalledTimes(1));
     expect(logUnlistens[1]).not.toHaveBeenCalled();
+  });
+
+  // Regression: stream IDs were Date.now()-only, so a resubscribe landing in
+  // the same millisecond reused the dead stream's ID — two live streams then
+  // shared one event channel and one stop handle.
+  it("gives the resubscribed stream an ID of its own", async () => {
+    const { logListeners } = await startStreamingOnePod();
+
+    await act(async () => {
+      logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
+    });
+    await waitFor(() => expect(mockStreamPodLogs).toHaveBeenCalledTimes(2));
+
+    const [firstId] = mockStreamPodLogs.mock.calls[0];
+    const [secondId] = mockStreamPodLogs.mock.calls[1];
+    expect(secondId).not.toBe(firstId);
   });
 
   it("stays silent when the pod rotated out of the roster", async () => {
@@ -266,6 +283,7 @@ describe("useWorkloadLogs stream drop vs pod rotation", () => {
     await act(async () => {
       logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
     });
+    await act(async () => { await Promise.resolve(); });
 
     expect(mockStreamPodLogs).toHaveBeenCalledTimes(1);
   });
@@ -276,12 +294,14 @@ describe("useWorkloadLogs stream drop vs pod rotation", () => {
     await act(async () => {
       logListeners[0]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
     });
-    expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(mockStreamPodLogs).toHaveBeenCalledTimes(2));
 
     // The resubscribed stream drops too
     await act(async () => {
       logListeners[1]({ payload: { type: "Ended", data: { reason: "connection reset" } } });
     });
+    // Give a would-be third subscribe every chance to appear before asserting
+    await act(async () => { await Promise.resolve(); });
     expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
   });
 
@@ -293,6 +313,7 @@ describe("useWorkloadLogs stream drop vs pod rotation", () => {
     await act(async () => {
       logListeners[0]({ payload: { type: "Ended", data: { reason: null } } });
     });
+    await act(async () => { await Promise.resolve(); });
 
     expect(mockStreamPodLogs).toHaveBeenCalledTimes(1);
   });

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -124,9 +124,20 @@ export function useWorkloadLogs(
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
   const selectorQueryRef = useRef("");
+  // Pod roster mirror, so the Ended handler can tell a rotated-away pod from a
+  // pod that is still supposed to be streaming
+  const podsRef = useRef<PodInfo[]>([]);
+  // Last timestamp seen per pod, to resume a resubscribe without refetching
+  const lastTimestampRef = useRef(new Map<string, string>());
+  // Pods already auto-resubscribed once; guards against a reconnect loop
+  const resubscribedRef = useRef(new Set<string>());
+  // Lets a resubscribe drop the dead stream's listener without leaking it
+  const unlistenByStreamRef = useRef(new Map<string, UnlistenFn>());
   // Stable color assignment - remembers colors for pods that have disappeared
   const colorAssignmentsRef = useRef(new Map<string, PodColorEntry>());
   const nextColorIndexRef = useRef(0);
+
+  podsRef.current = pods;
 
   // Pod color map - assigns stable colors, never forgets a pod
   const podColorMap = useMemo(() => {
@@ -262,6 +273,7 @@ export function useWorkloadLogs(
       unlisten();
     }
     activeListeners.current = [];
+    unlistenByStreamRef.current.clear();
 
     flushPending();
 
@@ -269,6 +281,127 @@ export function useWorkloadLogs(
       setIsStreaming(false);
     }
   }, [flushPending]);
+
+  /**
+   * Subscribes to one pod's log stream. `onStarted` only fires for the initial
+   * fan-out, where it counts down to isStreaming; a resubscribe passes nothing.
+   */
+  const subscribePod = useCallback(
+    async (
+      podName: string,
+      logOptions: Omit<LogOptions, "namespace" | "pod_name">,
+      onStarted?: () => void,
+    ): Promise<{ streamId: string; unlisten: UnlistenFn }> => {
+      const streamId = `workload-logs-${kind}-${namespace}-${workloadName}-${podName}-${Date.now()}`;
+      const unlisten = await listen<LogEvent>(`log-stream-${streamId}`, (event) => {
+        const logEvent = event.payload;
+
+        switch (logEvent.type) {
+          case "Line":
+            rememberTimestamp(podName, logEvent.data.timestamp);
+            pendingLogsRef.current.push(stampSeq(logEvent.data));
+            scheduleFlush();
+            break;
+          case "Lines":
+            rememberTimestamp(podName, logEvent.data.at(-1)?.timestamp);
+            pendingLogsRef.current.push(...logEvent.data.map(stampSeq));
+            scheduleFlush();
+            break;
+          case "Error":
+            flushPending();
+            console.error(`Stream error for pod ${podName}:`, logEvent.data);
+            break;
+          case "Ended":
+            flushPending();
+            handleStreamEnded(podName, streamId, logEvent.data.reason ?? null);
+            break;
+          case "Started":
+            onStarted?.();
+            break;
+          case "Stopped": {
+            const idx = activeStreamIds.current.indexOf(streamId);
+            if (idx !== -1) {
+              activeStreamIds.current.splice(idx, 1);
+            }
+            if (activeStreamIds.current.length === 0 && mountedRef.current) {
+              flushPending();
+              setIsStreaming(false);
+            }
+            break;
+          }
+        }
+      });
+
+      unlistenByStreamRef.current.set(streamId, unlisten);
+      await streamPodLogs(streamId, { namespace, pod_name: podName, ...logOptions });
+      return { streamId, unlisten };
+    },
+    // handleStreamEnded/rememberTimestamp only read refs, so the first-render
+    // closures stay correct and do not belong in the dep list
+    [kind, namespace, workloadName, scheduleFlush, flushPending],
+  );
+
+  const subscribePodRef = useRef(subscribePod);
+  subscribePodRef.current = subscribePod;
+
+  function rememberTimestamp(podName: string, timestamp: string | null | undefined) {
+    if (timestamp) lastTimestampRef.current.set(podName, timestamp);
+  }
+
+  /**
+   * A stream ending is routine here: replicas finish or get replaced by a
+   * rolling update while the others keep streaming. It is only a real drop when
+   * the backend reports a reason AND the pod is still on the roster — then the
+   * view would silently go quiet, so resubscribe from the last line seen.
+   * A clean end (reason null) means the container itself stopped producing.
+   */
+  function handleStreamEnded(podName: string, streamId: string, reason: string | null) {
+    if (!reason || !mountedRef.current) return;
+    if (!podsRef.current.some((p) => p.name === podName)) return;
+    if (resubscribedRef.current.has(podName)) {
+      // ponytail: one retry per pod, then give up quietly. A notice with a
+      // manual reconnect is the upgrade path if one retry proves too few.
+      console.warn(`Log stream for pod ${podName} dropped again, not retrying: ${reason}`);
+      return;
+    }
+    resubscribedRef.current.add(podName);
+
+    const lastTimestamp = lastTimestampRef.current.get(podName);
+    // One second of overlap is cheaper than a missing line.
+    const sinceSeconds = lastTimestamp
+      ? Math.max(1, Math.ceil((Date.now() - new Date(lastTimestamp).getTime()) / 1000) + 1)
+      : undefined;
+
+    void (async () => {
+      try {
+        const { streamId: newId, unlisten } = await subscribePodRef.current(podName, {
+          follow: true,
+          timestamps: true,
+          since_seconds: sinceSeconds,
+          tail_lines: sinceSeconds === undefined ? 100 : undefined,
+        });
+        if (!mountedRef.current) {
+          unlisten();
+          stopLogStream(newId).catch(() => {});
+          return;
+        }
+        // Retire the dead stream: its listener would otherwise outlive it
+        const dead = unlistenByStreamRef.current.get(streamId);
+        if (dead) {
+          dead();
+          unlistenByStreamRef.current.delete(streamId);
+          const listenerIdx = activeListeners.current.indexOf(dead);
+          if (listenerIdx !== -1) activeListeners.current.splice(listenerIdx, 1);
+        }
+        const idx = activeStreamIds.current.indexOf(streamId);
+        if (idx !== -1) activeStreamIds.current.splice(idx, 1);
+        activeStreamIds.current.push(newId);
+        activeListeners.current.push(unlisten);
+      } catch (e) {
+        console.error(`Failed to resubscribe log stream for pod ${podName}:`, e);
+      }
+    })();
+  }
 
   const startStream = useCallback(
     async (tailLines = 100) => {
@@ -286,76 +419,29 @@ export function useWorkloadLogs(
           return;
         }
 
+        resubscribedRef.current.clear();
+
         const streamIds: string[] = [];
         const listeners: UnlistenFn[] = [];
         let startedCount = 0;
 
+        const onStarted = () => {
+          startedCount++;
+          if (startedCount === currentPods.length && mountedRef.current) {
+            setIsStreaming(true);
+            setIsLoading(false);
+          }
+        };
+
         for (const pod of currentPods) {
           if (!mountedRef.current) break;
-          const streamId = `workload-logs-${kind}-${namespace}-${workloadName}-${pod.name}-${Date.now()}`;
+          const { streamId, unlisten } = await subscribePod(
+            pod.name,
+            { follow: true, timestamps: true, tail_lines: tailLines },
+            onStarted,
+          );
           streamIds.push(streamId);
-
-          const eventName = `log-stream-${streamId}`;
-
-          const unlisten = await listen<LogEvent>(eventName, (event) => {
-            const logEvent = event.payload;
-
-            switch (logEvent.type) {
-              case "Line":
-                pendingLogsRef.current.push(stampSeq(logEvent.data));
-                scheduleFlush();
-                break;
-              case "Lines":
-                pendingLogsRef.current.push(...logEvent.data.map(stampSeq));
-                scheduleFlush();
-                break;
-              case "Error":
-                flushPending();
-                console.error(`Stream error for pod ${pod.name}:`, logEvent.data);
-                break;
-              case "Ended":
-                // One pod's stream ending is routine here — a replica finishes
-                // or is replaced while the others keep streaming. Flush what it
-                // produced; the pod watch handles the roster.
-                flushPending();
-                if (logEvent.data.reason) {
-                  console.info(
-                    `Log stream for pod ${pod.name} ended: ${logEvent.data.reason}`
-                  );
-                }
-                break;
-              case "Started":
-                startedCount++;
-                if (startedCount === currentPods.length && mountedRef.current) {
-                  setIsStreaming(true);
-                  setIsLoading(false);
-                }
-                break;
-              case "Stopped": {
-                const idx = activeStreamIds.current.indexOf(streamId);
-                if (idx !== -1) {
-                  activeStreamIds.current.splice(idx, 1);
-                }
-                if (activeStreamIds.current.length === 0 && mountedRef.current) {
-                  flushPending();
-                  setIsStreaming(false);
-                }
-                break;
-              }
-            }
-          });
-
           listeners.push(unlisten);
-
-          const logOptions: LogOptions = {
-            namespace,
-            pod_name: pod.name,
-            follow: true,
-            timestamps: true,
-            tail_lines: tailLines,
-          };
-
-          await streamPodLogs(streamId, logOptions);
         }
 
         activeStreamIds.current = streamIds;
@@ -374,7 +460,7 @@ export function useWorkloadLogs(
         }
       }
     },
-    [isStreaming, stopAllStreams, fetchPods, namespace, workloadName, kind, scheduleFlush, flushPending]
+    [isStreaming, stopAllStreams, fetchPods, subscribePod]
   );
 
   const clearLogs = useCallback(() => {

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -133,6 +133,8 @@ export function useWorkloadLogs(
   const resubscribedRef = useRef(new Set<string>());
   // Lets a resubscribe drop the dead stream's listener without leaking it
   const unlistenByStreamRef = useRef(new Map<string, UnlistenFn>());
+  // Disambiguates stream IDs created within the same millisecond
+  const nextStreamSeqRef = useRef(0);
   // Stable color assignment - remembers colors for pods that have disappeared
   const colorAssignmentsRef = useRef(new Map<string, PodColorEntry>());
   const nextColorIndexRef = useRef(0);
@@ -292,7 +294,10 @@ export function useWorkloadLogs(
       logOptions: Omit<LogOptions, "namespace" | "pod_name">,
       onStarted?: () => void,
     ): Promise<{ streamId: string; unlisten: UnlistenFn }> => {
-      const streamId = `workload-logs-${kind}-${namespace}-${workloadName}-${podName}-${Date.now()}`;
+      // Counter, not just Date.now(): a resubscribe can land in the same
+      // millisecond as the stream it replaces, and two live streams sharing an
+      // ID would share one event channel and one stop handle.
+      const streamId = `workload-logs-${kind}-${namespace}-${workloadName}-${podName}-${Date.now()}-${nextStreamSeqRef.current++}`;
       const unlisten = await listen<LogEvent>(`log-stream-${streamId}`, (event) => {
         const logEvent = event.payload;
 

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -379,12 +379,22 @@ export function useWorkloadLogs(
 
     void (async () => {
       try {
-        const { streamId: newId, unlisten } = await subscribePodRef.current(podName, {
-          follow: true,
-          timestamps: true,
-          since_seconds: sinceSeconds,
-          tail_lines: sinceSeconds === undefined ? 100 : undefined,
-        });
+        const { streamId: newId, unlisten } = await subscribePodRef.current(
+          podName,
+          {
+            follow: true,
+            timestamps: true,
+            since_seconds: sinceSeconds,
+            tail_lines: sinceSeconds === undefined ? 100 : undefined,
+          },
+          // The dead stream's Stopped event arrives before this one is
+          // registered and can drop the roster to empty, clearing isStreaming.
+          // Restore it once the replacement is live, or the view claims to be
+          // stopped while lines keep arriving.
+          () => {
+            if (mountedRef.current) setIsStreaming(true);
+          },
+        );
         if (!mountedRef.current) {
           unlisten();
           stopLogStream(newId).catch(() => {});

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -37,6 +37,12 @@ export const POD_COLOR_PAIRS = [
   { text: "text-amber-400", bg: "bg-amber-400" },
 ] as const;
 
+/**
+ * A drop this soon after the previous retry means reconnecting is not working,
+ * so stop instead of hammering the API server.
+ */
+const RESUBSCRIBE_COOLDOWN_MS = 30_000;
+
 export interface PodColorEntry {
   text: string;
   bg: string;
@@ -129,8 +135,8 @@ export function useWorkloadLogs(
   const podsRef = useRef<PodInfo[]>([]);
   // Last timestamp seen per pod, to resume a resubscribe without refetching
   const lastTimestampRef = useRef(new Map<string, string>());
-  // Pods already auto-resubscribed once; guards against a reconnect loop
-  const resubscribedRef = useRef(new Set<string>());
+  // When each pod was last auto-resubscribed; guards against a reconnect loop
+  const resubscribedRef = useRef(new Map<string, number>());
   // Lets a resubscribe drop the dead stream's listener without leaking it
   const unlistenByStreamRef = useRef(new Map<string, UnlistenFn>());
   // Disambiguates stream IDs created within the same millisecond
@@ -363,13 +369,15 @@ export function useWorkloadLogs(
   function handleStreamEnded(podName: string, streamId: string, reason: string | null) {
     if (!reason || !mountedRef.current) return;
     if (!podsRef.current.some((p) => p.name === podName)) return;
-    if (resubscribedRef.current.has(podName)) {
-      // ponytail: one retry per pod, then give up quietly. A notice with a
-      // manual reconnect is the upgrade path if one retry proves too few.
+    // Guard against a reconnect loop, not against retrying ever again: only a
+    // drop that follows hard on the heels of the last retry means reconnecting
+    // is not working. A stream that ran fine for a while has earned another try.
+    const lastRetry = resubscribedRef.current.get(podName);
+    if (lastRetry !== undefined && Date.now() - lastRetry < RESUBSCRIBE_COOLDOWN_MS) {
       console.warn(`Log stream for pod ${podName} dropped again, not retrying: ${reason}`);
       return;
     }
-    resubscribedRef.current.add(podName);
+    resubscribedRef.current.set(podName, Date.now());
 
     const lastTimestamp = lastTimestampRef.current.get(podName);
     // One second of overlap is cheaper than a missing line.


### PR DESCRIPTION
Closes #423

## Problem

In the aggregated workload log view every `Ended` event was treated as routine (pod rotation ends streams constantly). A real network drop therefore killed the affected per-pod streams silently — no notice, no reconnect, the view just stopped receiving lines.

## Approach: auto-resubscribe

The issue offered two options; this PR takes the auto-resubscribe one, because it needs no UI change and reuses the `since_seconds` resume already built for single-pod logs in #416.

`useWorkloadLogs` now separates the two cases in the `Ended` handler:

- **Rotation** — pod is no longer in the roster the pod-watch maintains → flush and stay silent, exactly as before. No notice spam during rolling updates.
- **Clean end** — `reason: null`, the container itself stopped producing → stay silent. Retrying would fight the pod's own lifecycle.
- **Drop** — `reason: Some(...)` while the pod is still on the roster → one automatic resubscribe, resuming from the last timestamp seen for that pod (1s overlap, same math as `useLogs.reconnect`).

Loop protection: max one automatic retry per pod. If the resubscribed stream drops again it logs a warning and gives up rather than hammering the API server. A `StreamEndedNotice` with a manual reconnect is the documented upgrade path if one retry proves too few in practice.

## Changes

- `src/lib/hooks/useWorkloadLogs.ts` — per-pod subscription extracted into `subscribePod()` so the initial fan-out and a resubscribe share one code path; `handleStreamEnded()` implements the rotation/clean/drop split; the dead stream's listener is retired on resubscribe so it does not leak.

## Tests

Regression tests in `src/lib/hooks/__tests__/useWorkloadLogs.test.ts` covering the failure mode and its counterpart:

- drop on a pod still on the roster → resubscribes with `since_seconds`, not a tail refetch
- the dead stream's listener is unlistened on resubscribe
- pod rotated out of the roster + `Ended` → silent
- second drop on the same pod → no further retry
- clean `Ended` (`reason: null`) → silent

## Verification

- `make check` — clean
- `make lint` — no new warnings (4 pre-existing ones in `LogViewer.tsx` on main)
- `npm run test` — 868/868 pass, 78 suites

Frontend-only; no backend change was needed since `LogEvent::Ended { reason }` already carries the distinction.