### PR TITLE
fix(linux): ship an AppImage that works on Mesa 25+ distros

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,6 +253,10 @@ jobs:
           set -euo pipefail
           bundle_dir=src-tauri/target/release/bundle/appimage
           shopt -s nullglob
+          # *.AppImage only. Bundling also writes the updater package
+          # <name>.AppImage.tar.gz, which this glob does not match and which
+          # is deliberately not published: latest.json points at the 22.04
+          # build, so an updater package for this one would never be fetched.
           images=("$bundle_dir"/*.AppImage)
           if [ ${#images[@]} -eq 0 ]; then
             echo "No AppImage produced in $bundle_dir" >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,19 +118,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Every entry sets appimage_suffix, including the ones that do not
+        # build an AppImage. The steps below branch on it, and GitHub only
+        # compares operands directly when their types match — an undefined
+        # property would be Null and get coerced to a number instead.
         include:
           - platform: macos-15
             label: macOS-aarch64
             args: '--target aarch64-apple-darwin'
             rust_target: aarch64-apple-darwin
+            appimage_suffix: ''
           - platform: macos-15
             label: macOS-x86_64
             args: '--target x86_64-apple-darwin'
             rust_target: x86_64-apple-darwin
+            appimage_suffix: ''
           - platform: windows-latest
             label: Windows-x64
             args: ''
             rust_target: ''
+            appimage_suffix: ''
           # Two Linux builds on purpose. The AppImage bundles the build host's
           # WebKitGTK, so one build cannot serve every target:
           #   22.04 -> WebKit 2.50, glibc 2.35 — works back to Ubuntu 22.04 /
@@ -144,6 +151,7 @@ jobs:
             label: Linux-x64
             args: ''
             rust_target: ''
+            appimage_suffix: ''
           - platform: ubuntu-24.04
             label: Linux-x64-modern
             # Only the AppImage: deb/rpm link against the system WebKit, so the
@@ -194,7 +202,13 @@ jobs:
           echo "$APPLE_API_KEY_CONTENT" > ~/private_keys/AuthKey_"$APPLE_API_KEY".p8
           echo "path=$HOME/private_keys/AuthKey_${APPLE_API_KEY}.p8" >> $GITHUB_OUTPUT
 
+      # Two build steps, split by an `if:` rather than by a conditional input.
+      # The modern build must NOT receive releaseId: tauri-action would upload
+      # its AppImage under the same name as the 22.04 one and overwrite it on
+      # the release. A `x && '' || y` expression cannot express that — '' is
+      # falsy, so it falls through to y and sets releaseId anyway.
       - name: Build Tauri app
+        if: matrix.appimage_suffix != '-modern'
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -209,17 +223,26 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          # The modern Linux build uploads itself in the next step instead: its
-          # AppImage has to be renamed first, or it would overwrite the 22.04
-          # one on the release (Tauri has no filename option for AppImage).
-          releaseId: ${{ matrix.appimage_suffix == '-modern' && '' || needs.create-release.outputs.release_id }}
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           tagName: ${{ needs.create-release.outputs.tag }}
           releaseDraft: true
           retryAttempts: 3
           args: ${{ matrix.args }}
 
+      - name: Build modern Linux AppImage
+        if: matrix.appimage_suffix == '-modern'
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          # No releaseId and no tagName: both make tauri-action upload. This
+          # build is renamed and uploaded by the next step instead.
+          args: ${{ matrix.args }}
+
       # Renames to Kubeli_<version>_amd64-modern.AppImage and uploads it (plus
-      # its updater signature) by hand, since tauri-action was told not to.
+      # its updater signature), which the build step above deliberately skipped.
       - name: Upload modern Linux AppImage
         if: matrix.appimage_suffix == '-modern'
         env:
@@ -237,16 +260,18 @@ jobs:
           fi
           for image in "${images[@]}"; do
             renamed="${image%.AppImage}${SUFFIX}.AppImage"
-            mv "$image" "$renamed"
-            gh release upload "$RELEASE_TAG" "$renamed" --clobber
-            echo "Uploaded $(basename "$renamed")"
-            # The .sig belongs to the file the updater would fetch. Ship it so
-            # the artifact stays verifiable even though latest.json points at
-            # the 22.04 build.
-            if [ -f "$image.sig" ]; then
-              mv "$image.sig" "$renamed.sig"
-              gh release upload "$RELEASE_TAG" "$renamed.sig" --clobber
+            # createUpdaterArtifacts is on and signing covers AppImage, so a
+            # missing .sig means signing broke, not that it was skipped.
+            # Publishing the binary without it would ship an unverifiable
+            # artifact, so stop instead.
+            if [ ! -f "$image.sig" ]; then
+              echo "No updater signature next to $(basename "$image")" >&2
+              exit 1
             fi
+            mv "$image" "$renamed"
+            mv "$image.sig" "$renamed.sig"
+            gh release upload "$RELEASE_TAG" "$renamed" "$renamed.sig" --clobber
+            echo "Uploaded $(basename "$renamed") and its signature"
           done
 
   sign-windows:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,10 +131,27 @@ jobs:
             label: Windows-x64
             args: ''
             rust_target: ''
+          # Two Linux builds on purpose. The AppImage bundles the build host's
+          # WebKitGTK, so one build cannot serve every target:
+          #   22.04 -> WebKit 2.50, glibc 2.35 — works back to Ubuntu 22.04 /
+          #            Debian 12, but its WebKit aborts with EGL_BAD_PARAMETER
+          #            against Mesa >= 25 (Fedora 43, Arch). See #429.
+          #   24.04 -> WebKit 2.52, glibc 2.39 — fixes that crash, but will not
+          #            start on distros older than Ubuntu 24.04 / Debian 13.
+          # 22.04 stays the updater target, so existing installs keep the
+          # widest-compatibility build unless the user picks the other one.
           - platform: ubuntu-22.04
             label: Linux-x64
             args: ''
             rust_target: ''
+          - platform: ubuntu-24.04
+            label: Linux-x64-modern
+            # Only the AppImage: deb/rpm link against the system WebKit, so the
+            # 22.04 job's packages already work on new distros. Building them
+            # twice would collide on identical filenames at upload.
+            args: '--bundles appimage'
+            rust_target: ''
+            appimage_suffix: '-modern'
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -156,10 +173,12 @@ jobs:
           workspaces: src-tauri
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: startsWith(matrix.platform, 'ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          echo "Bundling WebKitGTK: $(dpkg-query -W -f='${Version}' libwebkit2gtk-4.1-0)"
+          echo "Against glibc: $(dpkg-query -W -f='${Version}' libc6)"
 
       - name: Install dependencies
         run: npm ci
@@ -190,11 +209,45 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          releaseId: ${{ needs.create-release.outputs.release_id }}
+          # The modern Linux build uploads itself in the next step instead: its
+          # AppImage has to be renamed first, or it would overwrite the 22.04
+          # one on the release (Tauri has no filename option for AppImage).
+          releaseId: ${{ matrix.appimage_suffix == '-modern' && '' || needs.create-release.outputs.release_id }}
           tagName: ${{ needs.create-release.outputs.tag }}
           releaseDraft: true
           retryAttempts: 3
           args: ${{ matrix.args }}
+
+      # Renames to Kubeli_<version>_amd64-modern.AppImage and uploads it (plus
+      # its updater signature) by hand, since tauri-action was told not to.
+      - name: Upload modern Linux AppImage
+        if: matrix.appimage_suffix == '-modern'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.create-release.outputs.tag }}
+          SUFFIX: ${{ matrix.appimage_suffix }}
+        run: |
+          set -euo pipefail
+          bundle_dir=src-tauri/target/release/bundle/appimage
+          shopt -s nullglob
+          images=("$bundle_dir"/*.AppImage)
+          if [ ${#images[@]} -eq 0 ]; then
+            echo "No AppImage produced in $bundle_dir" >&2
+            exit 1
+          fi
+          for image in "${images[@]}"; do
+            renamed="${image%.AppImage}${SUFFIX}.AppImage"
+            mv "$image" "$renamed"
+            gh release upload "$RELEASE_TAG" "$renamed" --clobber
+            echo "Uploaded $(basename "$renamed")"
+            # The .sig belongs to the file the updater would fetch. Ship it so
+            # the artifact stays verifiable even though latest.json points at
+            # the 22.04 build.
+            if [ -f "$image.sig" ]; then
+              mv "$image.sig" "$renamed.sig"
+              gh release upload "$RELEASE_TAG" "$renamed.sig" --clobber
+            fi
+          done
 
   sign-windows:
     name: Sign Windows Installers
@@ -342,20 +395,30 @@ jobs:
             fi
           done
 
-          # Linux
-          for f in artifacts/*.AppImage.sig; do
-            if [ -f "$f" ]; then
-              LINUX_SIG=$(cat "$f")
-              echo "Found Linux signature: $f"
-              break
-            fi
-          done
+          # Linux — must be the 22.04 build, never the "-modern" one: it has the
+          # lower glibc floor, so it is the only AppImage safe to push to every
+          # existing install through the updater's single linux-x86_64 slot.
+          # Selection rule lives in scripts/select-linux-artifacts.js so it is
+          # covered by tests instead of only by a glob here.
+          LINUX_SIG_FILE=$(node -e '
+            const { selectUpdaterSignature } = require("./scripts/select-linux-artifacts");
+            const fs = require("fs");
+            process.stdout.write(selectUpdaterSignature(fs.readdirSync("artifacts")) ?? "");
+          ')
+          if [ -n "$LINUX_SIG_FILE" ]; then
+            LINUX_SIG=$(cat "artifacts/$LINUX_SIG_FILE")
+            echo "Found Linux signature: $LINUX_SIG_FILE"
+          fi
 
           # Find artifact filenames for FTP URLs
           MAC_TAR=$(ls artifacts/*.app.tar.gz 2>/dev/null | head -1 | xargs basename 2>/dev/null || echo "")
           WIN_EXE=$(ls artifacts/*x64-setup.exe 2>/dev/null | head -1 | xargs basename 2>/dev/null || echo "")
           WIN_EXE=${WIN_EXE:-$(ls artifacts/*x64_setup.exe 2>/dev/null | head -1 | xargs basename 2>/dev/null || echo "")}
-          LINUX_APPIMAGE=$(ls artifacts/*.AppImage 2>/dev/null | grep -v '.sig' | head -1 | xargs basename 2>/dev/null || echo "")
+          LINUX_APPIMAGE=$(node -e '
+            const { selectUpdaterAppImage } = require("./scripts/select-linux-artifacts");
+            const fs = require("fs");
+            process.stdout.write(selectUpdaterAppImage(fs.readdirSync("artifacts")) ?? "");
+          ')
 
           # Build FTP latest.json
           PLATFORMS=""
@@ -491,16 +554,21 @@ jobs:
               "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/Kubeli_latest_x64-setup.exe" --ftp-create-dirs
           fi
 
-          # Linux AppImage
-          APPIMAGE=$(ls artifacts/*.AppImage 2>/dev/null | grep -v '.sig' | head -1)
-          if [ -n "$APPIMAGE" ]; then
+          # Linux AppImages — both variants, each with its own "latest" alias.
+          # Kubeli_latest_amd64.AppImage stays the 22.04 build so existing
+          # download links keep serving the widest-compatibility one.
+          for APPIMAGE in $(ls artifacts/*.AppImage 2>/dev/null | grep -v '.sig'); do
             BASENAME=$(basename "$APPIMAGE")
-            echo "Uploading $BASENAME (versioned + latest)..."
+            ALIAS=$(BASENAME="$BASENAME" node -e '
+              const { landingAliasFor } = require("./scripts/select-linux-artifacts");
+              process.stdout.write(landingAliasFor(process.env.BASENAME));
+            ')
+            echo "Uploading $BASENAME (versioned + $ALIAS)..."
             curl -s -T "$APPIMAGE" --user "$FTP_USER:$FTP_PASSWORD" \
               "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/$BASENAME" --ftp-create-dirs
             curl -s -T "$APPIMAGE" --user "$FTP_USER:$FTP_PASSWORD" \
-              "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/Kubeli_latest_amd64.AppImage" --ftp-create-dirs
-          fi
+              "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/$ALIAS" --ftp-create-dirs
+          done
 
           echo "Landing page deployment complete"
 

--- a/scripts/__tests__/select-linux-artifacts.test.js
+++ b/scripts/__tests__/select-linux-artifacts.test.js
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global describe, expect, it */
+const {
+  landingAliasFor,
+  selectUpdaterAppImage,
+  selectUpdaterSignature,
+} = require("../select-linux-artifacts");
+
+const COMPAT = "Kubeli_0.4.0_amd64.AppImage";
+const MODERN = "Kubeli_0.4.0_amd64-modern.AppImage";
+
+// A release directory as the publish workflow sees it: both AppImages, both
+// signatures, plus the packages that must never be mistaken for one.
+const RELEASE = [
+  MODERN,
+  `${MODERN}.sig`,
+  COMPAT,
+  `${COMPAT}.sig`,
+  "Kubeli_0.4.0_amd64.deb",
+  "Kubeli-0.4.0-1.x86_64.rpm",
+];
+
+describe("updater artifact selection", () => {
+  // The bug this guards: "-modern" sorts before the compatibility build, so
+  // any first-match glob hands the updater the glibc 2.39 binary and every
+  // Ubuntu 22.04 install fails to start after updating.
+  it("never picks the modern build, even though it sorts first", () => {
+    const appImagesInGlobOrder = RELEASE.filter(
+      (name) => name.endsWith(".AppImage"),
+    ).sort();
+    expect(appImagesInGlobOrder[0]).toBe(MODERN);
+
+    expect(selectUpdaterAppImage(RELEASE)).toBe(COMPAT);
+  });
+
+  it("pairs the signature with the AppImage it belongs to", () => {
+    expect(selectUpdaterSignature(RELEASE)).toBe(`${COMPAT}.sig`);
+  });
+
+  it("still resolves when the modern build failed to produce artifacts", () => {
+    const onlyCompat = [COMPAT, `${COMPAT}.sig`];
+    expect(selectUpdaterAppImage(onlyCompat)).toBe(COMPAT);
+    expect(selectUpdaterSignature(onlyCompat)).toBe(`${COMPAT}.sig`);
+  });
+
+  // Publishing a latest.json whose linux slot points at the modern build is
+  // worse than publishing none, so an unusable set must resolve to null.
+  it("reports nothing when only the modern build exists", () => {
+    expect(selectUpdaterAppImage([MODERN, `${MODERN}.sig`])).toBeNull();
+    expect(selectUpdaterSignature([MODERN, `${MODERN}.sig`])).toBeNull();
+  });
+
+  it("does not mistake a deb or rpm for an AppImage", () => {
+    expect(
+      selectUpdaterAppImage(["Kubeli_0.4.0_amd64.deb", "Kubeli-0.4.0-1.x86_64.rpm"]),
+    ).toBeNull();
+  });
+
+  it("omits the signature when it is missing rather than guessing", () => {
+    expect(selectUpdaterSignature([COMPAT])).toBeNull();
+  });
+});
+
+describe("landing page aliases", () => {
+  it("keeps the existing download link on the compatibility build", () => {
+    expect(landingAliasFor(COMPAT)).toBe("Kubeli_latest_amd64.AppImage");
+  });
+
+  it("gives the modern build an alias of its own", () => {
+    expect(landingAliasFor(MODERN)).toBe("Kubeli_latest_amd64-modern.AppImage");
+  });
+
+  it("maps the two variants to distinct aliases", () => {
+    expect(landingAliasFor(COMPAT)).not.toBe(landingAliasFor(MODERN));
+  });
+});

--- a/scripts/select-linux-artifacts.js
+++ b/scripts/select-linux-artifacts.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Picks which AppImage the updater and the landing page should point at.
+ *
+ * Releases ship two Linux AppImages (see .github/workflows/publish.yml):
+ * the default one built on Ubuntu 22.04, and a "-modern" one built on 24.04
+ * for distros whose Mesa is too new for the older bundled WebKitGTK (#429).
+ *
+ * The updater has a single linux-x86_64 slot, so exactly one of them may go
+ * in it. It has to be the 22.04 build: it has the lower glibc floor, and the
+ * updater pushes it to every existing install regardless of distro. Picking
+ * by plain glob would take "-modern" instead, because it sorts first.
+ */
+
+const MODERN_SUFFIX = "-modern.AppImage";
+
+/** The AppImage safe to hand to every install, or null if it is missing. */
+function selectUpdaterAppImage(fileNames) {
+  return fileNames.filter(isCompatibilityAppImage).sort()[0] ?? null;
+}
+
+/** Its detached updater signature, matched by name so the pair can't drift. */
+function selectUpdaterSignature(fileNames) {
+  const appImage = selectUpdaterAppImage(fileNames);
+  if (!appImage) return null;
+  const signature = `${appImage}.sig`;
+  return fileNames.includes(signature) ? signature : null;
+}
+
+/** Stable download alias per variant, e.g. Kubeli_latest_amd64.AppImage. */
+function landingAliasFor(fileName) {
+  return fileName.endsWith(MODERN_SUFFIX)
+    ? "Kubeli_latest_amd64-modern.AppImage"
+    : "Kubeli_latest_amd64.AppImage";
+}
+
+function isCompatibilityAppImage(fileName) {
+  return (
+    fileName.endsWith(".AppImage") && !fileName.endsWith(MODERN_SUFFIX)
+  );
+}
+
+module.exports = {
+  MODERN_SUFFIX,
+  landingAliasFor,
+  selectUpdaterAppImage,
+  selectUpdaterSignature,
+};

--- a/src-tauri/src/app/bootstrap.rs
+++ b/src-tauri/src/app/bootstrap.rs
@@ -34,6 +34,14 @@ pub fn initialize() -> Args {
 /// Both variables are only set when the user hasn't already provided them,
 /// so users with working GPU setups can opt back in via the environment.
 ///
+/// What this does **not** cover: an AppImage carries the WebKitGTK of the
+/// machine that built it. If that copy is older than the host's Mesa, it
+/// aborts during EGL setup before rendering is ever configured, so neither
+/// variable helps — the abort happens no matter what they are set to. That
+/// is a packaging problem, fixed by the second AppImage built on a newer
+/// base (see `.github/workflows/publish.yml`) or by the .deb/.rpm, which
+/// link against the system WebKitGTK. See #429.
+///
 /// See: https://github.com/nicbarker/clay/issues/224
 ///      https://bugs.webkit.org/show_bug.cgi?id=297921
 ///      https://bugs.webkit.org/show_bug.cgi?id=302796

--- a/web/src/components/FAQSection.tsx
+++ b/web/src/components/FAQSection.tsx
@@ -24,7 +24,11 @@ const faqs = [
   },
   {
     question: "Which platforms are supported?",
-    answer: "Kubeli runs natively on macOS (10.15+), Windows (10/11), and Linux (x64 AppImage). All platforms support auto-updates, so you'll always have the latest features and security fixes."
+    answer: "Kubeli runs natively on macOS (10.15+), Windows (10/11), and Linux (x64 AppImage, .deb and .rpm). All platforms support auto-updates, so you'll always have the latest features and security fixes."
+  },
+  {
+    question: "The Linux AppImage shows a blank window or exits with EGL_BAD_PARAMETER. What now?",
+    answer: "Use the \"AppImage (new distros)\" download, or install the .deb/.rpm. An AppImage carries its own copy of WebKitGTK, and the standard build's copy is too old for the graphics drivers on Fedora 43, Arch and other distros running Mesa 25 or newer. The \"new distros\" build bundles a current WebKitGTK and needs glibc 2.39+ (Ubuntu 24.04, Debian 13, Fedora 39 and up). The .deb and .rpm sidestep the problem entirely because they use the WebKitGTK your distribution already ships."
   },
   {
     question: "Is my cluster data secure?",

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -101,6 +101,10 @@ const downloadGroups = [
     viewBox: "0 0 16 16",
     items: [
       { label: "AppImage", ext: ".AppImage", href: `${releaseBase}/Kubeli_${version}_amd64.AppImage` },
+      // Ships a newer bundled WebKitGTK. Needed on Fedora 43+, Arch and other
+      // distros on Mesa 25+, where the standard AppImage aborts with
+      // EGL_BAD_PARAMETER. Requires glibc 2.39+, so it is not the default.
+      { label: "AppImage (new distros)", ext: ".AppImage", href: `${releaseBase}/Kubeli_${version}_amd64-modern.AppImage` },
       { label: "Debian", ext: ".deb", href: `${releaseBase}/Kubeli_${version}_amd64.deb` },
       { label: "Red Hat", ext: ".rpm", href: `${releaseBase}/Kubeli-${version}-1.x86_64.rpm` },
     ],


### PR DESCRIPTION
Closes #429

## What breaks today

An AppImage carries the WebKitGTK of the machine that built it. Releases build on Ubuntu 22.04, which caps out at WebKit **2.50.4** — and that version aborts during EGL setup against Mesa 25+:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

The reporter isolated this cleanly: same GPU, same drivers, same env vars, only the WebKit version swapped → a source build against system WebKit 2.52.5 works. I confirmed the mechanism by extracting the shipped 0.3.84 AppImage:

- **bundled:** `libwebkit2gtk-4.1.so.0`, `libjavascriptcoregtk-4.1.so.0`, `WebKitWebProcess`, `WebKitNetworkProcess`
- **not bundled:** `libEGL`, `libGL`, `libgbm`, `libdrm` — correctly taken from the host

So the AppImage pairs **jammy's WebKit with the host's Mesa**. On Fedora 43 that's 2.50 against 25.3.6, and it aborts.

### Why the existing workaround can't fix it

`bootstrap.rs` sets `WEBKIT_DISABLE_COMPOSITING_MODE` and `WEBKIT_DISABLE_DMABUF_RENDERER`, and the reporter noted they make no difference. That's expected: the abort happens while WebKit initializes EGL, before either variable is consulted. This closed #201/#233 for the *driver-toggle* failure modes, but this is a packaging problem. I corrected the doc comment so this isn't re-litigated.

## The trade-off

Just moving to 24.04 — the issue's first suggestion — swaps one broken group for another:

| Base | WebKit | glibc | Consequence |
|---|---|---|---|
| 22.04 | 2.50.4 | 2.35 | works back to Debian 12; **crashes on Mesa 25+** |
| 24.04 | 2.52.3 | 2.39 | fixes the crash; **won't start on Ubuntu 22.04 / Debian 12** |

Jammy can't be upgraded past 2.50.4, so there's no single build that satisfies both. This ships **both**.

## Changes

- **Second Linux job** on `ubuntu-24.04`, AppImage only (`--bundles appimage`) — deb/rpm link against system WebKit, so the 22.04 job's packages already work everywhere; building them twice would collide on identical filenames.
- **Renamed to `_amd64-modern.AppImage`** and uploaded explicitly, since Tauri has no filename option for AppImage.
- **Updater stays on the 22.04 build.** It has one `linux-x86_64` slot and pushes to every existing install, so it must carry the lower glibc floor.
- **Landing page + FAQ** now name the variant to pick, and the FAQ finally mentions .deb/.rpm at all.

## The subtle part

`-modern` sorts **before** `Kubeli_<version>_amd64.AppImage`. The old `ls ... | head -1` would have silently started shipping the glibc-2.39 binary to every Linux user through the updater — turning this fix into a worse regression. Selection now lives in a tested helper.

## Tests

`scripts/__tests__/select-linux-artifacts.test.js` — 9 cases covering the failure mode, not just the happy path: modern-sorts-first, signature pairing, only-modern-present (must resolve to null rather than publish a bad `latest.json`), and modern-build-failed fallback.

Verified the tests catch the real bug: reintroducing the naive glob fails 3 of them; restoring the fix passes all 9.

## Verification

911 tests pass, `tsc` clean, ESLint clean, `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean, Astro build renders both download links.

Not verifiable locally: the `ubuntu-24.04` job itself, since bundling only runs on a Linux runner. `--bundles appimage` is confirmed valid from the Tauri source (`PackageType::from_short_name`) — the macOS CLI rejects it only because the value list is compile-time gated per host OS. Worth watching on the first release run.

## Deliberately not changed

The linuxdeploy GTK plugin forces `GDK_BACKEND=x11`, so the AppImage runs through XWayland — a different EGL path than the reporter's working native build. Tempting, but it's upstream behaviour guarding other Wayland crashes (tauri#8541), and the reporter already proved WebKit is the cause. Changing it would risk every Wayland user to chase an unverified hypothesis.