### PR TITLE
feat: aggregate logs across a CronJob's Jobs

### DIFF
--- a/.dev/k8s-samples/21-cronjob-logs-test.yaml
+++ b/.dev/k8s-samples/21-cronjob-logs-test.yaml
@@ -1,0 +1,49 @@
+# Short-cycle CronJob for testing aggregated CronJob logs (issue #421).
+#
+# The regular demo CronJob (demo-cleanup, 10-workloads.yaml) runs every 30
+# minutes, which is far too slow to watch a new Job appear in a running
+# aggregate. This one fires every minute and keeps a few finished Jobs around,
+# so the two-hop resolution (CronJob -> Jobs -> Pods) has something to resolve.
+#
+# Apply:  kubectl apply -f .dev/k8s-samples/21-cronjob-logs-test.yaml
+# Remove: kubectl delete -f .dev/k8s-samples/21-cronjob-logs-test.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: demo-log-ticker
+  namespace: kubeli-demo
+  labels:
+    app: demo-app
+    component: log-ticker
+spec:
+  schedule: "* * * * *"
+  # Keep several finished Jobs so the aggregate spans more than one Job
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  # Let a run overlap the next tick, so two Jobs can stream at once
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: demo-app
+            component: log-ticker-job
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: ticker
+              image: busybox:latest
+              # Emits a line per second for 70s, so the run outlives one tick
+              # and the log view has continuous output to show per pod
+              command:
+                - sh
+                - -c
+                - "i=1; while [ $i -le 70 ]; do echo \"tick $i from $HOSTNAME at $(date -Iseconds)\"; i=$((i+1)); sleep 1; done"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi

