### PR TITLE
fix: probe bash, ash, then sh for pod shells

### DIFF
--- a/.dev/k8s-samples/22-shell-test.yaml
+++ b/.dev/k8s-samples/22-shell-test.yaml
@@ -1,0 +1,99 @@
+# Pods for testing Shell (issue #457): bash, then ash, then sh.
+# Applied by make minikube-setup-samples / minikube-start.
+# In Kubeli: switch to namespace kubeli-shell and open Shell on each pod.
+#
+# Expected:
+#   shell-bash (ubuntu)  -> GNU bash
+#   shell-ash  (alpine)  -> ash (bash is missing)
+#   shell-sh   (busybox) -> BusyBox sh (bash is missing; ash is the same applet)
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeli-shell
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shell-bash
+  namespace: kubeli-shell
+  labels:
+    app: shell-bash
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shell-bash
+  template:
+    metadata:
+      labels:
+        app: shell-bash
+    spec:
+      containers:
+        - name: shell
+          image: ubuntu:22.04
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shell-ash
+  namespace: kubeli-shell
+  labels:
+    app: shell-ash
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shell-ash
+  template:
+    metadata:
+      labels:
+        app: shell-ash
+    spec:
+      containers:
+        - name: shell
+          image: alpine:3.21
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shell-sh
+  namespace: kubeli-shell
+  labels:
+    app: shell-sh
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shell-sh
+  template:
+    metadata:
+      labels:
+        app: shell-sh
+    spec:
+      containers:
+        - name: shell
+          image: busybox:1.36
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi

--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,7 @@ minikube-setup-samples: ## Apply sample Kubernetes resources for testing
 		echo "  - RBAC: Roles, RoleBindings, ServiceAccount"; \
 		echo "  - Quotas: ResourceQuota, LimitRange"; \
 		echo "  - Flux HelmReleases: podinfo, redis, prometheus-stack, cert-manager"; \
+		echo "  - Shell test (kubeli-shell): shell-bash, shell-ash, shell-sh"; \
 	else \
 		echo "$(YELLOW)Warning: .dev/k8s-samples/ directory not found$(RESET)"; \
 	fi
@@ -556,6 +557,7 @@ minikube-clean-samples: ## Remove sample Kubernetes resources
 		helm uninstall demo-mysql -n kubeli-demo 2>/dev/null || true; \
 	fi
 	@kubectl delete namespace kubeli-demo --ignore-not-found=true
+	@kubectl delete namespace kubeli-shell --ignore-not-found=true
 	@kubectl delete pv demo-pv-100mi demo-pv-500mi demo-pv-1gi demo-pv-2gi demo-pv-5gi demo-pv-10gi demo-pv-20gi demo-pv-50gi demo-pv-100gi demo-pv-256gi --ignore-not-found=true
 	@kubectl delete ingressclass demo-ingress-class --ignore-not-found=true
 	@echo "$(GREEN)✓ Sample resources removed$(RESET)"

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -148,16 +148,25 @@ impl Default for ShellSessionManager {
     }
 }
 
-/// Command to exec when the UI does not pass one: bash, then ash, then sh.
-/// `clear` uses `;` so a missing `clear` binary does not skip bash.
+/// Shell probe: bash, then ash, then sh. `command -v` probes silently (no
+/// "not found" noise in the terminal) and `exec` replaces the outer sh, so
+/// the shell's exit status ends the session. A plain `bash || ash || sh`
+/// would drop the user into ash/sh after a bash that exits non-zero.
+/// No `clear` here: it wipes the xterm scrollback that reconnects keep.
+const SHELL_PROBE: &str = "command -v bash >/dev/null 2>&1 && exec bash; \
+     command -v ash >/dev/null 2>&1 && exec ash; exec sh";
+
+fn shell_probe_command(prefix: &str) -> Vec<String> {
+    vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!("{prefix}{SHELL_PROBE}"),
+    ]
+}
+
+/// Command to exec when the UI does not pass one.
 fn resolve_shell_command(command: Option<Vec<String>>) -> Vec<String> {
-    command.unwrap_or_else(|| {
-        vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "clear; (bash || ash || sh)".to_string(),
-        ]
-    })
+    command.unwrap_or_else(|| shell_probe_command(""))
 }
 
 /// Start an interactive shell session in a pod container
@@ -676,12 +685,10 @@ pub async fn node_shell_start(
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     }
 
-    // Exec into the debug pod with a proper shell (try bash, ash, sh in order)
-    let exec_cmd = vec![
-        "sh".to_string(),
-        "-c".to_string(),
-        "((clear && bash) || (clear && ash) || (clear && sh))".to_string(),
-    ];
+    // Exec into the debug pod with a proper shell (try bash, ash, sh in order).
+    // `clear;` wipes the pod-creation status lines; `;` keeps the probe going
+    // when the image has no `clear`.
+    let exec_cmd = shell_probe_command("clear; ");
     let attach_params = AttachParams::interactive_tty().container("node-shell");
 
     let (input_tx, mut input_rx) = mpsc::channel::<ShellInput>(256);
