### PR TITLE
fix(ci): serve each Mac architecture its own update bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
             app:
               - 'src/**'
               - 'src-tauri/**'
+              # Release-time artifact selection, covered by jest under
+              # scripts/__tests__ — without this the tests never run in CI.
+              - 'scripts/**'
               - 'package.json'
               - 'package-lock.json'
               - 'tsconfig*.json'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -441,10 +441,8 @@ jobs:
           # Build FTP latest.json
           PLATFORMS=""
 
-          # macOS — each slot gets the bundle built for its own architecture.
-          # Sharing one bundle across both shipped arm64 binaries to Intel
-          # machines, and they installed because the signature came from the
-          # same file (#433). A slot with no matching pair is left out.
+          # One bundle per slot. Sharing one across both shipped arm64
+          # binaries to Intel machines (#433).
           for SLOT in darwin-aarch64 darwin-x86_64; do
             MAC_TAR=$(SLOT="$SLOT" node -e '
               const { selectMacUpdateForSlot } = require("./scripts/select-linux-artifacts");

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -402,18 +402,8 @@ jobs:
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           # Read signatures
-          MAC_SIG=""
           WIN_SIG=""
           LINUX_SIG=""
-
-          # macOS — try aarch64 first, fall back to any .app.tar.gz.sig
-          for f in artifacts/*aarch64*.app.tar.gz.sig artifacts/*.app.tar.gz.sig; do
-            if [ -f "$f" ]; then
-              MAC_SIG=$(cat "$f")
-              echo "Found macOS signature: $f"
-              break
-            fi
-          done
 
           # Windows
           for f in artifacts/*x64-setup.exe.sig artifacts/*x64_setup.exe.sig; do
@@ -440,7 +430,6 @@ jobs:
           fi
 
           # Find artifact filenames for FTP URLs
-          MAC_TAR=$(ls artifacts/*.app.tar.gz 2>/dev/null | head -1 | xargs basename 2>/dev/null || echo "")
           WIN_EXE=$(ls artifacts/*x64-setup.exe 2>/dev/null | head -1 | xargs basename 2>/dev/null || echo "")
           WIN_EXE=${WIN_EXE:-$(ls artifacts/*x64_setup.exe 2>/dev/null | head -1 | xargs basename 2>/dev/null || echo "")}
           LINUX_APPIMAGE=$(node -e '
@@ -452,10 +441,27 @@ jobs:
           # Build FTP latest.json
           PLATFORMS=""
 
-          if [ -n "$MAC_SIG" ] && [ -n "$MAC_TAR" ]; then
-            PLATFORMS="\"darwin-aarch64\": { \"signature\": \"$MAC_SIG\", \"url\": \"https://$DEPLOY_API_URL/$MAC_TAR\" }"
-            PLATFORMS="$PLATFORMS, \"darwin-x86_64\": { \"signature\": \"$MAC_SIG\", \"url\": \"https://$DEPLOY_API_URL/$MAC_TAR\" }"
-          fi
+          # macOS — each slot gets the bundle built for its own architecture.
+          # Sharing one bundle across both shipped arm64 binaries to Intel
+          # machines, and they installed because the signature came from the
+          # same file (#433). A slot with no matching pair is left out.
+          for SLOT in darwin-aarch64 darwin-x86_64; do
+            MAC_TAR=$(SLOT="$SLOT" node -e '
+              const { selectMacUpdateForSlot } = require("./scripts/select-linux-artifacts");
+              const fs = require("fs");
+              const found = selectMacUpdateForSlot(fs.readdirSync("artifacts"), process.env.SLOT);
+              process.stdout.write(found?.bundle ?? "");
+            ')
+            if [ -z "$MAC_TAR" ]; then
+              echo "No complete macOS bundle for $SLOT, skipping that slot"
+              continue
+            fi
+
+            MAC_SIG=$(cat "artifacts/$MAC_TAR.sig")
+            echo "Found macOS bundle for $SLOT: $MAC_TAR"
+            if [ -n "$PLATFORMS" ]; then PLATFORMS="$PLATFORMS, "; fi
+            PLATFORMS="$PLATFORMS\"$SLOT\": { \"signature\": \"$MAC_SIG\", \"url\": \"https://$DEPLOY_API_URL/$MAC_TAR\" }"
+          done
 
           if [ -n "$WIN_SIG" ] && [ -n "$WIN_EXE" ]; then
             if [ -n "$PLATFORMS" ]; then PLATFORMS="$PLATFORMS, "; fi

--- a/scripts/__tests__/select-linux-artifacts.test.js
+++ b/scripts/__tests__/select-linux-artifacts.test.js
@@ -2,12 +2,15 @@
 /* global describe, expect, it */
 const {
   landingAliasFor,
+  selectMacUpdateForSlot,
   selectUpdaterAppImage,
   selectUpdaterSignature,
 } = require("../select-linux-artifacts");
 
 const COMPAT = "Kubeli_0.4.0_amd64.AppImage";
 const MODERN = "Kubeli_0.4.0_amd64-modern.AppImage";
+const MAC_ARM = "Kubeli_0.4.0_aarch64.app.tar.gz";
+const MAC_INTEL = "Kubeli_0.4.0_x64.app.tar.gz";
 
 // A release directory as the publish workflow sees it: both AppImages, both
 // signatures, plus the packages that must never be mistaken for one.
@@ -18,6 +21,10 @@ const RELEASE = [
   `${COMPAT}.sig`,
   "Kubeli_0.4.0_amd64.deb",
   "Kubeli-0.4.0-1.x86_64.rpm",
+  MAC_ARM,
+  `${MAC_ARM}.sig`,
+  MAC_INTEL,
+  `${MAC_INTEL}.sig`,
 ];
 
 describe("updater artifact selection", () => {
@@ -58,6 +65,59 @@ describe("updater artifact selection", () => {
 
   it("omits the signature when it is missing rather than guessing", () => {
     expect(selectUpdaterSignature([COMPAT])).toBeNull();
+  });
+});
+
+describe("macOS updater slots", () => {
+  // The bug this guards: aarch64 sorts before x64, so the first-match glob
+  // that fed both slots handed Intel machines an arm64 binary — and it
+  // installed cleanly, because the signature served with it matched.
+  it("gives each architecture its own bundle, not the one that sorts first", () => {
+    const macBundlesInGlobOrder = RELEASE.filter((name) =>
+      name.endsWith(".app.tar.gz"),
+    ).sort();
+    expect(macBundlesInGlobOrder[0]).toBe(MAC_ARM);
+
+    expect(selectMacUpdateForSlot(RELEASE, "darwin-x86_64").bundle).toBe(MAC_INTEL);
+    expect(selectMacUpdateForSlot(RELEASE, "darwin-aarch64").bundle).toBe(MAC_ARM);
+  });
+
+  it("pairs each bundle with its own signature", () => {
+    expect(selectMacUpdateForSlot(RELEASE, "darwin-x86_64").signature).toBe(
+      `${MAC_INTEL}.sig`,
+    );
+    expect(selectMacUpdateForSlot(RELEASE, "darwin-aarch64").signature).toBe(
+      `${MAC_ARM}.sig`,
+    );
+  });
+
+  // Falling back to the other architecture is what caused #433, so a missing
+  // build must resolve to null and drop the slot instead.
+  it("reports nothing rather than substituting the other architecture", () => {
+    const armOnly = [MAC_ARM, `${MAC_ARM}.sig`];
+    expect(selectMacUpdateForSlot(armOnly, "darwin-x86_64")).toBeNull();
+
+    const intelOnly = [MAC_INTEL, `${MAC_INTEL}.sig`];
+    expect(selectMacUpdateForSlot(intelOnly, "darwin-aarch64")).toBeNull();
+  });
+
+  it("omits a slot whose signature is missing rather than guessing", () => {
+    expect(selectMacUpdateForSlot([MAC_INTEL, MAC_ARM], "darwin-x86_64")).toBeNull();
+  });
+
+  // "aarch64" ends in "64" and contains "arch"; a looser match than the
+  // full _<arch>. segment risks the two bundles matching each other.
+  it("does not let the arm bundle satisfy the intel slot", () => {
+    expect(selectMacUpdateForSlot([MAC_ARM, `${MAC_ARM}.sig`], "darwin-x86_64")).toBeNull();
+  });
+
+  it("ignores the .dmg and the AppImages", () => {
+    const noMacTarballs = [COMPAT, `${COMPAT}.sig`, "Kubeli_0.4.0_x64.dmg"];
+    expect(selectMacUpdateForSlot(noMacTarballs, "darwin-x86_64")).toBeNull();
+  });
+
+  it("returns nothing for a slot it does not know", () => {
+    expect(selectMacUpdateForSlot(RELEASE, "linux-x86_64")).toBeNull();
   });
 });
 

--- a/scripts/__tests__/select-linux-artifacts.test.js
+++ b/scripts/__tests__/select-linux-artifacts.test.js
@@ -69,9 +69,6 @@ describe("updater artifact selection", () => {
 });
 
 describe("macOS updater slots", () => {
-  // The bug this guards: aarch64 sorts before x64, so the first-match glob
-  // that fed both slots handed Intel machines an arm64 binary — and it
-  // installed cleanly, because the signature served with it matched.
   it("gives each architecture its own bundle, not the one that sorts first", () => {
     const macBundlesInGlobOrder = RELEASE.filter((name) =>
       name.endsWith(".app.tar.gz"),
@@ -91,8 +88,6 @@ describe("macOS updater slots", () => {
     );
   });
 
-  // Falling back to the other architecture is what caused #433, so a missing
-  // build must resolve to null and drop the slot instead.
   it("reports nothing rather than substituting the other architecture", () => {
     const armOnly = [MAC_ARM, `${MAC_ARM}.sig`];
     expect(selectMacUpdateForSlot(armOnly, "darwin-x86_64")).toBeNull();
@@ -105,8 +100,6 @@ describe("macOS updater slots", () => {
     expect(selectMacUpdateForSlot([MAC_INTEL, MAC_ARM], "darwin-x86_64")).toBeNull();
   });
 
-  // "aarch64" ends in "64" and contains "arch"; a looser match than the
-  // full _<arch>. segment risks the two bundles matching each other.
   it("does not let the arm bundle satisfy the intel slot", () => {
     expect(selectMacUpdateForSlot([MAC_ARM, `${MAC_ARM}.sig`], "darwin-x86_64")).toBeNull();
   });

--- a/scripts/select-linux-artifacts.js
+++ b/scripts/select-linux-artifacts.js
@@ -1,18 +1,32 @@
 #!/usr/bin/env node
 /**
- * Picks which AppImage the updater and the landing page should point at.
+ * Picks which release artifacts the updater and the landing page point at.
  *
- * Releases ship two Linux AppImages (see .github/workflows/publish.yml):
- * the default one built on Ubuntu 22.04, and a "-modern" one built on 24.04
- * for distros whose Mesa is too new for the older bundled WebKitGTK (#429).
+ * Both selections here exist because a release directory holds several
+ * artifacts that match the same glob, and `ls ... | head -1` picks the wrong
+ * one in each case:
  *
- * The updater has a single linux-x86_64 slot, so exactly one of them may go
- * in it. It has to be the 22.04 build: it has the lower glibc floor, and the
- * updater pushes it to every existing install regardless of distro. Picking
- * by plain glob would take "-modern" instead, because it sorts first.
+ * - Linux ships two AppImages (see .github/workflows/publish.yml): the
+ *   default built on Ubuntu 22.04, and a "-modern" one built on 24.04 for
+ *   distros whose Mesa is too new for the older bundled WebKitGTK (#429).
+ *   The updater has a single linux-x86_64 slot, so exactly one may go in it.
+ *   It has to be the 22.04 build: it has the lower glibc floor, and the
+ *   updater pushes it to every install regardless of distro. A plain glob
+ *   takes "-modern" instead, because it sorts first.
+ *
+ * - macOS ships one .app.tar.gz per architecture, and the updater has a
+ *   separate slot for each. A plain glob takes aarch64 for both, because it
+ *   sorts before x64, and Intel machines then update to an arm64 binary
+ *   whose signature validates (#433).
  */
 
 const MODERN_SUFFIX = "-modern.AppImage";
+
+/** The macOS updater slots, and the architecture marker each one requires. */
+const MAC_ARCHITECTURES = {
+  "darwin-aarch64": "aarch64",
+  "darwin-x86_64": "x64",
+};
 
 /** The AppImage safe to hand to every install, or null if it is missing. */
 function selectUpdaterAppImage(fileNames) {
@@ -40,9 +54,38 @@ function isCompatibilityAppImage(fileName) {
   );
 }
 
+/**
+ * The macOS bundle and signature for one updater slot, or null if either is
+ * missing. Never falls back to the other architecture: serving an arm64
+ * binary to Intel is worse than serving no update, and the signature would
+ * still validate because it matches the file being served.
+ */
+function selectMacUpdateForSlot(fileNames, slot) {
+  const arch = MAC_ARCHITECTURES[slot];
+  if (!arch) return null;
+
+  const bundle = fileNames
+    .filter((name) => isMacBundleForArch(name, arch))
+    .sort()[0];
+  if (!bundle) return null;
+
+  const signature = `${bundle}.sig`;
+  if (!fileNames.includes(signature)) return null;
+
+  return { bundle, signature };
+}
+
+// Matches on the "_<arch>." segment rather than a bare substring, so that
+// "x64" cannot also match the "aarch64" bundle.
+function isMacBundleForArch(fileName, arch) {
+  return fileName.endsWith(`_${arch}.app.tar.gz`);
+}
+
 module.exports = {
+  MAC_ARCHITECTURES,
   MODERN_SUFFIX,
   landingAliasFor,
+  selectMacUpdateForSlot,
   selectUpdaterAppImage,
   selectUpdaterSignature,
 };

--- a/scripts/select-linux-artifacts.js
+++ b/scripts/select-linux-artifacts.js
@@ -1,28 +1,17 @@
 #!/usr/bin/env node
 /**
- * Picks which release artifacts the updater and the landing page point at.
+ * Picks which release artifacts the updater points at.
  *
- * Both selections here exist because a release directory holds several
- * artifacts that match the same glob, and `ls ... | head -1` picks the wrong
- * one in each case:
+ * A release holds several artifacts matching the same glob, and the one that
+ * sorts first is the wrong one in both cases: "-modern" before the
+ * compatibility AppImage (#429), aarch64 before x64 (#433).
  *
- * - Linux ships two AppImages (see .github/workflows/publish.yml): the
- *   default built on Ubuntu 22.04, and a "-modern" one built on 24.04 for
- *   distros whose Mesa is too new for the older bundled WebKitGTK (#429).
- *   The updater has a single linux-x86_64 slot, so exactly one may go in it.
- *   It has to be the 22.04 build: it has the lower glibc floor, and the
- *   updater pushes it to every install regardless of distro. A plain glob
- *   takes "-modern" instead, because it sorts first.
- *
- * - macOS ships one .app.tar.gz per architecture, and the updater has a
- *   separate slot for each. A plain glob takes aarch64 for both, because it
- *   sorts before x64, and Intel machines then update to an arm64 binary
- *   whose signature validates (#433).
+ * The Linux slot must get the 22.04 AppImage — it has the lower glibc floor
+ * and the updater pushes it to every install regardless of distro.
  */
 
 const MODERN_SUFFIX = "-modern.AppImage";
 
-/** The macOS updater slots, and the architecture marker each one requires. */
 const MAC_ARCHITECTURES = {
   "darwin-aarch64": "aarch64",
   "darwin-x86_64": "x64",
@@ -55,10 +44,8 @@ function isCompatibilityAppImage(fileName) {
 }
 
 /**
- * The macOS bundle and signature for one updater slot, or null if either is
- * missing. Never falls back to the other architecture: serving an arm64
- * binary to Intel is worse than serving no update, and the signature would
- * still validate because it matches the file being served.
+ * Never falls back to the other architecture: an arm64 binary on Intel is
+ * worse than no update, and its signature validates either way.
  */
 function selectMacUpdateForSlot(fileNames, slot) {
   const arch = MAC_ARCHITECTURES[slot];
@@ -75,8 +62,7 @@ function selectMacUpdateForSlot(fileNames, slot) {
   return { bundle, signature };
 }
 
-// Matches on the "_<arch>." segment rather than a bare substring, so that
-// "x64" cannot also match the "aarch64" bundle.
+// Anchored on the full segment so "x64" cannot match the aarch64 bundle.
 function isMacBundleForArch(fileName, arch) {
   return fileName.endsWith(`_${arch}.app.tar.gz`);
 }


### PR DESCRIPTION
Closes #433

## Problem

`latest.json` pointed `darwin-x86_64` at the **aarch64** bundle, so Intel Macs auto-updated to an arm64 binary. From the published v0.3.85 manifest:

```
darwin-aarch64: Kubeli_0.3.85_aarch64.app.tar.gz
darwin-x86_64:  Kubeli_0.3.85_aarch64.app.tar.gz   <-- wrong
```

The update installed cleanly: the signature was read from the same file that was served, so the updater had nothing to reject.

## Cause

Both slots were filled from a single first-match glob, and `aarch64` sorts before `x64`:

```bash
MAC_TAR=$(ls artifacts/*.app.tar.gz 2>/dev/null | head -1 ...)
```

The signature lookup had the same shape, preferring `*aarch64*` and then falling back to *any* `.app.tar.gz.sig`. The x64 bundle and its signature were built and uploaded all along — they were simply never referenced.

## Fix

Selection moves into `scripts/select-linux-artifacts.js`, alongside the AppImage rule added for the same class of bug in #430, and resolves **per slot**:

- `darwin-aarch64` → `*_aarch64.app.tar.gz` + its own `.sig`
- `darwin-x86_64` → `*_x64.app.tar.gz` + its own `.sig`

A slot whose bundle or signature is missing is **dropped**, never filled from the other architecture. Serving no update is better than serving a wrong-architecture one, and that silent fallback is exactly what hid this bug. Matching is anchored on the full `_<arch>.app.tar.gz` segment so the two names cannot satisfy each other.

## Tests

Six cases in `scripts/__tests__/select-linux-artifacts.test.js`. The regression test asserts the glob order first, so it documents *why* the naive version fails rather than just that it does.

Verified the coverage is real by reintroducing the old logic — **4 of the new tests fail**, and all pass on the fix.

Also simulated the rewritten workflow block against the real v0.3.85 asset list:

```
darwin-aarch64 -> Kubeli_0.3.85_aarch64.app.tar.gz
darwin-x86_64  -> Kubeli_0.3.85_x64.app.tar.gz
```

## Verification

- `npm run test:coverage` — 918/918 passing (83 suites)
- `make check` — clean
- `make lint` — 0 errors (4 pre-existing warnings in `LogViewer.tsx`, untouched)
- `publish.yml` parses as valid YAML

No Rust touched. The FTP deploy step already globs `artifacts/*.app.tar.gz`, so both architectures were being uploaded to the update host — only the manifest needed correcting.

## Note

This bug reaches users only at the next release, when `latest.json` is regenerated. Existing Intel installs on v0.3.85 already received the arm64 bundle; they will be corrected by the next release built from this workflow.