### PR TITLE
feat(watch): add real-time watch for deployments

### DIFF
--- a/src-tauri/src/app/command_registry/mod.rs
+++ b/src-tauri/src/app/command_registry/mod.rs
@@ -80,6 +80,7 @@ pub fn handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Syn
         crate::commands::resources::suspend_cronjob,
         crate::commands::resources::resume_cronjob,
         crate::commands::watch::watch_pods,
+        crate::commands::watch::watch_deployments,
         crate::commands::watch::watch_namespaces,
         crate::commands::watch::stop_watch,
         crate::commands::logs::get_pod_logs,

--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -491,6 +491,29 @@ pub async fn list_pods(
     Ok(pod_infos)
 }
 
+/// Map a Deployment into the frontend info struct. Shared by the list
+/// command and the watch stream so both produce identical rows.
+pub fn deployment_to_info(deployment: Deployment) -> DeploymentInfo {
+    let metadata = deployment.metadata;
+    let spec = deployment.spec.unwrap_or_default();
+    let status = deployment.status.unwrap_or_default();
+
+    let selector_query = label_selector_to_query(&spec.selector);
+    DeploymentInfo {
+        name: metadata.name.unwrap_or_default(),
+        namespace: metadata.namespace.unwrap_or_default(),
+        uid: metadata.uid.unwrap_or_default(),
+        replicas: spec.replicas.unwrap_or(0),
+        ready_replicas: status.ready_replicas.unwrap_or(0),
+        available_replicas: status.available_replicas.unwrap_or(0),
+        updated_replicas: status.updated_replicas.unwrap_or(0),
+        created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
+        labels: btree_to_hashmap(metadata.labels),
+        selector: btree_to_hashmap(spec.selector.match_labels),
+        selector_query,
+    }
+}
+
 /// List all deployments
 #[command]
 pub async fn list_deployments(
@@ -518,26 +541,7 @@ pub async fn list_deployments(
     let deployment_infos: Vec<DeploymentInfo> = deployment_list
         .items
         .into_iter()
-        .map(|deployment| {
-            let metadata = deployment.metadata;
-            let spec = deployment.spec.unwrap_or_default();
-            let status = deployment.status.unwrap_or_default();
-
-            let selector_query = label_selector_to_query(&spec.selector);
-            DeploymentInfo {
-                name: metadata.name.unwrap_or_default(),
-                namespace: metadata.namespace.unwrap_or_default(),
-                uid: metadata.uid.unwrap_or_default(),
-                replicas: spec.replicas.unwrap_or(0),
-                ready_replicas: status.ready_replicas.unwrap_or(0),
-                available_replicas: status.available_replicas.unwrap_or(0),
-                updated_replicas: status.updated_replicas.unwrap_or(0),
-                created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
-                labels: btree_to_hashmap(metadata.labels),
-                selector: btree_to_hashmap(spec.selector.match_labels),
-                selector_query,
-            }
-        })
+        .map(deployment_to_info)
         .collect();
 
     tracing::info!("Listed {} deployments", deployment_infos.len());

--- a/src-tauri/src/commands/watch.rs
+++ b/src-tauri/src/commands/watch.rs
@@ -1,9 +1,11 @@
 use crate::commands::resources::{
-    extract_container_info, extract_tolerations, ContainerInfo, NamespaceInfo, PodInfo,
+    deployment_to_info, extract_container_info, extract_tolerations, ContainerInfo, NamespaceInfo,
+    PodInfo,
 };
 use crate::error::KubeliError;
 use crate::k8s::AppState;
 use futures::StreamExt;
+use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::{Namespace, Pod};
 use kube::api::Api;
 use kube::runtime::watcher::{watcher, Config, Event};
@@ -282,6 +284,50 @@ pub async fn watch_pods(
     Ok(())
 }
 
+/// Start watching deployments in a namespace (or all namespaces)
+#[command]
+pub async fn watch_deployments(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    watch_manager: State<'_, Arc<WatchManager>>,
+    namespace: Option<String>,
+    label_selector: Option<String>,
+    watch_id: String,
+) -> Result<(), KubeliError> {
+    let client = state.k8s.get_client().await.map_err(KubeliError::from)?;
+    let manager = Arc::clone(watch_manager.inner());
+    let token = manager.add_session(watch_id.clone()).await;
+
+    let deployments: Api<Deployment> = if let Some(ns) = &namespace {
+        Api::namespaced(client, ns)
+    } else {
+        Api::all(client)
+    };
+
+    let watch_id_clone = watch_id.clone();
+    tokio::spawn(async move {
+        let config = label_selector
+            .as_deref()
+            .filter(|selector| !selector.is_empty())
+            .map(|selector| Config::default().labels(selector))
+            .unwrap_or_default();
+        let stream = watcher(deployments, config).boxed();
+        run_watch_loop(
+            app,
+            manager,
+            watch_id_clone,
+            "deployments-watch",
+            stream,
+            deployment_to_info,
+            token,
+        )
+        .await;
+    });
+
+    tracing::info!("Started deployments watch: {}", watch_id);
+    Ok(())
+}
+
 fn namespace_to_info(ns: Namespace) -> NamespaceInfo {
     let metadata = ns.metadata;
     let status = ns
@@ -394,6 +440,78 @@ mod tests {
             map_watch_event(Ok(Event::Delete(5)), &mut buf, |v| v),
             Some(WatchEvent::Deleted(5))
         ));
+    }
+
+    fn test_deployment(name: &str, ready: i32) -> Deployment {
+        let mut deployment = Deployment::default();
+        deployment.metadata.name = Some(name.to_string());
+        deployment.metadata.namespace = Some("default".to_string());
+        deployment.metadata.uid = Some(format!("uid-{name}"));
+        deployment.spec = Some(k8s_openapi::api::apps::v1::DeploymentSpec {
+            replicas: Some(3),
+            ..Default::default()
+        });
+        deployment.status = Some(k8s_openapi::api::apps::v1::DeploymentStatus {
+            ready_replicas: Some(ready),
+            ..Default::default()
+        });
+        deployment
+    }
+
+    #[test]
+    fn deployment_events_map_to_deployment_info() {
+        let mut buf: Option<Vec<crate::commands::resources::DeploymentInfo>> = None;
+
+        // Initial listing is buffered into one Restarted event
+        assert!(map_watch_event(Ok(Event::Init), &mut buf, deployment_to_info).is_none());
+        assert!(map_watch_event(
+            Ok(Event::InitApply(test_deployment("web", 1))),
+            &mut buf,
+            deployment_to_info
+        )
+        .is_none());
+        match map_watch_event(Ok(Event::InitDone), &mut buf, deployment_to_info) {
+            Some(WatchEvent::Restarted(items)) => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0].name, "web");
+                assert_eq!(items[0].uid, "uid-web");
+                assert_eq!(items[0].replicas, 3);
+                assert_eq!(items[0].ready_replicas, 1);
+            }
+            _ => panic!("expected Restarted"),
+        }
+
+        // Apply without a preceding Init falls back to Added
+        match map_watch_event(
+            Ok(Event::InitApply(test_deployment("api", 2))),
+            &mut buf,
+            deployment_to_info,
+        ) {
+            Some(WatchEvent::Added(info)) => assert_eq!(info.name, "api"),
+            _ => panic!("expected Added"),
+        }
+
+        // A rollout scaling up arrives as Modified
+        match map_watch_event(
+            Ok(Event::Apply(test_deployment("web", 3))),
+            &mut buf,
+            deployment_to_info,
+        ) {
+            Some(WatchEvent::Modified(info)) => {
+                assert_eq!(info.name, "web");
+                assert_eq!(info.ready_replicas, 3);
+            }
+            _ => panic!("expected Modified"),
+        }
+
+        match map_watch_event(
+            Ok(Event::Delete(test_deployment("web", 0))),
+            &mut buf,
+            deployment_to_info,
+        ) {
+            Some(WatchEvent::Deleted(info)) => assert_eq!(info.uid, "uid-web"),
+            _ => panic!("expected Deleted"),
+        }
     }
 
     #[tokio::test]