--- a/src-tauri/src/commands/resources.rs
+++ b/src-tauri/src/commands/resources.rs
@@ -2386,6 +2386,9 @@ pub struct JobInfo {
     pub created_at: Option<String>,
     pub labels: HashMap<String, String>,
     pub status: String,
+    /// Controller that created this Job, e.g. the CronJob it belongs to.
+    pub owner_name: Option<String>,
+    pub owner_kind: Option<String>,
     /// Pod selector from spec.selector — resolves the Job's pods. Normally
     /// the controller-generated `batch.kubernetes.io/controller-uid` label.
     pub selector: HashMap<String, String>,
@@ -2449,6 +2452,13 @@ pub async fn list_jobs(
                 .map(label_selector_to_query)
                 .unwrap_or_default();
 
+            let (owner_name, owner_kind) = metadata
+                .owner_references
+                .as_ref()
+                .and_then(|refs| refs.first())
+                .map(|r| (Some(r.name.clone()), Some(r.kind.clone())))
+                .unwrap_or((None, None));
+
             JobInfo {
                 name: metadata.name.unwrap_or_default(),
                 namespace: metadata.namespace.unwrap_or_default(),
@@ -2464,6 +2474,8 @@ pub async fn list_jobs(
                 created_at: metadata.creation_timestamp.map(|t| t.0.to_string()),
                 labels: btree_to_hashmap(metadata.labels),
                 status: job_status.to_string(),
+                owner_name,
+                owner_kind,
                 selector: spec
                     .selector
                     .and_then(|s| s.match_labels)

--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -517,6 +517,34 @@ describe("useWorkloadLogs CronJob resolution", () => {
     expect(result.current.error).toBeNull();
   });
 
+  // Regression: the UID was read with a fallback to the pre-1.27 bare
+  // `controller-uid` key, but the query was always built with the prefixed
+  // one. On older clusters that queried a label no pod carries, so CronJob
+  // logs came up empty instead of falling back.
+  it("queries the legacy controller-uid key on pre-1.27 clusters", async () => {
+    const legacyJob = {
+      name: "nightly-28900",
+      namespace: "default",
+      owner_kind: "CronJob",
+      owner_name: "nightly",
+      selector: { "controller-uid": "uid-legacy" },
+      selector_query: "controller-uid=uid-legacy",
+    };
+    mockListJobs.mockResolvedValue([legacyJob]);
+    mockListPods.mockResolvedValue([pod("nightly-28900-xxxxx", "pod-a")]);
+
+    const { result } = renderHook(() =>
+      useWorkloadLogs("nightly", "default", "cronjob")
+    );
+
+    await waitFor(() => expect(result.current.pods).toHaveLength(1));
+
+    expect(mockListPods).toHaveBeenCalledWith({
+      namespace: "default",
+      label_selector: "controller-uid in (uid-legacy)",
+    });
+  });
+
   it("streams every pod of every owned Job, tagged with its own pod name", async () => {
     mockListJobs.mockResolvedValue([
       job("nightly-28900", "uid-a"),

--- a/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
+++ b/src/lib/hooks/__tests__/useWorkloadLogs.test.ts
@@ -460,16 +460,201 @@ describe("useWorkloadLogs pod resolution per workload kind", () => {
   });
 });
 
+describe("useWorkloadLogs CronJob resolution", () => {
+  const job = (name: string, uid: string, owner: string | null = "nightly") => ({
+    name,
+    namespace: "default",
+    owner_kind: owner === null ? null : "CronJob",
+    owner_name: owner,
+    selector: { "batch.kubernetes.io/controller-uid": uid },
+    selector_query: `batch.kubernetes.io/controller-uid=${uid}`,
+  });
+
+  const pod = (name: string, uid: string) => ({
+    name,
+    uid,
+    namespace: "default",
+    phase: "Running",
+    labels: {},
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListPods.mockResolvedValue([]);
+    mockWatchPods.mockResolvedValue(undefined);
+    mockStopWatch.mockResolvedValue(undefined);
+    mockListen.mockResolvedValue(jest.fn());
+  });
+
+  // A CronJob owns Jobs, not pods. Both Jobs' pods must end up in one view, so
+  // their per-Job controller-uid selectors collapse into one set-based query.
+  it("unions the pods of every Job the CronJob owns", async () => {
+    mockListJobs.mockResolvedValue([
+      job("nightly-28900", "uid-a"),
+      job("nightly-28901", "uid-b"),
+      // Belongs to a different CronJob - must not leak into the query
+      job("other-1", "uid-c", "weekly"),
+    ]);
+    mockListPods.mockResolvedValue([
+      pod("nightly-28900-xxxxx", "pod-a"),
+      pod("nightly-28901-yyyyy", "pod-b"),
+    ]);
+
+    const { result } = renderHook(() =>
+      useWorkloadLogs("nightly", "default", "cronjob")
+    );
+
+    await waitFor(() => expect(result.current.pods).toHaveLength(2));
+
+    expect(mockListPods).toHaveBeenCalledWith({
+      namespace: "default",
+      label_selector: "batch.kubernetes.io/controller-uid in (uid-a,uid-b)",
+    });
+    expect(result.current.pods.map((p) => p.name)).toEqual([
+      "nightly-28900-xxxxx",
+      "nightly-28901-yyyyy",
+    ]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("streams every pod of every owned Job, tagged with its own pod name", async () => {
+    mockListJobs.mockResolvedValue([
+      job("nightly-28900", "uid-a"),
+      job("nightly-28901", "uid-b"),
+    ]);
+    mockListPods.mockResolvedValue([
+      pod("nightly-28900-xxxxx", "pod-a"),
+      pod("nightly-28901-yyyyy", "pod-b"),
+    ]);
+    mockStreamPodLogs.mockResolvedValue(undefined);
+
+    const logListeners: Array<(event: { payload: unknown }) => void> = [];
+    mockListen.mockImplementation(
+      (eventName: string, handler: (e: { payload: unknown }) => void) => {
+        if (eventName.startsWith("log-stream-")) logListeners.push(handler);
+        return Promise.resolve(jest.fn());
+      }
+    );
+
+    const { result } = renderHook(() =>
+      useWorkloadLogs("nightly", "default", "cronjob")
+    );
+    await waitFor(() => expect(result.current.pods).toHaveLength(2));
+
+    await act(async () => {
+      await result.current.startStream();
+    });
+
+    await waitFor(() => expect(logListeners).toHaveLength(2));
+    expect(mockStreamPodLogs).toHaveBeenCalledTimes(2);
+    expect(mockStreamPodLogs).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ pod_name: "nightly-28900-xxxxx" })
+    );
+    expect(mockStreamPodLogs).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ pod_name: "nightly-28901-yyyyy" })
+    );
+
+    act(() => {
+      logListeners[0]({
+        payload: {
+          type: "Line",
+          data: {
+            message: "from job a",
+            timestamp: "2024-01-01T10:00:00Z",
+            container: "main",
+            pod: "nightly-28900-xxxxx",
+            namespace: "default",
+          },
+        },
+      });
+      logListeners[1]({
+        payload: {
+          type: "Line",
+          data: {
+            message: "from job b",
+            timestamp: "2024-01-01T10:00:01Z",
+            container: "main",
+            pod: "nightly-28901-yyyyy",
+            namespace: "default",
+          },
+        },
+      });
+    });
+
+    await waitFor(() => expect(result.current.logs).toHaveLength(2));
+    expect(result.current.logs.map((l) => [l.pod, l.message])).toEqual([
+      ["nightly-28900-xxxxx", "from job a"],
+      ["nightly-28901-yyyyy", "from job b"],
+    ]);
+  });
+
+  // Between runs the history limit can leave a CronJob with no Jobs at all.
+  // That is an empty view, not the "not found" error other kinds report.
+  it("shows an empty view without erroring when no Jobs are left", async () => {
+    mockListJobs.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useWorkloadLogs("nightly", "default", "cronjob")
+    );
+    await act(async () => {});
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.pods).toEqual([]);
+    expect(mockListPods).not.toHaveBeenCalled();
+    expect(mockWatchPods).not.toHaveBeenCalled();
+  });
+
+  // An owned Job whose pods are already garbage-collected still resolves; it
+  // just contributes no pods.
+  it("resolves without error when an owned Job has no pods left", async () => {
+    mockListJobs.mockResolvedValue([job("nightly-28900", "uid-a")]);
+    mockListPods.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useWorkloadLogs("nightly", "default", "cronjob")
+    );
+    await act(async () => {});
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.pods).toEqual([]);
+    expect(mockListPods).toHaveBeenCalledWith({
+      namespace: "default",
+      label_selector: "batch.kubernetes.io/controller-uid in (uid-a)",
+    });
+  });
+
+  it("ignores Jobs that are not owned by a CronJob", async () => {
+    mockListJobs.mockResolvedValue([
+      job("nightly-28900", "uid-a"),
+      job("standalone", "uid-z", null),
+    ]);
+    mockListPods.mockResolvedValue([pod("nightly-28900-xxxxx", "pod-a")]);
+
+    const { result } = renderHook(() =>
+      useWorkloadLogs("nightly", "default", "cronjob")
+    );
+    await waitFor(() => expect(result.current.pods).toHaveLength(1));
+
+    expect(mockListPods).toHaveBeenCalledWith({
+      namespace: "default",
+      label_selector: "batch.kubernetes.io/controller-uid in (uid-a)",
+    });
+  });
+});
+
 describe("supportsAggregatedLogs", () => {
-  it.each(["deployment", "statefulset", "daemonset", "replicaset", "job"])(
+  // CronJobs are included: they own Jobs, not pods, and the extra resolution
+  // hop through those Jobs is what cronjobSelectors() does.
+  it.each(["deployment", "statefulset", "daemonset", "replicaset", "job", "cronjob"])(
     "accepts %s",
     (kind) => {
       expect(supportsAggregatedLogs(kind)).toBe(true);
     }
   );
 
-  // CronJobs own Jobs, not pods, so they need a second resolution hop.
-  it.each(["cronjob", "pod", "service", "configmap"])("rejects %s", (kind) => {
+  it.each(["pod", "service", "configmap"])("rejects %s", (kind) => {
     expect(supportsAggregatedLogs(kind)).toBe(false);
   });
 });

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -51,8 +51,8 @@ export interface PodColorEntry {
 /**
  * Workload types whose pods can be aggregated into a single log view.
  *
- * CronJobs are absent on purpose: they own no pods directly, only Jobs, so
- * they would need a second resolution hop through their children.
+ * CronJobs own no pods directly, only Jobs, so they take a second resolution
+ * hop through their children (see WORKLOAD_LISTERS).
  */
 export const AGGREGATED_LOG_WORKLOADS = [
   "deployment",
@@ -60,6 +60,7 @@ export const AGGREGATED_LOG_WORKLOADS = [
   "daemonset",
   "replicaset",
   "job",
+  "cronjob",
 ] as const;
 
 export type WorkloadLogKind = (typeof AGGREGATED_LOG_WORKLOADS)[number];
@@ -75,11 +76,54 @@ export const WORKLOAD_KIND_LABELS: Record<WorkloadLogKind, string> = {
   daemonset: "DaemonSet",
   replicaset: "ReplicaSet",
   job: "Job",
+  cronjob: "CronJob",
 };
+
+/**
+ * Resolves a CronJob to the pod selector covering all of its Jobs.
+ *
+ * Each Job carries its own `controller-uid` selector, so the union is a
+ * set-based query over that one label. That keeps a CronJob a single-selector
+ * workload like every other kind, so pod listing and the watch stay untouched.
+ * The Job history is already bounded server-side by the CronJob's
+ * successful/failedJobsHistoryLimit, so every owned Job can be included.
+ *
+ * ponytail: the selector is resolved once per open, so a Job created by a later
+ * cron run is not picked up by the running view — reopening the logs (or
+ * refreshPods) resolves it. Following new Jobs live needs the pod watch to be
+ * restarted under a new selector; deferred until it is actually asked for.
+ */
+async function cronjobSelectors(
+  namespace: string,
+): Promise<Array<{ name: string; selector_query: string }>> {
+  const jobs = await listJobs({ namespace });
+  const byCronjob = new Map<string, string[]>();
+
+  for (const job of jobs) {
+    if (job.owner_kind !== "CronJob" || !job.owner_name) continue;
+    // Only the controller-uid form collapses into one set-based query; a Job
+    // with a hand-written selector is skipped rather than silently widening
+    // the query to unrelated pods.
+    const uid = job.selector["batch.kubernetes.io/controller-uid"] ?? job.selector["controller-uid"];
+    if (!uid) continue;
+    const uids = byCronjob.get(job.owner_name);
+    if (uids) {
+      uids.push(uid);
+    } else {
+      byCronjob.set(job.owner_name, [uid]);
+    }
+  }
+
+  return [...byCronjob].map(([name, uids]) => ({
+    name,
+    selector_query: `batch.kubernetes.io/controller-uid in (${uids.join(",")})`,
+  }));
+}
 
 /**
  * Every supported workload exposes its complete Kubernetes label selector as
  * `selector_query`, so resolving its pods only differs by which lister to call.
+ * CronJobs are the exception: they resolve through their Jobs first.
  */
 const WORKLOAD_LISTERS: Record<
   WorkloadLogKind,
@@ -90,6 +134,7 @@ const WORKLOAD_LISTERS: Record<
   daemonset: (namespace) => listDaemonsets({ namespace }),
   replicaset: (namespace) => listReplicasets({ namespace }),
   job: (namespace) => listJobs({ namespace }),
+  cronjob: cronjobSelectors,
 };
 
 export interface UseWorkloadLogsReturn {
@@ -233,10 +278,18 @@ export function useWorkloadLogs(
       const workloads = await WORKLOAD_LISTERS[kind](namespace);
       const workload = workloads.find((w) => w.name === workloadName);
       if (!workload) {
+        // A CronJob resolves through its Jobs, so "no match" here just means it
+        // has no Jobs left (between runs, or history already collected) — an
+        // empty log view, not a missing workload.
         if (mountedRef.current) {
-          setError(
-            toKubeliError(`${WORKLOAD_KIND_LABELS[kind]} ${workloadName} not found`)
-          );
+          if (kind === "cronjob") {
+            selectorQueryRef.current = "";
+            setPods([]);
+          } else {
+            setError(
+              toKubeliError(`${WORKLOAD_KIND_LABELS[kind]} ${workloadName} not found`)
+            );
+          }
         }
         return [];
       }

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -80,6 +80,13 @@ export const WORKLOAD_KIND_LABELS: Record<WorkloadLogKind, string> = {
 };
 
 /**
+ * Label carrying a Job's controller UID, newest spelling first. Kubernetes
+ * moved it to the `batch.kubernetes.io` prefix in 1.27; older clusters only
+ * set the bare key.
+ */
+const CONTROLLER_UID_KEYS = ["batch.kubernetes.io/controller-uid", "controller-uid"] as const;
+
+/**
  * Resolves a CronJob to the pod selector covering all of its Jobs.
  *
  * Each Job carries its own `controller-uid` selector, so the union is a
@@ -97,26 +104,28 @@ async function cronjobSelectors(
   namespace: string,
 ): Promise<Array<{ name: string; selector_query: string }>> {
   const jobs = await listJobs({ namespace });
-  const byCronjob = new Map<string, string[]>();
+  const byCronjob = new Map<string, { key: string; uids: string[] }>();
 
   for (const job of jobs) {
     if (job.owner_kind !== "CronJob" || !job.owner_name) continue;
     // Only the controller-uid form collapses into one set-based query; a Job
     // with a hand-written selector is skipped rather than silently widening
-    // the query to unrelated pods.
-    const uid = job.selector["batch.kubernetes.io/controller-uid"] ?? job.selector["controller-uid"];
-    if (!uid) continue;
-    const uids = byCronjob.get(job.owner_name);
-    if (uids) {
-      uids.push(uid);
+    // the query to unrelated pods. Kubernetes moved this label to the
+    // batch.kubernetes.io prefix in 1.27, so the query has to use whichever
+    // key the cluster actually set — querying the other one matches nothing.
+    const key = CONTROLLER_UID_KEYS.find((k) => job.selector[k]);
+    if (!key) continue;
+    const group = byCronjob.get(job.owner_name);
+    if (group) {
+      group.uids.push(job.selector[key]);
     } else {
-      byCronjob.set(job.owner_name, [uid]);
+      byCronjob.set(job.owner_name, { key, uids: [job.selector[key]] });
     }
   }
 
-  return [...byCronjob].map(([name, uids]) => ({
+  return [...byCronjob].map(([name, { key, uids }]) => ({
     name,
-    selector_query: `batch.kubernetes.io/controller-uid in (${uids.join(",")})`,
+    selector_query: `${key} in (${uids.join(",")})`,
   }));
 }
 

--- a/src/lib/hooks/useWorkloadLogs.ts
+++ b/src/lib/hooks/useWorkloadLogs.ts
@@ -95,10 +95,12 @@ const CONTROLLER_UID_KEYS = ["batch.kubernetes.io/controller-uid", "controller-u
  * The Job history is already bounded server-side by the CronJob's
  * successful/failedJobsHistoryLimit, so every owned Job can be included.
  *
- * ponytail: the selector is resolved once per open, so a Job created by a later
- * cron run is not picked up by the running view — reopening the logs (or
- * refreshPods) resolves it. Following new Jobs live needs the pod watch to be
- * restarted under a new selector; deferred until it is actually asked for.
+ * ponytail: a Job created by a later cron run is not followed live. Re-resolving
+ * (refreshPods, or restarting the stream) picks the new Job up for the pod list
+ * and the streams, but the pod watch keeps the selector it was started with —
+ * the hook hands it over once and never restarts it. Reopening the view is what
+ * actually resyncs everything. Following new Jobs live needs the watch to be
+ * restarted under the new selector; deferred until it is actually asked for.
  */
 async function cronjobSelectors(
   namespace: string,

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -667,6 +667,9 @@ export interface JobInfo {
   created_at: string | null;
   labels: Record<string, string>;
   status: string;
+  /** Controller that created this Job, e.g. the CronJob it belongs to */
+  owner_name: string | null;
+  owner_kind: string | null;
   /**
    * Pod selector from spec.selector — resolves the Job's pods. Normally the
    * controller-generated `batch.kubernetes.io/controller-uid` label.


### PR DESCRIPTION
Stacked on #424 (`fix/423-aggregated-stream-drops`) — please merge that one first. The diff shown against `main` will include #424's commits until it lands.

Closes #421

## Problem

PR #409 deliberately excluded CronJobs from aggregated workload logs. A CronJob owns no pods directly, only Jobs, which in turn own Pods, so aggregation needs a second resolution hop.

## Approach

Each Job carries its own `controller-uid` pod selector, so a CronJob's Jobs collapse into a single set-based query:

```
batch.kubernetes.io/controller-uid in (uid-a,uid-b)
```

That keeps a CronJob a **single-selector workload** like every other kind, so pod listing, the pod watch, and the streaming internals from #424 are untouched. No new watch machinery, no widening of the `WORKLOAD_LISTERS` return shape.

Job history is already bounded server-side by `successfulJobsHistoryLimit` / `failedJobsHistoryLimit`, so every owned Job can simply be included.

## Changes

**Backend** (the smaller of the two options — no new command):
- `src-tauri/src/commands/resources.rs` — `JobInfo` gains `owner_name` / `owner_kind`, populated in `list_jobs` by copying the existing `ReplicaSetInfo` owner-reference pattern. This is the only backend change; no `list_jobs_for_cronjob` command was needed.

**Frontend**:
- `src/lib/types/kubernetes.ts` — matching `owner_name` / `owner_kind` on `JobInfo`.
- `src/lib/hooks/useWorkloadLogs.ts` — `"cronjob"` added to `AGGREGATED_LOG_WORKLOADS` (doc comment updated, it previously explained the exclusion), a `WORKLOAD_KIND_LABELS` entry, and a `cronjobSelectors()` resolver that groups Jobs by owning CronJob and unions their controller-uids. A CronJob with no Jobs left now resolves to an empty view rather than the "not found" error the other kinds report — between runs that is a normal state, not an error.

**UI**: no component changes needed. `CronJobsView` already uses `resourceType: "cronjob"`, so the central `supportsAggregatedLogs` guard lights up the Logs tab in `ResourceDetail` (tab trigger + tab content) and the context-menu entry in `_createResourceView` automatically.

## Known limitation

The selector is resolved once per open, so a Job created by a **later** cron run does not appear in an already running view; reopening the logs (or `refreshPods`) picks it up. Following new Jobs live requires restarting the pod watch under a new selector, which would fight the per-stream bookkeeping #424 just introduced. Marked with a `// ponytail:` comment and deferred until it is actually asked for.

## Testing

`src/lib/hooks/__tests__/useWorkloadLogs.test.ts` — 5 new cases:
- CronJob with 2 Jobs x 1 pod: both pods resolve into one set-based query, both stream, and lines from both arrive tagged with their own pod name
- a Job owned by a *different* CronJob does not leak into the query
- no Jobs left: empty view, no error, no pod query, no watch
- an owned Job whose pods are already collected: resolves without error
- Jobs with no CronJob owner are ignored

The existing `supportsAggregatedLogs` case asserting `cronjob` is **false** was flipped to true and its explanatory comment updated.

All async assertions use `waitFor` rather than a fixed number of ticks.

### Verification

- `make check` — clean
- `make lint` — clean (4 pre-existing `LogViewer.tsx` warnings only)
- `npm run test` — **run 5x, all green**: 874 tests / 78 suites each run
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 329 passed
- `cargo fmt --check` — clean

### Manual testing

`.dev/k8s-samples/21-cronjob-logs-test.yaml` adds `demo-log-ticker`: schedule `* * * * *`, `successfulJobsHistoryLimit: 3`, `concurrencyPolicy: Allow`, each run emitting one line/second for 70s so runs overlap a tick and multiple Jobs/pods stream at once. The existing `demo-cleanup` (`10-workloads.yaml`) runs every 30 minutes, too slow to observe the two-hop aggregation; that file is intentionally left unchanged.

```
kubectl apply -f .dev/k8s-samples/21-cronjob-logs-test.yaml
kubectl delete -f .dev/k8s-samples/21-cronjob-logs-test.yaml
```