### PR TITLE
feat(linux): publish signed APT and DNF repositories

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -337,6 +337,11 @@ jobs:
     needs: [create-release, build, sign-windows]
     runs-on: ubuntu-latest
     environment: production
+    # Job level, not step level: a step's own `if:` is evaluated before its
+    # `env:` block is applied, so a secret declared there is an empty string
+    # at that point and the guard would skip the step it guards.
+    env:
+      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -610,7 +615,6 @@ jobs:
       - name: Build signed APT and RPM repositories
         if: ${{ env.GPG_SIGNING_KEY != '' }}
         env:
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_SLUG: ${{ github.repository }}
         run: |
@@ -631,30 +635,37 @@ jobs:
       - name: Deploy repositories to FTP
         if: ${{ env.GPG_SIGNING_KEY != '' }}
         env:
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           FTP_HOST: ${{ secrets.FTP_HOST }}
           FTP_USER: ${{ secrets.FTP_USER }}
           FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
           DEPLOY_LANDING_FTP_PATH: ${{ secrets.DEPLOY_LANDING_FTP_PATH }}
         run: |
-          # Package indexes must never be readable while the packages they
-          # reference are still uploading, so pool/ and the packages go first
-          # and the signed metadata lands last.
           upload() {
             curl -sf -T "$1" --user "$FTP_USER:$FTP_PASSWORD" \
-              "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/$2" --ftp-create-dirs
+              "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/$1" --ftp-create-dirs
           }
 
           cd linux-repos
-          metadata=$(mktemp)
-          find . -type f | sed 's|^\./||' | sort > "$metadata"
+          all=$(mktemp)
+          # .packages/ is the download cache the build works from, not part of
+          # either repository.
+          find . -type f -not -path './.packages/*' | sed 's|^\./||' | sort > "$all"
 
-          grep -vE '^(apt/dists|rpm/repodata)/' "$metadata" | while read -r f; do
-            upload "$f" "$f"
-          done
-          grep -E '^(apt/dists|rpm/repodata)/' "$metadata" | while read -r f; do
-            upload "$f" "$f"
-          done
+          # Three passes, because a client refreshing mid-deploy must never
+          # reach a signed index that references a file not uploaded yet.
+          # Ordering within a pass is irrelevant; ordering between them is not,
+          # so the signature files are matched by name rather than left to sort
+          # order -- InRelease sorts before Packages, which is the wrong way
+          # round and would hand clients a hash mismatch.
+          is_signed_index='^(apt/dists/stable/(InRelease|Release|Release\.gpg)|rpm/repodata/repomd\.xml(\.asc)?)$'
+
+          # 1. Packages and keys.
+          grep -vE '^(apt/dists|rpm/repodata)/' "$all" | while read -r f; do upload "$f"; done
+          # 2. Index payloads the signatures will vouch for.
+          grep -E '^(apt/dists|rpm/repodata)/' "$all" | grep -vE "$is_signed_index" \
+            | while read -r f; do upload "$f"; done
+          # 3. The signed indexes themselves, last.
+          grep -E "$is_signed_index" "$all" | while read -r f; do upload "$f"; done
 
           echo "Repository deployment complete"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -605,6 +605,59 @@ jobs:
 
           echo "Landing page deployment complete"
 
