### PR TITLE
feat(shell): offer reconnect when an exec session drops

### DIFF
--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -40,8 +40,20 @@ enum ShellInput {
 pub enum ShellEvent {
     Output(String),
     Error(String),
-    Started { session_id: String },
-    Closed { session_id: String },
+    Started {
+        session_id: String,
+    },
+    /// The session ended after it had been running.
+    ///
+    /// Distinct from `Error`, which stays reserved for a connection that never
+    /// established (RBAC, pod not found). A session can end for entirely normal
+    /// reasons — the user typed `exit`, the shell process finished — so this is
+    /// a recoverable state offering reconnection, not a failure.
+    Closed {
+        session_id: String,
+        /// Present when the session was cut rather than exiting cleanly
+        reason: Option<String>,
+    },
 }
 
 /// Options for starting a shell session
@@ -207,18 +219,19 @@ pub async fn shell_start(
 
     // Spawn the shell session task
     tokio::spawn(async move {
-        match pods.exec(&options.pod_name, cmd, &attach_params).await {
+        let reason = match pods.exec(&options.pod_name, cmd, &attach_params).await {
             Ok(attached) => {
                 run_shell_session(attached, app.clone(), &event_name, stop_flag, &mut input_rx)
-                    .await;
+                    .await
             }
             Err(e) => {
                 let _ = app.emit(
                     &event_name,
                     ShellEvent::Error(format!("Failed to start shell: {}", e)),
                 );
+                None
             }
-        }
+        };
 
         // Clean up
         shell_manager_clone.remove_session(&session_id_clone).await;
@@ -226,6 +239,7 @@ pub async fn shell_start(
             &event_name,
             ShellEvent::Closed {
                 session_id: session_id_clone,
+                reason,
             },
         );
     });
@@ -281,21 +295,25 @@ fn take_valid_utf8(pending: &mut Vec<u8>, take_all: bool) -> String {
     }
 }
 
-/// Run the shell session handling stdin/stdout
+/// Run the shell session handling stdin/stdout.
+///
+/// Returns `Some(reason)` when the session was cut (I/O error on the exec
+/// stream) and `None` when it ended cleanly (shell exited, user disconnected).
 async fn run_shell_session(
     mut attached: AttachedProcess,
     app: AppHandle,
     event_name: &str,
     stop_flag: Arc<AtomicBool>,
     input_rx: &mut mpsc::Receiver<ShellInput>,
-) {
+) -> Option<String> {
     let (Some(mut stdin), Some(mut stdout)) = (attached.stdin(), attached.stdout()) else {
         tracing::error!("Shell attach did not provide stdin/stdout streams");
         let _ = app.emit(
             event_name,
             ShellEvent::Error("Failed to open shell I/O streams".to_string()),
         );
-        return;
+        // The connection never came up: `Error` above already covers it.
+        return None;
     };
     // terminal_size() takes the sender out of AttachedProcess (kube 4.0), so it
     // must be called exactly once and reused — calling it per resize returns
@@ -311,7 +329,7 @@ async fn run_shell_session(
     loop {
         if stop_flag.load(Ordering::SeqCst) {
             tracing::info!("Shell session stopped by user");
-            break;
+            return None;
         }
 
         tokio::select! {
@@ -321,7 +339,7 @@ async fn run_shell_session(
                     Some(ShellInput::Data(data)) => {
                         if let Err(e) = stdin.write_all(&data).await {
                             tracing::error!("Failed to write to stdin: {}", e);
-                            break;
+                            return Some(e.to_string());
                         }
                         if let Err(e) = stdin.flush().await {
                             tracing::error!("Failed to flush stdin: {}", e);
@@ -333,8 +351,8 @@ async fn run_shell_session(
                         }
                     }
                     None => {
-                        // Channel closed
-                        break;
+                        // Channel closed - the session was torn down locally
+                        return None;
                     }
                 }
             }
@@ -342,9 +360,9 @@ async fn run_shell_session(
             result = stdout.read(&mut stdout_buf) => {
                 match result {
                     Ok(0) => {
-                        // EOF
+                        // EOF - the shell process exited
                         flush_shell_output(&app, event_name, &mut pending, true);
-                        break;
+                        return None;
                     }
                     Ok(n) => {
                         pending.extend_from_slice(&stdout_buf[..n]);
@@ -352,6 +370,7 @@ async fn run_shell_session(
                         // (e.g. `cat` of a large file) emit one IPC event per
                         // ~batch instead of one per 4 KB read.
                         let mut eof = false;
+                        let mut read_error = None;
                         while pending.len() < MAX_SHELL_BATCH {
                             match tokio::time::timeout(
                                 SHELL_BATCH_WINDOW,
@@ -364,17 +383,24 @@ async fn run_shell_session(
                                     break;
                                 }
                                 Ok(Ok(n)) => pending.extend_from_slice(&stdout_buf[..n]),
-                                Ok(Err(_)) | Err(_) => break,
+                                Ok(Err(e)) => {
+                                    read_error = Some(e.to_string());
+                                    break;
+                                }
+                                // Batch window elapsed: flush what we have
+                                Err(_) => break,
                             }
                         }
-                        flush_shell_output(&app, event_name, &mut pending, eof);
+                        flush_shell_output(&app, event_name, &mut pending, eof || read_error.is_some());
+                        if let Some(reason) = read_error {
+                            return Some(reason);
+                        }
                         if eof {
-                            break;
+                            return None;
                         }
                     }
                     Err(e) => {
-                        let _ = app.emit(event_name, ShellEvent::Error(format!("Read error: {}", e)));
-                        break;
+                        return Some(e.to_string());
                     }
                 }
             }
@@ -681,7 +707,7 @@ pub async fn node_shell_start(
 
     // Spawn the shell session task
     tokio::spawn(async move {
-        match pods
+        let reason = match pods
             .exec(&debug_pod_name_clone, exec_cmd, &attach_params)
             .await
         {
@@ -700,15 +726,16 @@ pub async fn node_shell_start(
                     stop_flag,
                     &mut input_rx,
                 )
-                .await;
+                .await
             }
             Err(e) => {
                 let _ = app.emit(
                     &event_name_clone,
                     ShellEvent::Error(format!("Failed to attach to debug pod: {}", e)),
                 );
+                None
             }
-        }
+        };
 
         // Clean up: delete the debug pod
         let cleanup_pods: Api<Pod> = Api::namespaced(cleanup_client, NODE_SHELL_NAMESPACE);
@@ -729,6 +756,7 @@ pub async fn node_shell_start(
             &event_name_clone,
             ShellEvent::Closed {
                 session_id: session_id_clone,
+                reason,
             },
         );
     });
@@ -777,7 +805,36 @@ pub async fn node_shell_cleanup(
 
 #[cfg(test)]
 mod tests {
-    use super::take_valid_utf8;
+    use super::{take_valid_utf8, ShellEvent};
+
+    // A session cut mid-run is recoverable; only a connection that never
+    // established is an Error. The terminal branches on this reason to decide
+    // between "Session closed" and a reconnect prompt.
+    #[test]
+    fn dropped_session_closes_with_a_reason() {
+        let closed = serde_json::to_value(ShellEvent::Closed {
+            session_id: "shell-1".to_string(),
+            reason: Some("connection reset".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(closed["type"], "Closed");
+        assert_eq!(closed["data"]["session_id"], "shell-1");
+        assert_eq!(closed["data"]["reason"], "connection reset");
+    }
+
+    #[test]
+    fn clean_exit_carries_no_reason() {
+        let closed = serde_json::to_value(ShellEvent::Closed {
+            session_id: "shell-1".to_string(),
+            reason: None,
+        })
+        .unwrap();
+
+        // null rather than a placeholder string: the terminal distinguishes a
+        // shell that exited from a connection that was cut
+        assert!(closed["data"]["reason"].is_null());
+    }
 
     #[test]
     fn keeps_incomplete_utf8_tail_for_next_chunk() {

--- a/src/components/features/terminal/NodeTerminal.tsx
+++ b/src/components/features/terminal/NodeTerminal.tsx
@@ -3,6 +3,7 @@
 import { useRef, useCallback, useEffect, useState } from "react";
 import type { Terminal as XTermType } from "@xterm/xterm";
 import { Terminal } from "./Terminal";
+import { SessionDroppedNotice } from "./SessionDroppedNotice";
 import { useNodeShell } from "@/lib/hooks/useNodeShell";
 
 export interface NodeTerminalProps {
@@ -20,6 +21,8 @@ export function NodeTerminal({
 }: NodeTerminalProps) {
   const terminalRef = useRef<XTermType | null>(null);
   const [autoConnect, setAutoConnect] = useState(true);
+  /** Set when the session was cut rather than exiting cleanly */
+  const [droppedReason, setDroppedReason] = useState<string | null>(null);
 
   const {
     isConnected,
@@ -38,9 +41,15 @@ export function NodeTerminal({
     },
     onStarted: () => {
       // Output is already sent from backend
+      setDroppedReason(null);
     },
-    onClosed: () => {
-      terminalRef.current?.write(`\r\n\x1b[33mSession closed\x1b[0m\r\n`);
+    onClosed: (reason) => {
+      setDroppedReason(reason);
+      terminalRef.current?.write(
+        reason
+          ? `\r\n\x1b[33mConnection lost: ${reason}\x1b[0m\r\n`
+          : `\r\n\x1b[33mSession closed\x1b[0m\r\n`
+      );
     },
   }, tabSessionId);
 
@@ -78,7 +87,10 @@ export function NodeTerminal({
   }, [nodeName]);
 
   const handleReconnect = useCallback(() => {
-    terminalRef.current?.clear();
+    // No clear(): reconnecting stays in the same tab and the scrollback from
+    // before the drop is the whole reason to reconnect here rather than in a
+    // fresh tab.
+    setDroppedReason(null);
     terminalRef.current?.write(`Reconnecting to node ${nodeName}...\r\n`);
     connect();
   }, [connect, nodeName]);
@@ -159,6 +171,11 @@ export function NodeTerminal({
         <div className="px-3 py-2 bg-[#45475a] text-[#f38ba8] text-sm border-b border-[#313244]">
           {error}
         </div>
+      )}
+
+      {/* Dropped-session notice */}
+      {droppedReason && !isConnected && !isConnecting && (
+        <SessionDroppedNotice reason={droppedReason} onReconnect={handleReconnect} />
       )}
 
       {/* Terminal */}

--- a/src/components/features/terminal/PodTerminal.tsx
+++ b/src/components/features/terminal/PodTerminal.tsx
@@ -3,6 +3,7 @@
 import { useRef, useCallback, useEffect, useState } from "react";
 import type { Terminal as XTermType } from "@xterm/xterm";
 import { Terminal } from "./Terminal";
+import { SessionDroppedNotice } from "./SessionDroppedNotice";
 import { useShell } from "@/lib/hooks/useShell";
 
 export interface PodTerminalProps {
@@ -24,6 +25,8 @@ export function PodTerminal({
 }: PodTerminalProps) {
   const terminalRef = useRef<XTermType | null>(null);
   const [autoConnect, setAutoConnect] = useState(true);
+  /** Set when the session was cut rather than exiting cleanly */
+  const [droppedReason, setDroppedReason] = useState<string | null>(null);
 
   const {
     isConnected,
@@ -44,10 +47,16 @@ export function PodTerminal({
       terminalRef.current?.write(`\r\n\x1b[31mError: ${err}\x1b[0m\r\n`);
     },
     onStarted: () => {
+      setDroppedReason(null);
       terminalRef.current?.write(`\x1b[32mConnected to ${podName}\x1b[0m\r\n`);
     },
-    onClosed: () => {
-      terminalRef.current?.write(`\r\n\x1b[33mSession closed\x1b[0m\r\n`);
+    onClosed: (reason) => {
+      setDroppedReason(reason);
+      terminalRef.current?.write(
+        reason
+          ? `\r\n\x1b[33mConnection lost: ${reason}\x1b[0m\r\n`
+          : `\r\n\x1b[33mSession closed\x1b[0m\r\n`
+      );
     },
   }, tabSessionId);
 
@@ -97,7 +106,10 @@ export function PodTerminal({
   }, [podName]);
 
   const handleReconnect = useCallback(() => {
-    terminalRef.current?.clear();
+    // No clear(): reconnecting stays in the same tab and the scrollback from
+    // before the drop is the whole reason to reconnect here rather than in a
+    // fresh tab.
+    setDroppedReason(null);
     terminalRef.current?.write(`Reconnecting to ${podName}...\r\n`);
     connect();
   }, [connect, podName]);
@@ -195,6 +207,11 @@ export function PodTerminal({
         <div className="px-3 py-2 bg-[#45475a] text-[#f38ba8] text-sm border-b border-[#313244]">
           {error}
         </div>
+      )}
+
+      {/* Dropped-session notice */}
+      {droppedReason && !isConnected && !isConnecting && (
+        <SessionDroppedNotice reason={droppedReason} onReconnect={handleReconnect} />
       )}
 
       {/* Terminal */}

--- a/src/components/features/terminal/SessionDroppedNotice.tsx
+++ b/src/components/features/terminal/SessionDroppedNotice.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { PlugZap } from "lucide-react";
+
+export interface SessionDroppedNoticeProps {
+  /** Why the session was cut, as reported by the backend */
+  reason: string;
+  onReconnect: () => void;
+}
+
+/**
+ * Inline notice for an exec session that was cut after it had been running.
+ *
+ * A session drops for entirely ordinary reasons - a network blip, an API
+ * server restart, a rotated token - so this reads as a recoverable state
+ * rather than an error. Reconnecting reuses the same tab, so the xterm
+ * instance and its scrollback survive.
+ *
+ * ponytail: hardcoded English like the rest of PodTerminal/NodeTerminal
+ * (their header labels are not translated either); worth wiring to next-intl
+ * only when the whole terminal area gets localized.
+ */
+export function SessionDroppedNotice({ reason, onReconnect }: SessionDroppedNoticeProps) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 bg-[#45475a] text-sm border-b border-[#313244]">
+      <PlugZap className="size-4 shrink-0 text-[#f9e2af]" />
+      <span className="text-[#cdd6f4]">Connection lost: {reason}</span>
+      <button
+        onClick={onReconnect}
+        className="text-[#89b4fa] hover:underline"
+      >
+        Reconnect
+      </button>
+    </div>
+  );
+}

--- a/src/components/features/terminal/__tests__/SessionDroppedNotice.test.tsx
+++ b/src/components/features/terminal/__tests__/SessionDroppedNotice.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SessionDroppedNotice } from "../SessionDroppedNotice";
+
+describe("SessionDroppedNotice", () => {
+  // Regression: a dropped session only wrote a yellow "Session closed" line
+  // into xterm - no reason, no way back. The notice has to name the cause and
+  // offer a one-click reconnect.
+  it("names the reason and reconnects on click", async () => {
+    const onReconnect = jest.fn();
+    render(<SessionDroppedNotice reason="connection reset" onReconnect={onReconnect} />);
+
+    expect(screen.getByText(/connection reset/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/features/terminal/index.ts
+++ b/src/components/features/terminal/index.ts
@@ -7,5 +7,8 @@ export type { PodTerminalProps } from "./PodTerminal";
 export { NodeTerminal } from "./NodeTerminal";
 export type { NodeTerminalProps } from "./NodeTerminal";
 
+export { SessionDroppedNotice } from "./SessionDroppedNotice";
+export type { SessionDroppedNoticeProps } from "./SessionDroppedNotice";
+
 export { TerminalTabs, TerminalTabsProvider, useTerminalTabs } from "./TerminalTabs";
 export type { TerminalTab } from "./TerminalTabs";

--- a/src/lib/hooks/__tests__/useShell.test.ts
+++ b/src/lib/hooks/__tests__/useShell.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { listen } from "@tauri-apps/api/event";
+import { useShell } from "../useShell";
+import { getPodContainers, shellStart } from "../../tauri/commands";
+import type { ShellEvent } from "../../types";
+
+jest.mock("@tauri-apps/api/event", () => ({
+  listen: jest.fn(),
+}));
+
+jest.mock("../../tauri/commands", () => ({
+  shellStart: jest.fn().mockResolvedValue(undefined),
+  shellSendInput: jest.fn().mockResolvedValue(undefined),
+  shellResize: jest.fn().mockResolvedValue(undefined),
+  shellClose: jest.fn().mockResolvedValue(undefined),
+  getPodContainers: jest.fn().mockResolvedValue(["app"]),
+}));
+
+describe("useShell Closed events", () => {
+  let emit: (event: { payload: ShellEvent }) => void;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getPodContainers as jest.Mock).mockResolvedValue(["app"]);
+    (shellStart as jest.Mock).mockResolvedValue(undefined);
+    (listen as jest.Mock).mockImplementation((_event, handler) => {
+      emit = handler;
+      return Promise.resolve(jest.fn());
+    });
+  });
+
+  const connected = async (onClosed: (reason: string | null) => void) => {
+    const { result } = renderHook(() => useShell("default", "my-pod", { onClosed }));
+
+    await waitFor(() => expect(result.current.containers).toEqual(["app"]));
+    await act(async () => {
+      await result.current.connect();
+    });
+    act(() => {
+      emit({ payload: { type: "Started", data: { session_id: "s1" } } });
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    return result;
+  };
+
+  // Regression: a dropped exec stream reported the same "Closed" as a clean
+  // exit, so the terminal could only show a dead "Session closed" line with no
+  // way to tell a network blip from the user typing `exit`.
+  it("forwards the drop reason to onClosed", async () => {
+    const onClosed = jest.fn();
+    const result = await connected(onClosed);
+
+    act(() => {
+      emit({
+        payload: { type: "Closed", data: { session_id: "s1", reason: "connection reset" } },
+      });
+    });
+
+    expect(onClosed).toHaveBeenCalledWith("connection reset");
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it("passes null to onClosed when the shell exited cleanly", async () => {
+    const onClosed = jest.fn();
+    await connected(onClosed);
+
+    act(() => {
+      emit({ payload: { type: "Closed", data: { session_id: "s1", reason: null } } });
+    });
+
+    expect(onClosed).toHaveBeenCalledWith(null);
+  });
+
+  // A drop is recoverable, so it must not raise the error banner the way a
+  // connection that never came up does.
+  it("does not set the error state on a dropped session", async () => {
+    const result = await connected(jest.fn());
+
+    act(() => {
+      emit({
+        payload: { type: "Closed", data: { session_id: "s1", reason: "connection reset" } },
+      });
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/lib/hooks/useNodeShell.ts
+++ b/src/lib/hooks/useNodeShell.ts
@@ -15,7 +15,8 @@ export interface UseNodeShellOptions {
   onOutput?: (data: string) => void;
   onError?: (error: string) => void;
   onStarted?: () => void;
-  onClosed?: () => void;
+  /** `reason` is set when the session was cut, null when it exited cleanly */
+  onClosed?: (reason: string | null) => void;
 }
 
 export interface UseNodeShellReturn {
@@ -104,7 +105,7 @@ export function useNodeShell(
             setIsConnected(false);
             setIsConnecting(false);
             sessionIdRef.current = null;
-            onClosed?.();
+            onClosed?.(shellEvent.data.reason);
             break;
         }
       });

--- a/src/lib/hooks/useShell.ts
+++ b/src/lib/hooks/useShell.ts
@@ -15,7 +15,8 @@ export interface UseShellOptions {
   onOutput?: (data: string) => void;
   onError?: (error: string) => void;
   onStarted?: () => void;
-  onClosed?: () => void;
+  /** `reason` is set when the session was cut, null when it exited cleanly */
+  onClosed?: (reason: string | null) => void;
 }
 
 export interface UseShellReturn {
@@ -136,7 +137,7 @@ export function useShell(
               setIsConnected(false);
               setIsConnecting(false);
               sessionIdRef.current = null;
-              onClosed?.();
+              onClosed?.(shellEvent.data.reason);
               break;
           }
         });

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -177,7 +177,7 @@ export type ShellEvent =
   | { type: "Output"; data: string }
   | { type: "Error"; data: string }
   | { type: "Started"; data: { session_id: string } }
-  | { type: "Closed"; data: { session_id: string } };
+  | { type: "Closed"; data: { session_id: string; reason: string | null } };
 
 export interface PortForward {
   id: string;


### PR DESCRIPTION
Closes #422

## Problem

PR #416 gave log streams an `Ended` event with a reason and a one-click reconnect. Shell and node shell sessions never got the same treatment: whether the exec stream was cut by a network blip, an API server restart or a rotated token, or the user simply typed `exit`, the terminal wrote the same yellow "Session closed" line and stopped. No reason, no distinction, no obvious way back.

## Approach

Mirror the `LogEvent::Ended` pattern rather than inventing a new one.

**Backend** — `ShellEvent::Closed` gains `reason: Option<String>`. `run_shell_session` now returns `Option<String>` instead of falling out of a `break`, so every exit path is explicit:

| Path | Reason |
|---|---|
| stop flag set (user disconnect) | `None` |
| input channel closed | `None` |
| stdout EOF, incl. mid-batch | `None` (shell exited) |
| stdout read error, incl. inside the batch drain loop | `Some(err)` |
| stdin write error | `Some(err)` |
| attach never produced stdin/stdout | `None` (`Error` already emitted) |

Both call sites are covered — pod exec in `shell_start` and the debug-pod exec in `node_shell_start`.

The read-error path no longer emits `ShellEvent::Error`. The reason now travels in `Closed`, and keeping the `Error` emit would raise the red error banner for what is a recoverable drop. `Error` stays reserved for connections that never came up (RBAC, pod not found, attach failure), exactly as the doc comment on `LogEvent::Ended` describes.

**Frontend** — `onClosed` receives the reason. A drop renders `SessionDroppedNotice`, modelled on `StreamEndedNotice`: one line naming the cause plus a Reconnect action. A clean exit keeps the existing "Session closed" behaviour untouched.

**Scrollback** — reconnect calls the terminal's existing `connect()` in the same tab and no longer calls `terminal.clear()`. The xterm instance is never recreated, so what was on screen before the drop is still there after reconnecting. That was the previous behaviour's main loss and the reason to reconnect in-place rather than open a fresh tab.

## Notes on what was deliberately not done

- `SessionDroppedNotice` is a new component rather than a generalization of `StreamEndedNotice`. The two share a shape but not a visual language: the logs notice uses design tokens and `next-intl`, the terminal components use hardcoded catppuccin hex and untranslated English throughout (`Connected`, `Disconnect`, `Reconnect` in both headers today). Merging them would have meant either restyling the logs notice or localizing the whole terminal area — both larger than the bug. Marked with a `// ponytail:` comment.
- No auto-reconnect. A dropped shell has no resumable server-side state the way a log stream does, so silently reattaching would drop the user into a fresh shell that looks like the old one. The reconnect stays explicit.

## Tests

- `src-tauri/src/commands/shell.rs` — `dropped_session_closes_with_a_reason`, `clean_exit_carries_no_reason`: serialization shape, mirroring the equivalent `LogEvent::Ended` tests.
- `src/lib/hooks/__tests__/useShell.test.ts` — a `Closed` event with a reason reaches `onClosed`; a clean close passes `null`; a drop does not set the error state.
- `src/components/features/terminal/__tests__/SessionDroppedNotice.test.tsx` — the notice names the reason and its Reconnect button fires.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 331 passed, 0 failed
- `cargo fmt --check` — clean
- `make check` (tsc --noEmit) — clean
- `make lint` (eslint) — 0 errors (4 pre-existing warnings in `LogViewer.tsx`, untouched here)
- `npx jest` — 80 suites, 867 tests passed