--- a/src/components/features/dashboard/views/workloads/DeploymentsView.tsx
+++ b/src/components/features/dashboard/views/workloads/DeploymentsView.tsx
@@ -22,7 +22,10 @@ import type { DeploymentInfo } from "@/lib/types";
 
 export function DeploymentsView() {
   const t = useTranslations();
+  // autoRefresh stays on as the polling fallback: useK8sResource pauses the
+  // interval while the watch is live and resumes it if the watch fails.
   const { data, isLoading, error, refresh, retry } = useDeployments({
+    autoWatch: true,
     autoRefresh: true,
     refreshInterval: 30000,
   });

--- a/src/lib/hooks/k8s/resources/__tests__/workloads.test.ts
+++ b/src/lib/hooks/k8s/resources/__tests__/workloads.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from "@testing-library/react";
+import { listen } from "@tauri-apps/api/event";
+import { useDeployments } from "../workloads";
+import { useClusterStore } from "@/lib/stores/cluster-store";
+
+const mockListDeployments = jest.fn();
+const mockWatchDeployments = jest.fn();
+const mockStopWatch = jest.fn();
+
+jest.mock("../../../../tauri/commands", () => ({
+  listPods: jest.fn().mockResolvedValue([]),
+  listDeployments: (...args: unknown[]) => mockListDeployments(...args),
+  listReplicasets: jest.fn().mockResolvedValue([]),
+  listDaemonsets: jest.fn().mockResolvedValue([]),
+  listStatefulsets: jest.fn().mockResolvedValue([]),
+  listJobs: jest.fn().mockResolvedValue([]),
+  listCronjobs: jest.fn().mockResolvedValue([]),
+  watchPods: jest.fn().mockResolvedValue(undefined),
+  watchDeployments: (...args: unknown[]) => mockWatchDeployments(...args),
+  stopWatch: (...args: unknown[]) => mockStopWatch(...args),
+}));
+
+describe("useDeployments watch wiring", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockListDeployments.mockResolvedValue([]);
+    mockWatchDeployments.mockResolvedValue(undefined);
+    mockStopWatch.mockResolvedValue(undefined);
+    useClusterStore.setState({ isConnected: true, selectedNamespaces: ["default"] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  async function renderWithAutoWatch() {
+    const hook = renderHook(() => useDeployments({ autoWatch: true }));
+    await act(async () => {
+      await flushPromises();
+    });
+    // Auto-watch starts after a 500ms delay
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+      await flushPromises();
+    });
+    return hook;
+  }
+
+  it("starts a deployments watch for the selected namespace", async () => {
+    const { result } = await renderWithAutoWatch();
+
+    expect(mockWatchDeployments).toHaveBeenCalledTimes(1);
+    expect(mockWatchDeployments).toHaveBeenCalledWith(
+      expect.stringContaining("deployments-"),
+      "default"
+    );
+    expect(result.current.isWatching).toBe(true);
+  });
+
+  it("listens on the deployments-watch event channel emitted by the backend", async () => {
+    await renderWithAutoWatch();
+
+    const watchId = mockWatchDeployments.mock.calls[0][0] as string;
+    expect(listen).toHaveBeenCalledWith(
+      `deployments-watch-${watchId}`,
+      expect.any(Function)
+    );
+  });
+});
+
+function flushPromises() {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+    jest.advanceTimersByTime(0);
+  });
+}