+      # deb/rpm cannot use the Tauri updater, so an apt/dnf repository is the
+      # only way those installs receive updates at all (#348).
+      - name: Build signed APT and RPM repositories
+        if: ${{ env.GPG_SIGNING_KEY != '' }}
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_SLUG: ${{ github.repository }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq apt-utils createrepo-c rpm gnupg
+
+          printf '%s' "$GPG_SIGNING_KEY" | gpg --batch --quiet --import
+          GPG_KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/{print $5; exit}')
+          if [ -z "$GPG_KEY_ID" ]; then
+            echo "Signing key did not import" >&2
+            exit 1
+          fi
+          echo "::add-mask::$GPG_KEY_ID"
+          export GPG_KEY_ID
+
+          ./scripts/build-linux-repos.sh linux-repos
+
+      - name: Deploy repositories to FTP
+        if: ${{ env.GPG_SIGNING_KEY != '' }}
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          FTP_HOST: ${{ secrets.FTP_HOST }}
+          FTP_USER: ${{ secrets.FTP_USER }}
+          FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
+          DEPLOY_LANDING_FTP_PATH: ${{ secrets.DEPLOY_LANDING_FTP_PATH }}
+        run: |
+          # Package indexes must never be readable while the packages they
+          # reference are still uploading, so pool/ and the packages go first
+          # and the signed metadata lands last.
+          upload() {
+            curl -sf -T "$1" --user "$FTP_USER:$FTP_PASSWORD" \
+              "ftp://$FTP_HOST$DEPLOY_LANDING_FTP_PATH/$2" --ftp-create-dirs
+          }
+
+          cd linux-repos
+          metadata=$(mktemp)
+          find . -type f | sed 's|^\./||' | sort > "$metadata"
+
+          grep -vE '^(apt/dists|rpm/repodata)/' "$metadata" | while read -r f; do
+            upload "$f" "$f"
+          done
+          grep -E '^(apt/dists|rpm/repodata)/' "$metadata" | while read -r f; do
+            upload "$f" "$f"
+          done
+
+          echo "Repository deployment complete"
+
       - name: Build Astro landing page
         run: |
           npm install -g bun

--- a/scripts/build-linux-repos.sh
+++ b/scripts/build-linux-repos.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Builds the signed APT and DNF repositories that Linux users install from.
+#
+# Both are rebuilt from scratch on every release, with the packages pulled
+# from the GitHub releases rather than from whatever the publish host happens
+# to hold. FTP offers no reliable way to list or diff remote state, so
+# reconstructing from the releases keeps the result reproducible and makes a
+# failed upload recoverable by rerunning.
+#
+# Usage: build-linux-repos.sh <output-dir> [max-releases]
+set -euo pipefail
+
+OUT_DIR="${1:?output directory required}"
+MAX_RELEASES="${2:-20}"
+
+: "${GPG_KEY_ID:?GPG_KEY_ID must be set}"
+: "${REPO_SLUG:=atilladeniz/Kubeli}"
+
+APT_DIR="$OUT_DIR/apt"
+RPM_DIR="$OUT_DIR/rpm"
+PKG_DIR="$OUT_DIR/.packages"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$APT_DIR/pool/main" "$APT_DIR/dists/stable/main/binary-amd64" "$RPM_DIR" "$PKG_DIR"
+
+echo "Collecting packages from the last $MAX_RELEASES releases..."
+tags=$(gh release list --repo "$REPO_SLUG" --limit "$MAX_RELEASES" \
+  --exclude-drafts --json tagName --jq '.[].tagName')
+
+for tag in $tags; do
+  gh release download "$tag" --repo "$REPO_SLUG" \
+    --pattern '*.deb' --pattern '*.rpm' --dir "$PKG_DIR" --skip-existing 2>/dev/null || true
+done
+
+deb_count=$(find "$PKG_DIR" -name '*.deb' | wc -l | tr -d ' ')
+rpm_count=$(find "$PKG_DIR" -name '*.rpm' | wc -l | tr -d ' ')
+echo "Found $deb_count deb and $rpm_count rpm packages"
+
+# A repo with no packages would publish as an empty but valid index, silently
+# removing every version from users' package managers.
+if [ "$deb_count" -eq 0 ] || [ "$rpm_count" -eq 0 ]; then
+  echo "Refusing to publish: expected at least one deb and one rpm" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------- APT --------
+echo "Building APT repository..."
+cp "$PKG_DIR"/*.deb "$APT_DIR/pool/main/"
+cd "$APT_DIR"
+
+apt-ftparchive packages pool/main > dists/stable/main/binary-amd64/Packages
+gzip -kf dists/stable/main/binary-amd64/Packages
+
+cat > /tmp/apt-release.conf <<'CONF'
+APT::FTPArchive::Release::Origin "Kubeli";
+APT::FTPArchive::Release::Label "Kubeli";
+APT::FTPArchive::Release::Suite "stable";
+APT::FTPArchive::Release::Codename "stable";
+APT::FTPArchive::Release::Architectures "amd64";
+APT::FTPArchive::Release::Components "main";
+APT::FTPArchive::Release::Description "Kubeli - Kubernetes Management Desktop App";
+CONF
+apt-ftparchive -c /tmp/apt-release.conf release dists/stable > dists/stable/Release
+
+# InRelease (inline signature) is what modern apt fetches; Release.gpg is kept
+# for older clients that still ask for the detached form.
+gpg --batch --yes --local-user "$GPG_KEY_ID" \
+  --clearsign -o dists/stable/InRelease dists/stable/Release
+gpg --batch --yes --local-user "$GPG_KEY_ID" \
+  -abs -o dists/stable/Release.gpg dists/stable/Release
+
+# Binary, not ASCII-armored: apt requires the dearmored form under
+# /usr/share/keyrings, and an armored file there fails with NO_PUBKEY.
+gpg --export "$GPG_KEY_ID" > "$APT_DIR/kubeli-archive-keyring.gpg"
+
+# ---------------------------------------------------------------- RPM --------
+echo "Building RPM repository..."
+cp "$PKG_DIR"/*.rpm "$RPM_DIR/"
+
+cat > "$HOME/.rpmmacros" <<MACROS
+%_signature gpg
+%_gpg_name $GPG_KEY_ID
+%__gpg /usr/bin/gpg
+%_gpg_sign_cmd_extra_args --batch --pinentry-mode loopback
+MACROS
+
+# Re-signing an already-signed package is a no-op, so this stays correct when
+# older releases are reprocessed on later runs.
+rpm --addsign "$RPM_DIR"/*.rpm >/dev/null
+
+createrepo_c --quiet "$RPM_DIR"
+gpg --batch --yes --local-user "$GPG_KEY_ID" \
+  --detach-sign --armor "$RPM_DIR/repodata/repomd.xml"
+
+# dnf reads the armored form, so the RPM side ships the opposite encoding
+# from APT's keyring on purpose.
+gpg --armor --export "$GPG_KEY_ID" > "$RPM_DIR/RPM-GPG-KEY-kubeli"
+
+echo "Done: $(find "$OUT_DIR" -type f | wc -l | tr -d ' ') files"

--- a/scripts/build-linux-repos.sh
+++ b/scripts/build-linux-repos.sh
@@ -11,11 +11,15 @@
 # Usage: build-linux-repos.sh <output-dir> [max-releases]
 set -euo pipefail
 
-OUT_DIR="${1:?output directory required}"
 MAX_RELEASES="${2:-20}"
 
 : "${GPG_KEY_ID:?GPG_KEY_ID must be set}"
 : "${REPO_SLUG:=atilladeniz/Kubeli}"
+
+# Absolute, because the APT stage has to cd into its own tree and every path
+# derived here would otherwise resolve against the new working directory.
+mkdir -p "${1:?output directory required}"
+OUT_DIR="$(cd "$1" && pwd)"
 
 APT_DIR="$OUT_DIR/apt"
 RPM_DIR="$OUT_DIR/rpm"
@@ -24,9 +28,12 @@ PKG_DIR="$OUT_DIR/.packages"
 rm -rf "$OUT_DIR"
 mkdir -p "$APT_DIR/pool/main" "$APT_DIR/dists/stable/main/binary-amd64" "$RPM_DIR" "$PKG_DIR"
 
+# Drafts are included on purpose: the release being published is still a draft
+# while this runs, and excluding drafts would leave the newest version out of
+# the very repository built to ship it.
 echo "Collecting packages from the last $MAX_RELEASES releases..."
 tags=$(gh release list --repo "$REPO_SLUG" --limit "$MAX_RELEASES" \
-  --exclude-drafts --json tagName --jq '.[].tagName')
+  --json tagName --jq '.[].tagName')
 
 for tag in $tags; do
   gh release download "$tag" --repo "$REPO_SLUG" \
@@ -52,6 +59,9 @@ cd "$APT_DIR"
 apt-ftparchive packages pool/main > dists/stable/main/binary-amd64/Packages
 gzip -kf dists/stable/main/binary-amd64/Packages
 
+# ValidTime is 90 days: long enough to survive a gap between releases, which
+# would otherwise expire the repository for every user at once, and short
+# enough to bound how long a stale signed index stays replayable.
 cat > /tmp/apt-release.conf <<'CONF'
 APT::FTPArchive::Release::Origin "Kubeli";
 APT::FTPArchive::Release::Label "Kubeli";
@@ -60,6 +70,7 @@ APT::FTPArchive::Release::Codename "stable";
 APT::FTPArchive::Release::Architectures "amd64";
 APT::FTPArchive::Release::Components "main";
 APT::FTPArchive::Release::Description "Kubeli - Kubernetes Management Desktop App";
+APT::FTPArchive::Release::ValidTime "7776000";
 CONF
 apt-ftparchive -c /tmp/apt-release.conf release dists/stable > dists/stable/Release
 

--- a/web/src/components/FAQSection.tsx
+++ b/web/src/components/FAQSection.tsx
@@ -24,11 +24,15 @@ const faqs = [
   },
   {
     question: "Which platforms are supported?",
-    answer: "Kubeli runs natively on macOS (10.15+), Windows (10/11), and Linux (x64 AppImage, .deb and .rpm). All platforms support auto-updates, so you'll always have the latest features and security fixes."
+    answer: "Kubeli runs natively on macOS (10.15+), Windows (10/11), and Linux (x64 AppImage, .deb and .rpm). macOS, Windows and the AppImage update themselves from inside the app. On Linux, install from the APT or DNF repository to get updates through apt upgrade or dnf upgrade — a downloaded .deb or .rpm cannot update itself."
   },
   {
     question: "The Linux AppImage shows a blank window or exits with EGL_BAD_PARAMETER. What now?",
     answer: "Use the \"AppImage (new distros)\" download, or install the .deb/.rpm. An AppImage carries its own copy of WebKitGTK, and the standard build's copy is too old for the graphics drivers on Fedora 43, Arch and other distros running Mesa 25 or newer. The \"new distros\" build bundles a current WebKitGTK and needs glibc 2.39+ (Ubuntu 24.04, Debian 13, Fedora 39 and up). The .deb and .rpm sidestep the problem entirely because they use the WebKitGTK your distribution already ships."
+  },
+  {
+    question: "How do I keep Kubeli up to date on Linux?",
+    answer: "Install from the APT or DNF repository, then apt upgrade or dnf upgrade keeps Kubeli current along with the rest of your system. Setup is two commands and is documented at /linux-repositories. The AppImage updates itself from inside the app; a .deb or .rpm downloaded directly has no update mechanism."
   },
   {
     question: "Is my cluster data secure?",

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -400,6 +400,7 @@ const websiteSchema = {
           <div>
             <h3 class="font-semibold text-sm text-foreground mb-4">Support</h3>
             <ul class="space-y-3 text-sm">
+              <li><a href="/linux-repositories" class="text-muted-foreground hover:text-foreground transition-colors">Linux Repositories</a></li>
               <li><a href="https://github.com/atilladeniz/kubeli" target="_blank" rel="noopener" class="text-muted-foreground hover:text-foreground transition-colors">GitHub</a></li>
               <li><a href="https://github.com/atilladeniz/kubeli/discussions" target="_blank" rel="noopener" class="text-muted-foreground hover:text-foreground transition-colors">Discussions</a></li>
               <li><a href="https://github.com/atilladeniz/kubeli/issues/new?assignees=&labels=enhancement&template=feature_request.yml" target="_blank" rel="noopener" class="text-muted-foreground hover:text-foreground transition-colors">Feature Request</a></li>

--- a/web/src/pages/linux-repositories.astro
+++ b/web/src/pages/linux-repositories.astro
@@ -26,15 +26,16 @@ const repo = "https://github.com/atilladeniz/Kubeli";
         Both commands are required: the first stores the signing key, the second
         points apt at the repository and binds it to that key.
       </p>
-      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>sudo curl -fsSL {repoHost}/apt/kubeli-archive-keyring.gpg \
-  -o /usr/share/keyrings/kubeli-archive-keyring.gpg
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>sudo mkdir -p /etc/apt/keyrings
+sudo curl -fsSL {repoHost}/apt/kubeli-archive-keyring.gpg \
+  -o /etc/apt/keyrings/kubeli-archive-keyring.gpg
 
 echo "Types: deb
 URIs: {repoHost}/apt
 Suites: stable
 Components: main
 Architectures: amd64
-Signed-By: /usr/share/keyrings/kubeli-archive-keyring.gpg" \
+Signed-By: /etc/apt/keyrings/kubeli-archive-keyring.gpg" \
   | sudo tee /etc/apt/sources.list.d/kubeli.sources</code></pre>
 
       <p class="text-sm text-muted-foreground">Then install:</p>
@@ -51,6 +52,8 @@ sudo apt install kubeli</code></pre>
       <p class="text-sm text-muted-foreground">
         Import the key before adding the repository — dnf verifies the repository
         metadata signature on the first refresh and fails if the key is unknown.
+        On that first refresh dnf also asks you to confirm the key; the
+        fingerprint it shows is listed below.
       </p>
       <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>sudo rpm --import {repoHost}/rpm/RPM-GPG-KEY-kubeli
 
@@ -80,7 +83,7 @@ gpgkey={repoHost}/rpm/RPM-GPG-KEY-kubeli" \
       <p class="text-sm text-muted-foreground">
         To confirm what you downloaded matches:
       </p>
-      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>gpg --show-keys /usr/share/keyrings/kubeli-archive-keyring.gpg</code></pre>
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>gpg --show-keys /etc/apt/keyrings/kubeli-archive-keyring.gpg</code></pre>
     </section>
 
     <section class="space-y-4">

--- a/web/src/pages/linux-repositories.astro
+++ b/web/src/pages/linux-repositories.astro
@@ -1,0 +1,96 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+
+const repoHost = "https://kubeli.dev";
+const repo = "https://github.com/atilladeniz/Kubeli";
+---
+
+<BaseLayout
+  title="Linux Repositories"
+  description="Install Kubeli from the official APT and DNF repositories and get updates through apt upgrade or dnf upgrade."
+  canonicalPath="/linux-repositories"
+>
+  <div class="mx-auto max-w-3xl px-4 sm:px-8 py-8 sm:py-12">
+    <h1 class="text-3xl font-semibold mb-3">Linux Repositories</h1>
+    <p class="text-muted-foreground mb-10">
+      Installing from a repository means <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">apt</code> or
+      <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">dnf</code> handles updates along with the rest of
+      your system. The <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">.deb</code> and
+      <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">.rpm</code> downloads cannot update themselves, so
+      this is the recommended way to install Kubeli on Linux.
+    </p>
+
+    <section class="space-y-4 mb-12">
+      <h2 class="text-xl font-semibold">Debian, Ubuntu, and derivatives</h2>
+      <p class="text-sm text-muted-foreground">
+        Both commands are required: the first stores the signing key, the second
+        points apt at the repository and binds it to that key.
+      </p>
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>sudo curl -fsSL {repoHost}/apt/kubeli-archive-keyring.gpg \
+  -o /usr/share/keyrings/kubeli-archive-keyring.gpg
+
+echo "Types: deb
+URIs: {repoHost}/apt
+Suites: stable
+Components: main
+Architectures: amd64
+Signed-By: /usr/share/keyrings/kubeli-archive-keyring.gpg" \
+  | sudo tee /etc/apt/sources.list.d/kubeli.sources</code></pre>
+
+      <p class="text-sm text-muted-foreground">Then install:</p>
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>sudo apt update
+sudo apt install kubeli</code></pre>
+
+      <p class="text-sm text-muted-foreground">
+        Updates arrive with <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">sudo apt upgrade</code>.
+      </p>
+    </section>
+
+    <section class="space-y-4 mb-12">
+      <h2 class="text-xl font-semibold">Fedora, RHEL, Rocky, AlmaLinux</h2>
+      <p class="text-sm text-muted-foreground">
+        Import the key before adding the repository — dnf verifies the repository
+        metadata signature on the first refresh and fails if the key is unknown.
+      </p>
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>sudo rpm --import {repoHost}/rpm/RPM-GPG-KEY-kubeli
+
+echo "[kubeli]
+name=Kubeli
+baseurl={repoHost}/rpm
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey={repoHost}/rpm/RPM-GPG-KEY-kubeli" \
+  | sudo tee /etc/yum.repos.d/kubeli.repo</code></pre>
+
+      <p class="text-sm text-muted-foreground">Then install:</p>
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>sudo dnf install kubeli</code></pre>
+
+      <p class="text-sm text-muted-foreground">
+        Updates arrive with <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">sudo dnf upgrade</code>.
+      </p>
+    </section>
+
+    <section class="space-y-4 mb-12">
+      <h2 class="text-xl font-semibold">Verifying the key</h2>
+      <p class="text-sm text-muted-foreground">
+        Every package and every repository index is signed with this key:
+      </p>
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>584A D889 E8F1 3AB8 618B  6419 AD8D 146E 6F18 94D2</code></pre>
+      <p class="text-sm text-muted-foreground">
+        To confirm what you downloaded matches:
+      </p>
+      <pre class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm"><code>gpg --show-keys /usr/share/keyrings/kubeli-archive-keyring.gpg</code></pre>
+    </section>
+
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold">Other options</h2>
+      <p class="text-sm text-muted-foreground">
+        The AppImage and the standalone <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">.deb</code> /
+        <code class="rounded bg-muted px-1 py-0.5 text-[0.9em]">.rpm</code> files stay available on the
+        <a href={`${repo}/releases/latest`} class="underline underline-offset-4" target="_blank" rel="noopener">releases page</a>.
+        The AppImage updates itself from inside the app; the standalone packages do not update at all.
+      </p>
+    </section>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
Refs #348

## Why

The Tauri updater supports **AppImage only** on Linux. A `.deb` or `.rpm` downloaded by hand has no update path at all — which is exactly what the reporter hit:

> automatic update on rpm package is not working

That is not a bug to fix; it is a missing distribution channel. Repositories hand updating to `apt` / `dnf`, which is the mechanism those users already have.

## What

`scripts/build-linux-repos.sh` builds both trees, signed with `GPG_SIGNING_KEY`, published to the existing FTP host from the `finalize` job.

**Rebuilt from scratch each release**, with packages pulled from the GitHub releases rather than from whatever the publish host currently holds. FTP offers no way to list or diff remote state, so reconstructing from the releases keeps the result reproducible and makes a failed upload recoverable by simply rerunning.

**Upload order matters:** packages and `pool/` go first, signed indexes last. A client refreshing mid-deploy would otherwise fetch metadata referencing files that are not uploaded yet.

**Guard:** the build aborts if no `.deb` or no `.rpm` was found. An empty repo is still a *valid* repo — publishing one would silently withdraw every version from users' package managers.

The steps are gated on `GPG_SIGNING_KEY` being present, so a release without the secret skips the repos instead of failing.

## Verification

Containers, against the **real v0.3.85 packages**, running the actual script (not a sketch):

**Debian 12** — `Signed-By` source, no manual trust:
```
Get:1 file:/out/apt stable InRelease [2384 B]
kubeli:
  Candidate: 0.3.85
     0.3.85 500  file:/out/apt stable/main amd64 Packages
```

**Fedora 41** — with `repo_gpgcheck=1`, so the metadata signature is checked:
```
kubeli.x86_64 0.3.85-1 kubeli
```

Package signature confirmed on the rpm itself:
```
Signature : RSA/SHA512, Key ID ad8d146e6f1894d2
```

Also: `shellcheck` clean, `make check` clean, Astro builds, YAML valid.

### Two findings the testing produced

1. **`dnf` needs the key imported before the first refresh.** With `repo_gpgcheck=1` it verifies `repomd.xml` immediately and fails with `Signing key not found` if the key is unknown — the interactive import prompt cannot complete non-interactively. The documented install order (`rpm --import` first) is therefore required, not cosmetic.
2. **`dpkg-scanpackages` is not in `apt-utils`** (it is in `dpkg-dev`). Using `apt-ftparchive` for both the Packages and Release stages avoids the extra dependency.

## Docs

- New `/linux-repositories` page with copy-paste setup for both package managers, plus the key fingerprint for verification
- Linked from the footer (Support) on all 10 pages
- **Corrected a false claim in the FAQ:** it stated *"All platforms support auto-updates"* — untrue for `.deb`/`.rpm`, and precisely the confusion behind this issue

## Not included

Flathub, the fourth item in #348. Their [requirements](https://docs.flathub.org/docs/for-app-authors/requirements) prohibit apps containing AI-generated or AI-assisted code, with permanent bans as a stated consequence. Reasoning is in the issue thread.

## Note

The repositories only exist once a release runs with this merged. Nothing is served at the documented URLs until then, so the docs page describes a channel that goes live with the next release.