@@ -813,14 +820,50 @@ pub async fn node_shell_cleanup(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_shell_command, take_valid_utf8, ShellEvent};
+    use super::{resolve_shell_command, take_valid_utf8, ShellEvent, SHELL_PROBE};
+
+    // Regression for the probe semantics: bash is preferred, and a bash that
+    // exits non-zero must end the session instead of falling through to sh.
+    #[cfg(unix)]
+    #[test]
+    fn shell_probe_prefers_bash_and_does_not_fall_through() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::{Command, Stdio};
+
+        let dir = std::env::temp_dir().join(format!("kubeli-probe-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let fake_bash = dir.join("bash");
+        std::fs::write(&fake_bash, "#!/bin/sh\necho fake-bash\nexit 3\n").unwrap();
+        std::fs::set_permissions(&fake_bash, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = format!(
+            "{}:{}",
+            dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+
+        let out = Command::new("sh")
+            .args(["-c", SHELL_PROBE])
+            .env("PATH", path)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "fake-bash");
+        // A fall-through to `sh` would read EOF from stdin and exit 0.
+        assert_eq!(out.status.code(), Some(3));
+        assert!(
+            out.stderr.is_empty(),
+            "probe must be silent: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
 
     #[test]
-    fn pod_shell_defaults_to_bash_ash_sh_probe() {
-        assert_eq!(
-            resolve_shell_command(None),
-            vec!["sh", "-c", "clear; (bash || ash || sh)"]
-        );
+    fn pod_shell_probe_has_no_clear() {
+        let cmd = resolve_shell_command(None);
+        assert_eq!(&cmd[..2], ["sh", "-c"]);
+        assert!(!cmd[2].contains("clear"));
     }
 
     #[test]

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -148,6 +148,18 @@ impl Default for ShellSessionManager {
     }
 }
 
+/// Command to exec when the UI does not pass one: bash, then ash, then sh.
+/// `clear` uses `;` so a missing `clear` binary does not skip bash.
+fn resolve_shell_command(command: Option<Vec<String>>) -> Vec<String> {
+    command.unwrap_or_else(|| {
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "clear; (bash || ash || sh)".to_string(),
+        ]
+    })
+}
+
 /// Start an interactive shell session in a pod container
 #[command]
 pub async fn shell_start(
@@ -180,11 +192,7 @@ pub async fn shell_start(
             .map(|c| c.name.clone())
     });
 
-    // Default to sh if no command specified
-    let cmd = options
-        .command
-        .clone()
-        .unwrap_or_else(|| vec!["sh".to_string()]);
+    let cmd = resolve_shell_command(options.command.clone());
 
     let mut attach_params = AttachParams::interactive_tty();
     if let Some(c) = &container {
@@ -805,7 +813,21 @@ pub async fn node_shell_cleanup(
 
 #[cfg(test)]
 mod tests {
-    use super::{take_valid_utf8, ShellEvent};
+    use super::{resolve_shell_command, take_valid_utf8, ShellEvent};
+
+    #[test]
+    fn pod_shell_defaults_to_bash_ash_sh_probe() {
+        assert_eq!(
+            resolve_shell_command(None),
+            vec!["sh", "-c", "clear; (bash || ash || sh)"]
+        );
+    }
+
+    #[test]
+    fn explicit_command_is_kept() {
+        let cmd = vec!["powershell".to_string()];
+        assert_eq!(resolve_shell_command(Some(cmd.clone())), cmd);
+    }
 
     // A session cut mid-run is recoverable; only a connection that never
     // established is an Error. The terminal branches on this reason to decide


### PR DESCRIPTION
## Description

Pod shell always exec'd `sh`, even when the image had bash.

Default is now `sh -c "clear; (bash || ash || sh)"` when no command is passed. `ShellOptions.command` is unchanged if the caller sets it. No UI change.

Also adds `kubeli-shell` sample pods (`shell-bash`, `shell-ash`, `shell-sh`) so `make minikube-setup-samples` has something to click for this.

## Related Issue

Fixes #457

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated documentation as needed
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

N/A

## Testing

- **Test scripts:** `cargo test --bin kubeli commands::shell::tests` — all 7 passed, including `pod_shell_defaults_to_bash_ash_sh_probe` and `explicit_command_is_kept` in `src-tauri/src/commands/shell.rs`.
- **Minikube:** Added `kubeli-shell` sample pods (`shell-bash`, `shell-ash`, `shell-sh`). Opened Shell from the existing UI button. Ubuntu landed in GNU bash, alpine/busybox fell through to ash/sh.
- **Personal cluster:** Connected to my live Kubernetes cluster and used the same Shell button on pods that need this (e.g. images with bash). Probe picked bash instead of staying on `sh`.

- [x] Tested on macOS (version: 15 Sequoia, Apple Silicon)
- [x] Tested with Kubernetes cluster (provider: minikube + personal cluster)