--- a/src/lib/hooks/k8s/resources/workloads.ts
+++ b/src/lib/hooks/k8s/resources/workloads.ts
@@ -9,6 +9,7 @@ import {
   listJobs,
   listCronjobs,
   watchPods,
+  watchDeployments,
 } from "../../../tauri/commands";
 import type {
   PodInfo,
@@ -34,11 +35,17 @@ export const usePods = createNamespacedHook<PodInfo>({
 });
 
 /**
- * Hook for fetching Deployments.
+ * Hook for fetching Deployments with optional watch support.
+ * Deployments support real-time updates via WebSocket watching.
  */
 export const useDeployments = createListOptionsHook<DeploymentInfo>(
   "Deployments",
-  listDeployments
+  listDeployments,
+  {
+    supportsWatch: true,
+    watchFn: watchDeployments,
+    watchEventPrefix: "deployments",
+  }
 );
 
 /**

--- a/src/lib/tauri/commands/__tests__/wrappers.test.ts
+++ b/src/lib/tauri/commands/__tests__/wrappers.test.ts
@@ -103,6 +103,7 @@ const cases: TestCase[] = [
   { name: "shellResize", run: () => shell.shellResize("shell-1", 120, 40), expectedCommand: "shell_resize", expectedPayload: { sessionId: "shell-1", cols: 120, rows: 40 } },
   { name: "shellClose", run: () => shell.shellClose("shell-1"), expectedCommand: "shell_close", expectedPayload: { sessionId: "shell-1" } },
   { name: "watchPods", run: () => watch.watchPods("watch-1", "default"), expectedCommand: "watch_pods", expectedPayload: { watchId: "watch-1", namespace: "default" } },
+  { name: "watchDeployments", run: () => watch.watchDeployments("watch-1", "default"), expectedCommand: "watch_deployments", expectedPayload: { watchId: "watch-1", namespace: "default" } },
   { name: "watchNamespaces", run: () => watch.watchNamespaces("watch-1"), expectedCommand: "watch_namespaces", expectedPayload: { watchId: "watch-1" } },
   { name: "stopWatch", run: () => watch.stopWatch("watch-1"), expectedCommand: "stop_watch", expectedPayload: { watchId: "watch-1" } },
   { name: "aiCheckCliAvailable", run: () => ai.aiCheckCliAvailable(), expectedCommand: "ai_check_cli_available" },

--- a/src/lib/tauri/commands/watch.ts
+++ b/src/lib/tauri/commands/watch.ts
@@ -13,6 +13,18 @@ export async function watchPods(
   });
 }
 
+export async function watchDeployments(
+  watchId: string,
+  namespace?: string,
+  labelSelector?: string
+): Promise<void> {
+  return invoke("watch_deployments", {
+    watchId,
+    namespace,
+    ...(labelSelector ? { labelSelector } : {}),
+  });
+}
+
 export async function watchNamespaces(watchId: string): Promise<void> {
   return invoke("watch_namespaces", { watchId });
 }


### PR DESCRIPTION
Part of #209 — this is PR 1 of 2.

## Problem

Only Pods and Namespaces had a real-time watch. Deployments polled every 30s, so scaling a deployment or watching a rollout progress showed stale numbers for up to half a minute.

## What changed

The generic watch plumbing (`run_watch_loop` / `map_watch_event`) already existed and is generic over the k8s type plus a converter. Adding a kind is a thin typed wrapper plus a mapper, so that is all this does — no new generic `watch_resource()` command.

Backend:
- `deployment_to_info` extracted from the closure inside `list_deployments` into a shared function, so the list command and the watch stream produce identical rows instead of two copies of the mapping.
- `watch_deployments` command following `watch_pods` exactly, handling both the namespaced and all-namespaces case, emitting on the `deployments-watch` prefix.
- Registered in the command registry.

Frontend:
- `watchDeployments` binding.
- `useDeployments` gets `supportsWatch` / `watchFn` / `watchEventPrefix` — the hook interface was already generic, only Pods used it.
- `DeploymentsView` turns on `autoWatch`. `autoRefresh` stays on as the fallback: `useK8sResource` pauses the interval while the watch is live and resumes it if the watch errors out.

## Scope

Deliberately Deployments only, to validate the pattern at a size that can be tested by hand. **Services, StatefulSets, DaemonSets and ReplicaSets follow in PR 2** using the same wrapper.

## Tests

- Rust: `deployment_events_map_to_deployment_info` covers the initial listing collapsing into one `Restarted`, `InitApply` without `Init` falling back to `Added`, a rollout arriving as `Modified`, and `Deleted`.
- Frontend: `useDeployments` starts a watch for the selected namespace and listens on the `deployments-watch-<id>` channel — asserting the event prefix matches what the Rust side emits.

Verified: `cargo clippy --all-targets -- -D warnings` clean, `cargo test` 330 passed, `cargo fmt --check` clean, `make check` clean, `make lint` clean (4 pre-existing LogViewer warnings), `npm run test` 866 passed across 5 consecutive full-suite runs.

## Manual test

Open the Deployments view, scale a deployment from another terminal (`kubectl scale deploy/x --replicas=5`), and the replica counts should update immediately instead of on the next 30s tick.