### PR TITLE
fix(web): offer the modern AppImage on the changelog page too

### DIFF
--- a/web/src/pages/changelog.astro
+++ b/web/src/pages/changelog.astro
@@ -43,6 +43,7 @@ const latestInstallers = [
   { label: "Windows (.exe)", icon: osIcons.windows, href: `${releaseBase}/Kubeli_${version}_x64-setup.exe` },
   { label: "Windows (.msi)", icon: osIcons.windows, href: `${releaseBase}/Kubeli_${version}_x64_en-US.msi` },
   { label: "Linux (.AppImage)", icon: osIcons.linux, href: `${releaseBase}/Kubeli_${version}_amd64.AppImage` },
+  { label: "Linux (.AppImage, new distros)", icon: osIcons.linux, href: `${releaseBase}/Kubeli_${version}_amd64-modern.AppImage` },
   { label: "Linux (.deb)", icon: osIcons.linux, href: `${releaseBase}/Kubeli_${version}_amd64.deb` },
   { label: "Linux (.rpm)", icon: osIcons.linux, href: `${releaseBase}/Kubeli-${version}-1.x86_64.rpm` },
 ];


### PR DESCRIPTION
Follow-up to #430.

The changelog page has its own download menu, separate from the landing page's. It listed only the compatibility AppImage, so someone arriving there had no way to find the build for Mesa 25+ distros — the one #430 added to fix the Fedora 43 crash.

The menu's own comment says "Every installer for the newest release", so the omission was a gap, not a deliberate choice.

## Scope

Only the changelog **menu** changed. The single-button downloads on the landing hero and the four `compare/` pages still point at the compatibility AppImage — those pick one file for the common case, and that is the right default. Adding a second button there would ask visitors to make a decision they have no context for.

## Verified

Built the site and checked every rendered link in the menu against the actual v0.3.85 release assets — all 8 resolve to files that exist:

```
Kubeli_0.3.85_amd64.AppImage          OK
Kubeli_0.3.85_amd64-modern.AppImage   OK
Kubeli_0.3.85_amd64.deb               OK
Kubeli-0.3.85-1.x86_64.rpm            OK
+ the 4 macOS/Windows entries         OK
```

`tsc` clean, Astro build clean.

Note: `-modern` only exists from v0.3.85 onward, which is fine — this menu always renders the newest release.